### PR TITLE
Add item type definitions and structure validation

### DIFF
--- a/src/pyfabric/items/types.py
+++ b/src/pyfabric/items/types.py
@@ -1,0 +1,153 @@
+"""Fabric item type definitions and .platform file parsing.
+
+Defines the known Fabric git-sync item types, their required and optional
+files, and provides parsing/validation for .platform metadata files.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+
+# ── .platform file model ─────────────────────────────────────────────────────
+
+PLATFORM_SCHEMA = "https://developer.microsoft.com/json-schemas/fabric/gitIntegration/platformProperties/2.0.0/schema.json"
+
+
+@dataclass(frozen=True)
+class PlatformMetadata:
+    """The ``metadata`` section of a .platform file."""
+
+    type: str
+    display_name: str
+    description: str = ""
+
+
+@dataclass(frozen=True)
+class PlatformConfig:
+    """The ``config`` section of a .platform file."""
+
+    version: str
+    logical_id: str
+
+
+@dataclass(frozen=True)
+class PlatformFile:
+    """Parsed representation of a Fabric .platform file."""
+
+    metadata: PlatformMetadata
+    config: PlatformConfig
+    schema: str = PLATFORM_SCHEMA
+
+    @property
+    def expected_dir_name(self) -> str:
+        """Expected directory name: ``{displayName}.{type}``."""
+        return f"{self.metadata.display_name}.{self.metadata.type}"
+
+
+def parse_platform(content: str) -> PlatformFile:
+    """Parse a .platform file from its JSON string content.
+
+    Raises ``ValueError`` with a descriptive message if required fields
+    are missing or the JSON is invalid.
+    """
+    try:
+        data = json.loads(content)
+    except json.JSONDecodeError as e:
+        raise ValueError(f"Invalid JSON in .platform file: {e}") from None
+
+    metadata_raw = data.get("metadata")
+    if metadata_raw is None:
+        raise ValueError(".platform file missing required 'metadata' section")
+
+    item_type = metadata_raw.get("type")
+    if not item_type:
+        raise ValueError(".platform metadata missing required 'type' field")
+
+    display_name = metadata_raw.get("displayName")
+    if not display_name:
+        raise ValueError(".platform metadata missing required 'displayName' field")
+
+    config_raw = data.get("config")
+    if config_raw is None:
+        raise ValueError(".platform file missing required 'config' section")
+
+    logical_id = config_raw.get("logicalId")
+    if not logical_id:
+        raise ValueError(".platform config missing required 'logicalId' field")
+
+    return PlatformFile(
+        metadata=PlatformMetadata(
+            type=item_type,
+            display_name=display_name,
+            description=metadata_raw.get("description", ""),
+        ),
+        config=PlatformConfig(
+            version=config_raw.get("version", "2.0"),
+            logical_id=logical_id,
+        ),
+        schema=data.get("$schema", PLATFORM_SCHEMA),
+    )
+
+
+# ── Item type registry ───────────────────────────────────────────────────────
+
+
+@dataclass(frozen=True)
+class ItemType:
+    """Definition of a Fabric item type and its expected file structure."""
+
+    type_name: str
+    required_files: list[str] = field(default_factory=list)
+    optional_files: list[str] = field(default_factory=list)
+
+    @property
+    def dir_suffix(self) -> str:
+        """Directory suffix in git-sync format: ``.{type_name}``."""
+        return f".{self.type_name}"
+
+
+ITEM_TYPES: dict[str, ItemType] = {
+    "Notebook": ItemType(
+        type_name="Notebook",
+        required_files=["notebook-content.py"],
+        optional_files=["notebook-settings.json", "fs-settings.json"],
+    ),
+    "Lakehouse": ItemType(
+        type_name="Lakehouse",
+        required_files=["lakehouse.metadata.json"],
+        optional_files=["alm.settings.json", "shortcuts.metadata.json"],
+    ),
+    "Dataflow": ItemType(
+        type_name="Dataflow",
+        required_files=["queryMetadata.json", "mashup.pq"],
+    ),
+    "Environment": ItemType(
+        type_name="Environment",
+        required_files=[
+            "Libraries/PublicLibraries/environment.yml",
+            "Setting/Sparkcompute.yml",
+        ],
+    ),
+    "VariableLibrary": ItemType(
+        type_name="VariableLibrary",
+        required_files=["variables.json", "settings.json"],
+    ),
+    "SemanticModel": ItemType(
+        type_name="SemanticModel",
+        required_files=["model.bim"],
+        optional_files=["definition.pbixproj"],
+    ),
+    "Report": ItemType(
+        type_name="Report",
+        required_files=["report.json"],
+    ),
+    "Pipeline": ItemType(
+        type_name="Pipeline",
+        required_files=["pipeline-content.json"],
+    ),
+    "Warehouse": ItemType(
+        type_name="Warehouse",
+        required_files=[],
+    ),
+}

--- a/src/pyfabric/items/validate.py
+++ b/src/pyfabric/items/validate.py
@@ -1,0 +1,143 @@
+"""Validate Fabric item structures before git-syncing.
+
+Checks that item directories have the correct structure, required files,
+and valid .platform metadata for their item type.
+
+Usage:
+    from pyfabric.items.validate import validate_item, validate_workspace
+
+    result = validate_item(Path("ws/nb_test.Notebook"))
+    if not result.valid:
+        for error in result.errors:
+            print(f"ERROR: {error.message}")
+
+    results = validate_workspace(Path("ws/"))
+    for r in results:
+        status = "OK" if r.valid else "FAIL"
+        print(f"{status}: {r.item_path.name}")
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+
+from .types import ITEM_TYPES, parse_platform
+
+
+@dataclass(frozen=True)
+class ValidationError:
+    """A single validation error or warning."""
+
+    message: str
+    path: Path | None = None
+
+
+@dataclass
+class ValidationResult:
+    """Result of validating a single Fabric item."""
+
+    item_path: Path
+    item_type: str | None = None
+    errors: list[ValidationError] = field(default_factory=list)
+    warnings: list[ValidationError] = field(default_factory=list)
+
+    @property
+    def valid(self) -> bool:
+        """True if there are no errors (warnings are acceptable)."""
+        return len(self.errors) == 0
+
+
+def validate_item(item_dir: Path) -> ValidationResult:
+    """Validate a single Fabric item directory.
+
+    Checks:
+    - .platform file exists and is valid JSON with required fields
+    - Item type is known
+    - All required files for the item type are present
+    - Directory name matches the expected ``{displayName}.{type}`` pattern
+
+    Returns a ``ValidationResult`` with errors and warnings.
+    """
+    result = ValidationResult(item_path=item_dir)
+    platform_path = item_dir / ".platform"
+
+    # Check .platform exists
+    if not platform_path.exists():
+        result.errors.append(
+            ValidationError(".platform file is missing", platform_path)
+        )
+        return result
+
+    # Parse .platform
+    try:
+        content = platform_path.read_text(encoding="utf-8")
+        platform = parse_platform(content)
+    except ValueError as e:
+        result.errors.append(ValidationError(str(e), platform_path))
+        return result
+
+    result.item_type = platform.metadata.type
+
+    # Check item type is known
+    item_type_def = ITEM_TYPES.get(platform.metadata.type)
+    if item_type_def is None:
+        result.errors.append(
+            ValidationError(
+                f"Unknown item type '{platform.metadata.type}'",
+                platform_path,
+            )
+        )
+        return result
+
+    # Check directory name matches
+    expected_dir = platform.expected_dir_name
+    if item_dir.name != expected_dir:
+        result.warnings.append(
+            ValidationError(
+                f"Directory name mismatch: '{item_dir.name}' "
+                f"(expected '{expected_dir}')",
+                item_dir,
+            )
+        )
+
+    # Check required files
+    for required_file in item_type_def.required_files:
+        if not (item_dir / required_file).exists():
+            result.errors.append(
+                ValidationError(
+                    f"Required file missing: {required_file}",
+                    item_dir / required_file,
+                )
+            )
+
+    return result
+
+
+def validate_workspace(workspace_dir: Path) -> list[ValidationResult]:
+    """Validate all Fabric items in a workspace directory.
+
+    Scans for directories matching the ``{name}.{ItemType}`` pattern
+    and validates each one. Non-item directories are ignored.
+
+    Returns a list of ``ValidationResult``, one per item found.
+    """
+    results: list[ValidationResult] = []
+    if not workspace_dir.is_dir():
+        return results
+
+    for entry in sorted(workspace_dir.iterdir()):
+        if not entry.is_dir():
+            continue
+        # Item directories have a dot-separated suffix matching a known type
+        # or at least contain a .platform file
+        parts = entry.name.rsplit(".", 1)
+        if len(parts) != 2:
+            continue
+        _display_name, type_suffix = parts
+        # Accept any directory with Type suffix pattern (known or unknown)
+        if not type_suffix[0].isupper():
+            continue
+        results.append(validate_item(entry))
+
+    return results

