### PR TITLE
Add testing framework: DuckDB Spark mock, notebookutils, pytest fixtures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,4 +50,9 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
       - run: pip install -e ".[dev]"
-      - run: pytest --cov=src/pyfabric --cov-report=term-missing
+      - run: pytest --cov=src/pyfabric --cov-branch --cov-report=term-missing --json-report --json-report-file=test-report.json
+      - uses: actions/upload-artifact@v7
+        if: always()
+        with:
+          name: test-report-py${{ matrix.python-version }}
+          path: test-report.json

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,9 @@ Repository = "https://github.com/Creative-Planning/pyfabric"
 [project.scripts]
 pyfabric = "pyfabric.cli:main"
 
+[project.entry-points.pytest11]
+pyfabric = "pyfabric.testing.plugin"
+
 [project.optional-dependencies]
 azure = [
     "azure-identity>=1.17",
@@ -121,7 +124,7 @@ warn_unused_ignores = true
 
 # Third-party libraries without type stubs
 [[tool.mypy.overrides]]
-module = ["requests.*", "pyodbc.*", "pyarrow.*", "deltalake.*", "pandas.*", "duckdb.*", "structlog.*"]
+module = ["requests.*", "pyodbc.*", "pyarrow.*", "pandas.*", "duckdb.*", "structlog.*"]
 ignore_missing_imports = true
 
 # Ported fabric-libs modules — strict typing will be added iteratively.

--- a/src/pyfabric/testing/__init__.py
+++ b/src/pyfabric/testing/__init__.py
@@ -1,0 +1,14 @@
+"""pyfabric testing utilities for local Fabric development.
+
+Provides DuckDB-backed Spark session mock, notebookutils mock, and pytest
+fixtures so users can test notebook and pipeline logic locally without
+deploying to Fabric.
+
+Install: ``pip install pyfabric[testing]``
+
+Usage in tests::
+
+    def test_my_notebook(fabric_spark, mock_notebookutils):
+        result = fabric_spark.sql("SELECT 1 AS value")
+        assert result.collect()[0][0] == 1
+"""

--- a/src/pyfabric/testing/analyze.py
+++ b/src/pyfabric/testing/analyze.py
@@ -1,0 +1,76 @@
+"""AI-powered test and log analysis (Ollama integration placeholder).
+
+This module provides hooks for local LLM-powered analysis of test reports
+and log files. Currently raises RuntimeError — the implementation will be
+added when the ``pyfabric[llm]`` optional dependency is available.
+
+Future usage::
+
+    from pyfabric.testing.analyze import analyze_test_report, analyze_log_file
+
+    # Analyze a pytest JSON report for failure patterns
+    summary = analyze_test_report("test-report.json", model="gemma3")
+
+    # Analyze a structlog JSON log file for anomalies
+    findings = analyze_log_file(".logs/my_script_20250401.jsonl", model="gemma3")
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def analyze_test_report(
+    report_path: str | Path,
+    *,
+    model: str = "gemma3",
+    host: str = "http://localhost:11434",
+) -> str:
+    """Analyze a pytest JSON report using a local Ollama model.
+
+    Reads the test report, extracts failures and errors, and asks
+    the local LLM to summarize root causes and suggest fixes.
+
+    Args:
+        report_path: Path to pytest-json-report output file.
+        model: Ollama model name (default: gemma3).
+        host: Ollama API endpoint.
+
+    Returns:
+        AI-generated analysis summary.
+
+    Raises:
+        RuntimeError: Always — Ollama integration not yet implemented.
+    """
+    raise RuntimeError(
+        "Ollama integration not yet implemented. "
+        "Install: pip install ollama, then run: ollama pull gemma3"
+    )
+
+
+def analyze_log_file(
+    log_path: str | Path,
+    *,
+    model: str = "gemma3",
+    host: str = "http://localhost:11434",
+) -> str:
+    """Analyze a structlog JSON Lines log file using a local Ollama model.
+
+    Reads the log file, identifies error patterns and anomalies, and asks
+    the local LLM to summarize findings and recommend actions.
+
+    Args:
+        log_path: Path to a .jsonl log file from pyfabric._logging.
+        model: Ollama model name (default: gemma3).
+        host: Ollama API endpoint.
+
+    Returns:
+        AI-generated analysis summary.
+
+    Raises:
+        RuntimeError: Always — Ollama integration not yet implemented.
+    """
+    raise RuntimeError(
+        "Ollama integration not yet implemented. "
+        "Install: pip install ollama, then run: ollama pull gemma3"
+    )

--- a/src/pyfabric/testing/duckdb_spark.py
+++ b/src/pyfabric/testing/duckdb_spark.py
@@ -1,0 +1,255 @@
+"""DuckDB-backed Spark session mock for local Fabric notebook testing.
+
+Provides a drop-in replacement for PySpark's SparkSession that executes
+SQL against DuckDB with automatic Delta table discovery. Supports:
+
+- ``spark.sql("SELECT ...")`` with Delta table path rewriting
+- ``spark.sql("SHOW TABLES IN <lakehouse>")``
+- ``spark.catalog.listTables(dbName)``
+- ``DataFrame.collect()``, ``.show()``, ``.count()``, iteration
+
+Local lakehouse data is expected at::
+
+    <lakehouse_root>/<lakehouse_name>/Tables/<table_name>/  (Delta format)
+
+Usage::
+
+    from pyfabric.testing.duckdb_spark import DuckDBSparkSession
+
+    spark = DuckDBSparkSession(lakehouse_root=Path("./test_data"))
+    df = spark.sql("SELECT * FROM my_lakehouse.my_table")
+    print(df.count())
+    spark.stop()
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from typing import Any
+
+import duckdb
+import structlog
+
+log = structlog.get_logger()
+
+
+# ── Row and DataFrame ────────────────────────────────────────────────────────
+
+
+class Row:
+    """Minimal PySpark Row replacement."""
+
+    __slots__ = ("_columns", "_values")
+
+    def __init__(self, values: tuple[Any, ...], columns: list[str] | None = None):
+        self._values = values
+        self._columns = columns
+
+    def __getitem__(self, index: int | str) -> Any:
+        if isinstance(index, str):
+            if self._columns is None:
+                raise KeyError(f"Column access requires column names: {index}")
+            return self._values[self._columns.index(index)]
+        return self._values[index]
+
+    def __repr__(self) -> str:
+        if self._columns:
+            pairs = ", ".join(
+                f"{k}={v!r}" for k, v in zip(self._columns, self._values, strict=False)
+            )
+            return f"Row({pairs})"
+        return f"Row{self._values}"
+
+    def asDict(self) -> dict[str, Any]:
+        """Convert to dict (PySpark Row compatibility)."""
+        if self._columns is None:
+            raise ValueError("Column names not available")
+        return dict(zip(self._columns, self._values, strict=False))
+
+
+class DataFrame:
+    """Minimal PySpark DataFrame replacement wrapping a DuckDB result."""
+
+    def __init__(self, result: duckdb.DuckDBPyConnection, columns: list[str]):
+        self._result = result
+        self._columns = columns
+
+    def collect(self) -> list[Row]:
+        """Return all rows as a list of Row objects."""
+        return [Row(tuple(r), self._columns) for r in self._result.fetchall()]
+
+    def show(self, n: int = 20, truncate: bool = True) -> None:
+        """Print rows in tabular format (PySpark-compatible output)."""
+        rows = self._result.fetchmany(n)
+        if not rows:
+            print(f"Empty DataFrame with columns: {self._columns}")
+            return
+        widths = [
+            max(len(c), max((len(str(r[i])) for r in rows), default=0))
+            for i, c in enumerate(self._columns)
+        ]
+        header = " | ".join(
+            c.ljust(w) for c, w in zip(self._columns, widths, strict=False)
+        )
+        print(header)
+        print("-" * len(header))
+        for row in rows:
+            print(
+                " | ".join(str(v).ljust(w) for v, w in zip(row, widths, strict=False))
+            )
+
+    def count(self) -> int:
+        """Return the number of rows."""
+        rows = self._result.fetchall()
+        return len(rows)
+
+    def toPandas(self) -> Any:
+        """Convert to pandas DataFrame."""
+        return self._result.df()
+
+    def __iter__(self) -> Any:
+        return iter(self.collect())
+
+
+# ── Catalog ──────────────────────────────────────────────────────────────────
+
+
+class TableInfo:
+    """Minimal spark.catalog table info."""
+
+    __slots__ = ("database", "isTemporary", "name")
+
+    def __init__(self, database: str, name: str, *, isTemporary: bool = False):
+        self.database = database
+        self.name = name
+        self.isTemporary = isTemporary
+
+    def __repr__(self) -> str:
+        return f"TableInfo(database={self.database!r}, name={self.name!r})"
+
+    def __getitem__(self, index: int) -> Any:
+        return (self.database, self.name, self.isTemporary)[index]
+
+
+class Catalog:
+    """Minimal spark.catalog replacement backed by local Delta directories."""
+
+    def __init__(self, lakehouse_root: Path):
+        self._root = lakehouse_root
+
+    def listTables(self, dbName: str | None = None) -> list[TableInfo]:
+        """List tables found as Delta directories under lakehouse_root."""
+        results: list[TableInfo] = []
+        search_roots: list[tuple[str, Path]] = []
+
+        if dbName:
+            for variant in [dbName, dbName.lower()]:
+                tables_dir = self._root / variant / "Tables"
+                if tables_dir.exists():
+                    search_roots.append((variant, tables_dir))
+        else:
+            for child in sorted(self._root.iterdir()):
+                if child.is_dir():
+                    tables_dir = child / "Tables"
+                    if tables_dir.exists():
+                        search_roots.append((child.name, tables_dir))
+
+        for db, tables_dir in search_roots:
+            for entry in sorted(tables_dir.iterdir()):
+                if entry.is_dir() and (entry / "_delta_log").exists():
+                    results.append(TableInfo(database=db, name=entry.name))
+                # Also check schema subdirectories (dbo/<table>)
+                elif entry.is_dir():
+                    for sub in sorted(entry.iterdir()):
+                        if sub.is_dir() and (sub / "_delta_log").exists():
+                            results.append(TableInfo(database=db, name=sub.name))
+
+        return results
+
+    def tableExists(self, tableName: str) -> bool:
+        """Check if a table exists (searches all lakehouses)."""
+        return any(info.name == tableName for info in self.listTables())
+
+
+# ── Spark Session ────────────────────────────────────────────────────────────
+
+
+class DuckDBSparkSession:
+    """Drop-in replacement for PySpark SparkSession backed by DuckDB.
+
+    Supports:
+    - ``spark.sql("SELECT ...")`` with automatic Delta table rewriting
+    - ``spark.sql("SHOW TABLES IN <lakehouse>")``
+    - ``spark.catalog.listTables(dbName)``
+    - ``spark.catalog.tableExists(tableName)``
+    """
+
+    def __init__(self, lakehouse_root: Path | None = None):
+        self._root = lakehouse_root or Path.cwd() / "local_lakehouse"
+        self._conn = duckdb.connect()
+        self._conn.execute("INSTALL delta; LOAD delta;")
+        self.catalog = Catalog(self._root)
+        log.debug("DuckDBSparkSession initialized", lakehouse_root=str(self._root))
+
+    def sql(self, query: str) -> DataFrame:
+        """Execute a SQL query with automatic Fabric table reference rewriting."""
+        translated = self._translate(query.strip())
+        log.debug("SQL", original=query.strip()[:100], translated=translated[:100])
+        result = self._conn.execute(translated)
+        columns = [d[0] for d in result.description]
+        return DataFrame(result, columns)
+
+    def stop(self) -> None:
+        """Close the DuckDB connection."""
+        self._conn.close()
+        log.debug("DuckDBSparkSession stopped")
+
+    def _translate(self, query: str) -> str:
+        """Rewrite Fabric/Spark SQL idioms to DuckDB-compatible SQL."""
+        # SHOW TABLES IN <lakehouse>
+        m = re.match(r"SHOW\s+TABLES\s+(?:IN\s+)?(\w+)", query, re.IGNORECASE)
+        if m:
+            return self._show_tables(m.group(1))
+
+        # Rewrite <lakehouse>.<schema>.<table> or <lakehouse>.<table> references
+        # to delta_scan() calls, but only when the path actually exists.
+        def replace_ref(match: re.Match[str]) -> str:
+            parts = match.group(0).split(".")
+            if len(parts) == 3:
+                lakehouse, schema, table = parts
+                path = self._root / lakehouse / "Tables" / schema / table
+            elif len(parts) == 2:
+                lakehouse, table = parts
+                path = self._root / lakehouse / "Tables" / table
+            else:
+                return match.group(0)
+            if (path / "_delta_log").exists():
+                return f"delta_scan('{path.as_posix()}')"
+            return match.group(0)
+
+        return re.sub(r"\b\w+\.\w+(?:\.\w+)?\b", replace_ref, query)
+
+    def _show_tables(self, lakehouse: str) -> str:
+        """Generate SQL that returns SHOW TABLES output for a lakehouse."""
+        tables_dir = self._root / lakehouse / "Tables"
+        if not tables_dir.exists():
+            return "SELECT '' AS namespace, '' AS tableName WHERE 1=0"
+
+        table_rows = []
+        for entry in sorted(tables_dir.iterdir()):
+            if entry.is_dir() and (entry / "_delta_log").exists():
+                table_rows.append(
+                    f"SELECT '{lakehouse}' AS namespace, '{entry.name}' AS tableName, false AS isTemporary"
+                )
+            # Schema subdirectories
+            elif entry.is_dir():
+                for sub in sorted(entry.iterdir()):
+                    if sub.is_dir() and (sub / "_delta_log").exists():
+                        table_rows.append(
+                            f"SELECT '{lakehouse}' AS namespace, '{sub.name}' AS tableName, false AS isTemporary"
+                        )
+
+        if not table_rows:
+            return "SELECT '' AS namespace, '' AS tableName WHERE 1=0"
+        return " UNION ALL ".join(table_rows)

--- a/src/pyfabric/testing/fixtures.py
+++ b/src/pyfabric/testing/fixtures.py
@@ -1,0 +1,47 @@
+"""Pytest fixtures for local Fabric notebook and pipeline testing.
+
+These fixtures are auto-registered via the pytest plugin entry point.
+Users get them for free by installing ``pyfabric[testing]``.
+
+Available fixtures:
+- ``fabric_spark`` — DuckDBSparkSession with a temporary lakehouse root
+- ``mock_notebookutils`` — MockNotebookUtils with a temporary filesystem root
+- ``lakehouse_root`` — Path to the temporary lakehouse directory
+"""
+
+from __future__ import annotations
+
+from collections.abc import Generator
+from pathlib import Path
+
+import pytest
+
+from .duckdb_spark import DuckDBSparkSession
+from .mock_notebookutils import MockNotebookUtils
+
+
+@pytest.fixture
+def lakehouse_root(tmp_path: Path) -> Path:
+    """Temporary lakehouse root directory for testing."""
+    return tmp_path / "lakehouses"
+
+
+@pytest.fixture
+def fabric_spark(lakehouse_root: Path) -> Generator[DuckDBSparkSession]:
+    """DuckDB-backed Spark session for local notebook testing.
+
+    Lakehouse data should be placed at:
+        ``lakehouse_root/<lakehouse_name>/Tables/<table_name>/`` (Delta format)
+    """
+    lakehouse_root.mkdir(parents=True, exist_ok=True)
+    session = DuckDBSparkSession(lakehouse_root=lakehouse_root)
+    yield session
+    session.stop()
+
+
+@pytest.fixture
+def mock_notebookutils(tmp_path: Path) -> MockNotebookUtils:
+    """MockNotebookUtils with a temporary filesystem root."""
+    root = tmp_path / "notebookutils"
+    root.mkdir(parents=True, exist_ok=True)
+    return MockNotebookUtils(root=root)

--- a/src/pyfabric/testing/mock_notebookutils.py
+++ b/src/pyfabric/testing/mock_notebookutils.py
@@ -1,0 +1,122 @@
+"""Mock notebookutils / mssparkutils for local Fabric notebook testing.
+
+Provides a drop-in replacement for Fabric's ``notebookutils`` that works
+locally without a Fabric runtime. Filesystem operations use the local
+filesystem; notebook.run() is a no-op; credentials.getToken() raises.
+
+Usage::
+
+    from pyfabric.testing.mock_notebookutils import MockNotebookUtils
+
+    notebookutils = MockNotebookUtils(root=Path("./test_data"))
+    notebookutils.fs.mkdirs("/my/path")
+    files = notebookutils.fs.ls("/my/path")
+"""
+
+from __future__ import annotations
+
+import shutil
+from pathlib import Path
+
+import structlog
+
+log = structlog.get_logger()
+
+
+class _MockFs:
+    """Mock for notebookutils.fs — local filesystem operations."""
+
+    def __init__(self, root: Path):
+        self._root = root
+
+    def _resolve(self, path: str) -> Path:
+        """Resolve a path relative to the mock root."""
+        return self._root / path.lstrip("/")
+
+    def ls(self, path: str) -> list[str]:
+        """List files/directories at path."""
+        p = self._resolve(path)
+        if not p.exists():
+            return []
+        return [str(child) for child in sorted(p.iterdir())]
+
+    def mkdirs(self, path: str) -> None:
+        """Create directories recursively."""
+        p = self._resolve(path)
+        p.mkdir(parents=True, exist_ok=True)
+        log.debug("notebookutils.fs.mkdirs", path=str(p))
+
+    def cp(self, src: str, dst: str, recurse: bool = False) -> None:
+        """Copy file or directory."""
+        src_p, dst_p = self._resolve(src), self._resolve(dst)
+        if recurse:
+            shutil.copytree(src_p, dst_p, dirs_exist_ok=True)
+        else:
+            shutil.copy2(src_p, dst_p)
+
+    def rm(self, path: str, recurse: bool = False) -> None:
+        """Remove file or directory."""
+        p = self._resolve(path)
+        if recurse and p.is_dir():
+            shutil.rmtree(p)
+        elif p.exists():
+            p.unlink()
+
+    def put(self, path: str, content: str | bytes) -> None:
+        """Write content to a file."""
+        p = self._resolve(path)
+        p.parent.mkdir(parents=True, exist_ok=True)
+        if isinstance(content, bytes):
+            p.write_bytes(content)
+        else:
+            p.write_text(content, encoding="utf-8")
+
+    def head(self, path: str, max_bytes: int = 65536) -> str:
+        """Read the first N bytes of a file as text."""
+        p = self._resolve(path)
+        return p.read_text(encoding="utf-8")[:max_bytes]
+
+
+class _MockNotebook:
+    """Mock for notebookutils.notebook — run/exit are no-ops."""
+
+    def run(
+        self,
+        name: str,
+        timeout_seconds: int = 300,
+        arguments: dict[str, str] | None = None,
+    ) -> str:
+        """No-op: logs the call but doesn't execute anything."""
+        log.info("notebookutils.notebook.run", name=name, arguments=arguments)
+        return ""
+
+    def exit(self, value: str) -> None:
+        """No-op: logs the exit value."""
+        log.debug("notebookutils.notebook.exit", value=value)
+
+
+class _MockCredentials:
+    """Mock for notebookutils.credentials — always raises."""
+
+    def getToken(self, audience: str, client_id: str | None = None) -> str:
+        """Raises NotImplementedError — use pyfabric.client.auth instead."""
+        raise NotImplementedError(
+            f"getToken('{audience}') is not available in local mode. "
+            "Use pyfabric.client.auth.FabricCredential instead."
+        )
+
+
+class MockNotebookUtils:
+    """Drop-in replacement for Fabric notebookutils / mssparkutils.
+
+    Args:
+        root: Base directory for filesystem operations. Defaults to cwd.
+    """
+
+    def __init__(self, root: Path | None = None):
+        self._root = root or Path.cwd()
+        self.fs = _MockFs(self._root)
+        self.notebook = _MockNotebook()
+        self.credentials = _MockCredentials()
+        # Fabric compatibility alias
+        self.mssparkutils = self

--- a/src/pyfabric/testing/plugin.py
+++ b/src/pyfabric/testing/plugin.py
@@ -1,0 +1,9 @@
+"""Pytest plugin for pyfabric testing fixtures.
+
+Auto-discovered by pytest via the ``pyfabric`` entry point in pyproject.toml.
+Registers fixtures from ``pyfabric.testing.fixtures``.
+"""
+
+from pyfabric.testing.fixtures import fabric_spark, lakehouse_root, mock_notebookutils
+
+__all__ = ["fabric_spark", "lakehouse_root", "mock_notebookutils"]

--- a/tests/testing/test_analyze.py
+++ b/tests/testing/test_analyze.py
@@ -1,0 +1,15 @@
+"""Tests for Ollama analysis placeholder."""
+
+import pytest
+
+from pyfabric.testing.analyze import analyze_log_file, analyze_test_report
+
+
+class TestAnalyzePlaceholder:
+    def test_analyze_test_report_raises(self):
+        with pytest.raises(RuntimeError, match="not yet implemented"):
+            analyze_test_report("test-report.json")
+
+    def test_analyze_log_file_raises(self):
+        with pytest.raises(RuntimeError, match="not yet implemented"):
+            analyze_log_file("some.jsonl")

--- a/tests/testing/test_duckdb_spark.py
+++ b/tests/testing/test_duckdb_spark.py
@@ -24,7 +24,7 @@ class TestRow:
     def test_column_access_without_names_raises(self):
         r = Row((1, 2), None)
         with pytest.raises(KeyError):
-            r["id"]
+            _ = r["id"]
 
     def test_as_dict(self):
         r = Row((1, "alice"), ["id", "name"])

--- a/tests/testing/test_duckdb_spark.py
+++ b/tests/testing/test_duckdb_spark.py
@@ -1,0 +1,157 @@
+"""Tests for DuckDBSparkSession — the DuckDB-backed Spark mock."""
+
+import pytest
+
+from pyfabric.testing.duckdb_spark import (
+    DuckDBSparkSession,
+    Row,
+    TableInfo,
+)
+
+
+class TestRow:
+    def test_index_access(self):
+        r = Row((1, "alice", 3.14), ["id", "name", "value"])
+        assert r[0] == 1
+        assert r[1] == "alice"
+        assert r[2] == 3.14
+
+    def test_column_access(self):
+        r = Row((42, "test"), ["id", "name"])
+        assert r["id"] == 42
+        assert r["name"] == "test"
+
+    def test_column_access_without_names_raises(self):
+        r = Row((1, 2), None)
+        with pytest.raises(KeyError):
+            r["id"]
+
+    def test_as_dict(self):
+        r = Row((1, "alice"), ["id", "name"])
+        assert r.asDict() == {"id": 1, "name": "alice"}
+
+    def test_repr_with_columns(self):
+        r = Row((1,), ["id"])
+        assert "id=1" in repr(r)
+
+
+class TestTableInfo:
+    def test_attributes(self):
+        t = TableInfo(database="lh_test", name="products")
+        assert t.database == "lh_test"
+        assert t.name == "products"
+        assert t.isTemporary is False
+
+    def test_index_access(self):
+        t = TableInfo(database="db", name="tbl")
+        assert t[0] == "db"
+        assert t[1] == "tbl"
+        assert t[2] is False
+
+
+class TestDuckDBSparkSession:
+    def test_basic_sql(self):
+        spark = DuckDBSparkSession()
+        df = spark.sql("SELECT 1 AS value, 'hello' AS msg")
+        rows = df.collect()
+        assert len(rows) == 1
+        assert rows[0][0] == 1
+        assert rows[0]["msg"] == "hello"
+        spark.stop()
+
+    def test_count(self):
+        spark = DuckDBSparkSession()
+        df = spark.sql("SELECT * FROM (VALUES (1), (2), (3)) AS t(x)")
+        assert df.count() == 3
+        spark.stop()
+
+    def test_show_does_not_raise(self, capsys):
+        spark = DuckDBSparkSession()
+        df = spark.sql("SELECT 1 AS id, 'test' AS name")
+        df.show()  # should print without error
+        captured = capsys.readouterr()
+        assert "id" in captured.out
+        assert "test" in captured.out
+        spark.stop()
+
+    def test_show_empty(self, capsys):
+        spark = DuckDBSparkSession()
+        df = spark.sql("SELECT 1 AS x WHERE 1=0")
+        df.show()
+        captured = capsys.readouterr()
+        assert "Empty" in captured.out
+        spark.stop()
+
+    def test_iteration(self):
+        spark = DuckDBSparkSession()
+        df = spark.sql("SELECT * FROM (VALUES (1), (2)) AS t(x)")
+        values = [r[0] for r in df]
+        assert values == [1, 2]
+        spark.stop()
+
+    def test_to_pandas(self):
+        pytest.importorskip("pandas")
+        spark = DuckDBSparkSession()
+        df = spark.sql("SELECT 1 AS id, 'a' AS name")
+        pdf = df.toPandas()
+        assert len(pdf) == 1
+        assert "id" in pdf.columns
+        spark.stop()
+
+
+class TestDeltaTableDiscovery:
+    """Test Delta table rewriting with real Delta files."""
+
+    @pytest.fixture
+    def lakehouse_with_delta(self, tmp_path):
+        """Create a lakehouse dir with a real Delta table."""
+        try:
+            import pyarrow as pa
+            from deltalake import write_deltalake
+        except ImportError:
+            pytest.skip("deltalake + pyarrow required")
+
+        table_dir = tmp_path / "lh_test" / "Tables" / "products"
+        table_dir.mkdir(parents=True)
+        table = pa.table(
+            {
+                "id": pa.array([1, 2, 3]),
+                "name": pa.array(["Widget A", "Widget B", "Widget C"]),
+                "price": pa.array([9.99, 19.99, 29.99]),
+            }
+        )
+        write_deltalake(str(table_dir), table)
+        return tmp_path
+
+    def test_sql_rewrites_table_reference(self, lakehouse_with_delta):
+        spark = DuckDBSparkSession(lakehouse_root=lakehouse_with_delta)
+        df = spark.sql("SELECT * FROM lh_test.products")
+        assert df.count() == 3
+        spark.stop()
+
+    def test_show_tables(self, lakehouse_with_delta):
+        spark = DuckDBSparkSession(lakehouse_root=lakehouse_with_delta)
+        df = spark.sql("SHOW TABLES IN lh_test")
+        rows = df.collect()
+        names = [r[1] for r in rows]
+        assert "products" in names
+        spark.stop()
+
+    def test_show_tables_empty_lakehouse(self, tmp_path):
+        spark = DuckDBSparkSession(lakehouse_root=tmp_path)
+        df = spark.sql("SHOW TABLES IN nonexistent")
+        assert df.count() == 0
+        spark.stop()
+
+    def test_catalog_list_tables(self, lakehouse_with_delta):
+        spark = DuckDBSparkSession(lakehouse_root=lakehouse_with_delta)
+        tables = spark.catalog.listTables("lh_test")
+        assert len(tables) >= 1
+        assert any(t.name == "products" for t in tables)
+        spark.stop()
+
+    def test_catalog_table_exists(self, lakehouse_with_delta):
+        spark = DuckDBSparkSession(lakehouse_root=lakehouse_with_delta)
+        assert spark.catalog.tableExists("products")
+        assert not spark.catalog.tableExists("nonexistent")
+        spark.stop()

--- a/tests/testing/test_mock_notebookutils.py
+++ b/tests/testing/test_mock_notebookutils.py
@@ -1,0 +1,89 @@
+"""Tests for MockNotebookUtils — filesystem, notebook, credentials mocks."""
+
+from pathlib import Path
+
+import pytest
+
+from pyfabric.testing.mock_notebookutils import MockNotebookUtils
+
+
+class TestMockFs:
+    def test_mkdirs_creates_directory(self, tmp_path: Path):
+        nu = MockNotebookUtils(root=tmp_path)
+        nu.fs.mkdirs("/data/tables")
+        assert (tmp_path / "data" / "tables").is_dir()
+
+    def test_ls_lists_files(self, tmp_path: Path):
+        nu = MockNotebookUtils(root=tmp_path)
+        (tmp_path / "a.txt").write_text("hello")
+        (tmp_path / "b.txt").write_text("world")
+        result = nu.fs.ls("/")
+        assert len(result) == 2
+
+    def test_ls_nonexistent_returns_empty(self, tmp_path: Path):
+        nu = MockNotebookUtils(root=tmp_path)
+        assert nu.fs.ls("/nonexistent") == []
+
+    def test_put_and_head(self, tmp_path: Path):
+        nu = MockNotebookUtils(root=tmp_path)
+        nu.fs.put("/data/test.txt", "hello world")
+        content = nu.fs.head("/data/test.txt")
+        assert content == "hello world"
+
+    def test_put_bytes(self, tmp_path: Path):
+        nu = MockNotebookUtils(root=tmp_path)
+        nu.fs.put("/data/binary.bin", b"\x00\x01\x02")
+        assert (tmp_path / "data" / "binary.bin").read_bytes() == b"\x00\x01\x02"
+
+    def test_cp_file(self, tmp_path: Path):
+        nu = MockNotebookUtils(root=tmp_path)
+        (tmp_path / "src.txt").write_text("data")
+        nu.fs.cp("/src.txt", "/dst.txt")
+        assert (tmp_path / "dst.txt").read_text() == "data"
+
+    def test_cp_recurse(self, tmp_path: Path):
+        nu = MockNotebookUtils(root=tmp_path)
+        src = tmp_path / "src_dir"
+        src.mkdir()
+        (src / "file.txt").write_text("data")
+        nu.fs.cp("/src_dir", "/dst_dir", recurse=True)
+        assert (tmp_path / "dst_dir" / "file.txt").read_text() == "data"
+
+    def test_rm_file(self, tmp_path: Path):
+        nu = MockNotebookUtils(root=tmp_path)
+        f = tmp_path / "to_delete.txt"
+        f.write_text("delete me")
+        nu.fs.rm("/to_delete.txt")
+        assert not f.exists()
+
+    def test_rm_directory_recurse(self, tmp_path: Path):
+        nu = MockNotebookUtils(root=tmp_path)
+        d = tmp_path / "dir_to_delete"
+        d.mkdir()
+        (d / "file.txt").write_text("data")
+        nu.fs.rm("/dir_to_delete", recurse=True)
+        assert not d.exists()
+
+
+class TestMockNotebook:
+    def test_run_returns_empty_string(self, tmp_path: Path):
+        nu = MockNotebookUtils(root=tmp_path)
+        result = nu.notebook.run("nb_test", arguments={"key": "val"})
+        assert result == ""
+
+    def test_exit_does_not_raise(self, tmp_path: Path):
+        nu = MockNotebookUtils(root=tmp_path)
+        nu.notebook.exit("success")  # should not raise
+
+
+class TestMockCredentials:
+    def test_get_token_raises(self, tmp_path: Path):
+        nu = MockNotebookUtils(root=tmp_path)
+        with pytest.raises(NotImplementedError, match="not available in local mode"):
+            nu.credentials.getToken("https://api.fabric.microsoft.com")
+
+
+class TestMssparkutilsAlias:
+    def test_alias_points_to_self(self, tmp_path: Path):
+        nu = MockNotebookUtils(root=tmp_path)
+        assert nu.mssparkutils is nu


### PR DESCRIPTION
## Summary

Phase 4: `pyfabric.testing` sub-package for local Fabric notebook and pipeline development.

### New modules

| Module | Purpose |
|--------|---------|
| `testing/duckdb_spark.py` | DuckDBSparkSession — drop-in SparkSession with Delta table auto-discovery, SQL rewriting, DataFrame/Row/Catalog |
| `testing/mock_notebookutils.py` | MockNotebookUtils — fs (ls/mkdirs/cp/rm/put/head), notebook (run/exit no-ops), credentials (raises) |
| `testing/fixtures.py` | pytest fixtures: `fabric_spark`, `mock_notebookutils`, `lakehouse_root` |
| `testing/plugin.py` | pytest plugin auto-registered via entry point — users get fixtures with `pip install pyfabric[testing]` |
| `testing/analyze.py` | Ollama analysis placeholder (stubs for future local LLM log/test analysis) |

### CI improvement

- Test jobs now upload `test-report.json` as artifact for AI-assisted failure analysis

### Tests

33 new tests covering DuckDB Spark session (SQL, Delta discovery, catalog, DataFrame ops), notebookutils (all fs operations, notebook lifecycle, credentials error), and Ollama stubs.

290 tests passing, all mypy strict on new code.

## Test plan

- [ ] CI passes
- [ ] `pip install pyfabric[testing]` makes `fabric_spark` fixture available

🤖 Generated with [Claude Code](https://claude.com/claude-code)