--- a/tests/items/test_types.py
+++ b/tests/items/test_types.py
@@ -1,0 +1,154 @@
+"""Tests for item type definitions and .platform validation."""
+
+import json
+import uuid
+
+import pytest
+
+from pyfabric.items.types import (
+    ITEM_TYPES,
+    parse_platform,
+)
+
+
+class TestItemType:
+    def test_all_known_types_registered(self):
+        expected = {
+            "Notebook",
+            "Lakehouse",
+            "Dataflow",
+            "Environment",
+            "VariableLibrary",
+            "SemanticModel",
+            "Report",
+            "Pipeline",
+            "Warehouse",
+        }
+        registered = {it.type_name for it in ITEM_TYPES.values()}
+        assert expected.issubset(registered)
+
+    def test_item_type_has_required_files(self):
+        for name, it in ITEM_TYPES.items():
+            assert isinstance(it.required_files, list), f"{name} missing required_files"
+
+    def test_notebook_requires_content_file(self):
+        nb = ITEM_TYPES["Notebook"]
+        assert "notebook-content.py" in nb.required_files
+
+    def test_lakehouse_requires_metadata(self):
+        lh = ITEM_TYPES["Lakehouse"]
+        assert "lakehouse.metadata.json" in lh.required_files
+
+    def test_environment_requires_nested_files(self):
+        env = ITEM_TYPES["Environment"]
+        assert "Libraries/PublicLibraries/environment.yml" in env.required_files
+        assert "Setting/Sparkcompute.yml" in env.required_files
+
+    def test_variable_library_requires_core_files(self):
+        vl = ITEM_TYPES["VariableLibrary"]
+        assert "variables.json" in vl.required_files
+        assert "settings.json" in vl.required_files
+
+    def test_dataflow_requires_query_metadata(self):
+        df = ITEM_TYPES["Dataflow"]
+        assert "queryMetadata.json" in df.required_files
+        assert "mashup.pq" in df.required_files
+
+    def test_lookup_by_type_name(self):
+        assert ITEM_TYPES["Notebook"].type_name == "Notebook"
+        assert ITEM_TYPES["Lakehouse"].type_name == "Lakehouse"
+
+    def test_lookup_unknown_type_raises(self):
+        with pytest.raises(KeyError):
+            _ = ITEM_TYPES["NonExistentType"]
+
+    def test_item_type_has_dir_suffix(self):
+        for name, it in ITEM_TYPES.items():
+            assert it.dir_suffix == f".{name}"
+
+
+class TestPlatformFile:
+    def test_parse_valid_platform(self):
+        data = {
+            "$schema": "https://developer.microsoft.com/json-schemas/fabric/gitIntegration/platformProperties/2.0.0/schema.json",
+            "metadata": {
+                "type": "Notebook",
+                "displayName": "nb_test",
+            },
+            "config": {
+                "version": "2.0",
+                "logicalId": "12345678-1234-1234-1234-123456789012",
+            },
+        }
+        pf = parse_platform(json.dumps(data))
+        assert pf.metadata.type == "Notebook"
+        assert pf.metadata.display_name == "nb_test"
+        assert pf.config.version == "2.0"
+        assert pf.config.logical_id == "12345678-1234-1234-1234-123456789012"
+
+    def test_parse_platform_with_description(self):
+        data = {
+            "$schema": "https://developer.microsoft.com/json-schemas/fabric/gitIntegration/platformProperties/2.0.0/schema.json",
+            "metadata": {
+                "type": "Dataflow",
+                "displayName": "df_test",
+                "description": "A test dataflow",
+            },
+            "config": {
+                "version": "2.0",
+                "logicalId": str(uuid.uuid4()),
+            },
+        }
+        pf = parse_platform(json.dumps(data))
+        assert pf.metadata.description == "A test dataflow"
+
+    def test_parse_platform_missing_metadata_raises(self):
+        data = {
+            "config": {"version": "2.0", "logicalId": str(uuid.uuid4())},
+        }
+        with pytest.raises(ValueError, match="metadata"):
+            parse_platform(json.dumps(data))
+
+    def test_parse_platform_missing_type_raises(self):
+        data = {
+            "metadata": {"displayName": "test"},
+            "config": {"version": "2.0", "logicalId": str(uuid.uuid4())},
+        }
+        with pytest.raises(ValueError, match="type"):
+            parse_platform(json.dumps(data))
+
+    def test_parse_platform_missing_display_name_raises(self):
+        data = {
+            "metadata": {"type": "Notebook"},
+            "config": {"version": "2.0", "logicalId": str(uuid.uuid4())},
+        }
+        with pytest.raises(ValueError, match="displayName"):
+            parse_platform(json.dumps(data))
+
+    def test_parse_platform_missing_config_raises(self):
+        data = {
+            "metadata": {"type": "Notebook", "displayName": "test"},
+        }
+        with pytest.raises(ValueError, match="config"):
+            parse_platform(json.dumps(data))
+
+    def test_parse_platform_missing_logical_id_raises(self):
+        data = {
+            "metadata": {"type": "Notebook", "displayName": "test"},
+            "config": {"version": "2.0"},
+        }
+        with pytest.raises(ValueError, match="logicalId"):
+            parse_platform(json.dumps(data))
+
+    def test_parse_platform_invalid_json_raises(self):
+        with pytest.raises(ValueError, match="Invalid JSON"):
+            parse_platform("not json {{{")
+
+    def test_platform_dir_name(self):
+        data = {
+            "$schema": "https://developer.microsoft.com/json-schemas/fabric/gitIntegration/platformProperties/2.0.0/schema.json",
+            "metadata": {"type": "Notebook", "displayName": "nb_test"},
+            "config": {"version": "2.0", "logicalId": str(uuid.uuid4())},
+        }
+        pf = parse_platform(json.dumps(data))
+        assert pf.expected_dir_name == "nb_test.Notebook"

--- a/tests/items/test_validate.py
+++ b/tests/items/test_validate.py
@@ -1,0 +1,264 @@
+"""Tests for item structure validation."""
+
+import json
+import uuid
+from pathlib import Path
+
+from pyfabric.items.validate import (
+    validate_item,
+    validate_workspace,
+)
+
+
+def _make_platform(item_type: str, display_name: str) -> str:
+    return json.dumps(
+        {
+            "$schema": "https://developer.microsoft.com/json-schemas/fabric/gitIntegration/platformProperties/2.0.0/schema.json",
+            "metadata": {"type": item_type, "displayName": display_name},
+            "config": {"version": "2.0", "logicalId": str(uuid.uuid4())},
+        }
+    )
+
+
+def _create_item(
+    base: Path, display_name: str, item_type: str, files: dict[str, str]
+) -> Path:
+    """Helper to create a Fabric item directory with files."""
+    item_dir = base / f"{display_name}.{item_type}"
+    item_dir.mkdir(parents=True, exist_ok=True)
+    (item_dir / ".platform").write_text(
+        _make_platform(item_type, display_name), encoding="utf-8"
+    )
+    for rel_path, content in files.items():
+        p = item_dir / rel_path
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text(content, encoding="utf-8")
+    return item_dir
+
+
+class TestValidateItem:
+    def test_valid_notebook(self, tmp_path: Path):
+        item_dir = _create_item(
+            tmp_path,
+            "nb_test",
+            "Notebook",
+            {
+                "notebook-content.py": "# Fabric notebook source\n",
+            },
+        )
+        result = validate_item(item_dir)
+        assert result.valid
+        assert result.errors == []
+
+    def test_notebook_missing_content_file(self, tmp_path: Path):
+        item_dir = tmp_path / "nb_test.Notebook"
+        item_dir.mkdir()
+        (item_dir / ".platform").write_text(
+            _make_platform("Notebook", "nb_test"), encoding="utf-8"
+        )
+        result = validate_item(item_dir)
+        assert not result.valid
+        assert any("notebook-content.py" in e.message for e in result.errors)
+
+    def test_valid_lakehouse(self, tmp_path: Path):
+        item_dir = _create_item(
+            tmp_path,
+            "lh_test",
+            "Lakehouse",
+            {
+                "lakehouse.metadata.json": '{"defaultSchema":"dbo"}',
+            },
+        )
+        result = validate_item(item_dir)
+        assert result.valid
+
+    def test_valid_environment(self, tmp_path: Path):
+        item_dir = _create_item(
+            tmp_path,
+            "env_test",
+            "Environment",
+            {
+                "Libraries/PublicLibraries/environment.yml": "dependencies:\n  - pip:\n      - requests\n",
+                "Setting/Sparkcompute.yml": "runtime_version: 1.3\n",
+            },
+        )
+        result = validate_item(item_dir)
+        assert result.valid
+
+    def test_environment_missing_sparkcompute(self, tmp_path: Path):
+        item_dir = _create_item(
+            tmp_path,
+            "env_test",
+            "Environment",
+            {
+                "Libraries/PublicLibraries/environment.yml": "dependencies: []\n",
+            },
+        )
+        result = validate_item(item_dir)
+        assert not result.valid
+        assert any("Sparkcompute.yml" in e.message for e in result.errors)
+
+    def test_valid_variable_library(self, tmp_path: Path):
+        item_dir = _create_item(
+            tmp_path,
+            "vl_test",
+            "VariableLibrary",
+            {
+                "variables.json": '{"variables": []}',
+                "settings.json": '{"valueSetsOrder": ["UAT"]}',
+                "valueSets/UAT.json": '{"name": "UAT", "variableOverrides": []}',
+            },
+        )
+        result = validate_item(item_dir)
+        assert result.valid
+
+    def test_variable_library_missing_settings(self, tmp_path: Path):
+        item_dir = _create_item(
+            tmp_path,
+            "vl_test",
+            "VariableLibrary",
+            {
+                "variables.json": '{"variables": []}',
+            },
+        )
+        result = validate_item(item_dir)
+        assert not result.valid
+        assert any("settings.json" in e.message for e in result.errors)
+
+    def test_valid_dataflow(self, tmp_path: Path):
+        item_dir = _create_item(
+            tmp_path,
+            "df_test",
+            "Dataflow",
+            {
+                "queryMetadata.json": '{"formatVersion": "202502"}',
+                "mashup.pq": "binary content placeholder",
+            },
+        )
+        result = validate_item(item_dir)
+        assert result.valid
+
+    def test_missing_platform_file(self, tmp_path: Path):
+        item_dir = tmp_path / "nb_test.Notebook"
+        item_dir.mkdir()
+        (item_dir / "notebook-content.py").write_text("# code\n", encoding="utf-8")
+        result = validate_item(item_dir)
+        assert not result.valid
+        assert any(".platform" in e.message for e in result.errors)
+
+    def test_invalid_platform_json(self, tmp_path: Path):
+        item_dir = tmp_path / "nb_test.Notebook"
+        item_dir.mkdir()
+        (item_dir / ".platform").write_text("not json", encoding="utf-8")
+        (item_dir / "notebook-content.py").write_text("# code\n", encoding="utf-8")
+        result = validate_item(item_dir)
+        assert not result.valid
+        assert any("Invalid" in e.message or "JSON" in e.message for e in result.errors)
+
+    def test_dir_name_mismatch_warns(self, tmp_path: Path):
+        """Dir name doesn't match .platform displayName — should produce a warning."""
+        item_dir = tmp_path / "wrong_name.Notebook"
+        item_dir.mkdir()
+        (item_dir / ".platform").write_text(
+            _make_platform("Notebook", "nb_correct_name"), encoding="utf-8"
+        )
+        (item_dir / "notebook-content.py").write_text("# code\n", encoding="utf-8")
+        result = validate_item(item_dir)
+        assert any("mismatch" in w.message.lower() for w in result.warnings)
+
+    def test_unknown_item_type_produces_error(self, tmp_path: Path):
+        item_dir = tmp_path / "test.FakeType"
+        item_dir.mkdir()
+        (item_dir / ".platform").write_text(
+            _make_platform("FakeType", "test"), encoding="utf-8"
+        )
+        result = validate_item(item_dir)
+        assert not result.valid
+        assert any("Unknown item type" in e.message for e in result.errors)
+
+    def test_result_item_path(self, tmp_path: Path):
+        item_dir = _create_item(
+            tmp_path,
+            "nb_test",
+            "Notebook",
+            {
+                "notebook-content.py": "# code\n",
+            },
+        )
+        result = validate_item(item_dir)
+        assert result.item_path == item_dir
+
+    def test_result_item_type(self, tmp_path: Path):
+        item_dir = _create_item(
+            tmp_path,
+            "nb_test",
+            "Notebook",
+            {
+                "notebook-content.py": "# code\n",
+            },
+        )
+        result = validate_item(item_dir)
+        assert result.item_type == "Notebook"
+
+
+class TestValidateWorkspace:
+    def test_valid_workspace_with_multiple_items(self, tmp_path: Path):
+        _create_item(
+            tmp_path,
+            "nb_one",
+            "Notebook",
+            {
+                "notebook-content.py": "# code\n",
+            },
+        )
+        _create_item(
+            tmp_path,
+            "lh_one",
+            "Lakehouse",
+            {
+                "lakehouse.metadata.json": '{"defaultSchema":"dbo"}',
+            },
+        )
+        results = validate_workspace(tmp_path)
+        assert len(results) == 2
+        assert all(r.valid for r in results)
+
+    def test_workspace_with_invalid_item(self, tmp_path: Path):
+        _create_item(
+            tmp_path,
+            "nb_good",
+            "Notebook",
+            {
+                "notebook-content.py": "# code\n",
+            },
+        )
+        # Bad notebook — missing content file
+        bad_dir = tmp_path / "nb_bad.Notebook"
+        bad_dir.mkdir()
+        (bad_dir / ".platform").write_text(
+            _make_platform("Notebook", "nb_bad"), encoding="utf-8"
+        )
+        results = validate_workspace(tmp_path)
+        assert len(results) == 2
+        valid_count = sum(1 for r in results if r.valid)
+        assert valid_count == 1
+
+    def test_empty_workspace(self, tmp_path: Path):
+        results = validate_workspace(tmp_path)
+        assert results == []
+
+    def test_ignores_non_item_directories(self, tmp_path: Path):
+        """Directories without .ItemType suffix should be ignored."""
+        (tmp_path / "scripts").mkdir()
+        (tmp_path / ".git").mkdir()
+        (tmp_path / "README.md").write_text("# readme\n", encoding="utf-8")
+        _create_item(
+            tmp_path,
+            "nb_test",
+            "Notebook",
+            {
+                "notebook-content.py": "# code\n",
+            },
+        )
+        results = validate_workspace(tmp_path)
+        assert len(results) == 1


### PR DESCRIPTION
## Summary

- Add `items/types.py`: ItemType registry for 9 Fabric git-sync item types (Notebook, Lakehouse, Dataflow, Environment, VariableLibrary, SemanticModel, Report, Pipeline, Warehouse) with required/optional file definitions and `.platform` file parser
- Add `items/validate.py`: `validate_item()` and `validate_workspace()` for checking item structure before git-syncing — verifies `.platform` validity, required files, directory naming
- **TDD**: 37 new tests written before implementation, covering all item types, `.platform` parsing edge cases, error/warning paths, and workspace scanning

## Test coverage

| Module | Coverage |
|--------|---------|
| `items/types.py` | 100% |
| `items/validate.py` | 98% |

Full suite: 90 tests passing (53 existing + 37 new).

## Test plan

- [ ] CI passes (lint, mypy strict on new modules, test 3.12 + 3.13)
- [ ] New modules pass mypy strict (not in the ignore_errors override list)

🤖 Generated with [Claude Code](https://claude.com/claude-code)