### PR TITLE
Add documentation: API reference, testing guide, AI prompts

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@
 [![Python](https://img.shields.io/pypi/pyversions/pyfabric)](https://pypi.org/project/pyfabric/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 
-Python libraries helping AI coding assistants create and locally validate
-Microsoft Fabric items compatible with Fabric git sync.
+Python library for creating, validating, and locally testing Microsoft Fabric
+items that are compatible with Fabric git sync.
 
 ## Installation
 
@@ -17,25 +17,76 @@ pip install pyfabric
 ### Optional dependencies
 
 ```bash
-pip install pyfabric[azure]    # Azure auth + REST client
-pip install pyfabric[data]     # OneLake + SQL data access
-pip install pyfabric[testing]  # DuckDB-based local testing fixtures
-pip install pyfabric[all]      # Everything
+pip install pyfabric[azure]    # Azure authentication and REST client
+pip install pyfabric[data]     # OneLake and SQL data access
+pip install pyfabric[testing]  # DuckDB Spark mock and pytest fixtures
+pip install pyfabric[all]      # All optional dependencies
 ```
 
-## Overview
+## Quick start
 
-pyfabric provides utilities for:
+### Validate a Fabric workspace
 
-- Creating Microsoft Fabric item definitions (notebooks, lakehouses,
-  semantic models, environments, variable libraries, pipelines, etc.)
-  programmatically
-- Validating item structures locally before committing to a Fabric
-  git-synced repository
-- Running notebook and pipeline transformations locally against DuckDB
-  to verify data logic without deploying to Fabric
-- Generating correct `.platform` files, directory layouts, and metadata
-  that Fabric git sync expects
+```python
+from pathlib import Path
+from pyfabric.items.validate import validate_workspace
+
+results = validate_workspace(Path("my_workspace/"))
+for r in results:
+    status = "OK" if r.valid else "FAIL"
+    print(f"{status}: {r.item_path.name}")
+    for e in r.errors:
+        print(f"  ERROR: {e.message}")
+```
+
+### List workspaces with the REST client
+
+```python
+from pyfabric.client.auth import FabricCredential
+from pyfabric.client.http import FabricClient
+from pyfabric.workspace.workspaces import list_workspaces
+
+cred = FabricCredential(tenant="contoso")
+client = FabricClient(cred)
+
+for ws in list_workspaces(client):
+    print(f"{ws['displayName']}  {ws['id']}")
+```
+
+### Test notebook logic locally
+
+```python
+# In your test file (pytest)
+def test_my_notebook(fabric_spark, mock_notebookutils):
+    # fabric_spark is a DuckDB-backed SparkSession replacement
+    df = fabric_spark.sql("SELECT 1 AS value, 'hello' AS msg")
+    rows = df.collect()
+    assert rows[0]["value"] == 1
+
+    # mock_notebookutils replaces Fabric notebookutils
+    mock_notebookutils.fs.mkdirs("/output")
+    mock_notebookutils.fs.put("/output/result.txt", "done")
+```
+
+## Documentation
+
+| Document | Description |
+|----------|-------------|
+| [API Reference](docs/api.md) | All sub-packages and their public functions |
+| [Testing Guide](docs/testing.md) | Local testing with DuckDB Spark mock and pytest fixtures |
+| [AI Prompts](docs/prompts.md) | Sample prompts for Claude and Copilot to create Fabric items |
+| [CONTRIBUTING.md](CONTRIBUTING.md) | Development setup and release process |
+| [CLAUDE.md](CLAUDE.md) | Instructions for AI coding assistants |
+
+## Sub-packages
+
+| Package | Purpose | Install |
+|---------|---------|---------|
+| `pyfabric.client` | Fabric REST API authentication and HTTP client | `pyfabric[azure]` |
+| `pyfabric.items` | Create, validate, and manage Fabric item definitions | (included) |
+| `pyfabric.data` | OneLake, SQL endpoint, and lakehouse table operations | `pyfabric[data]` |
+| `pyfabric.workspace` | Workspace management (list, create, roles) | `pyfabric[azure]` |
+| `pyfabric.testing` | DuckDB Spark mock, notebookutils mock, pytest fixtures | `pyfabric[testing]` |
 
 ## Requirements
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -1,0 +1,316 @@
+# API Reference
+
+This document describes all public modules and functions in pyfabric.
+
+## pyfabric.client — Fabric REST API
+
+### pyfabric.client.auth
+
+Authentication and credential management for Microsoft Fabric.
+
+| Function / Class | Description |
+|-----------------|-------------|
+| `FabricCredential(tenant=None)` | Unified credential using Azure Identity or az CLI fallback. Caches tokens per scope. |
+| `FabricCredential.get_token(resource)` | Get a bearer token for a resource URL. Normalizes to scope format automatically. |
+| `FabricCredential.fabric_token` | Token for the Fabric REST API. |
+| `FabricCredential.storage_token` | Token for OneLake DFS (storage.azure.com). |
+| `FabricCredential.sql_token` | Token for SQL analytics endpoints. |
+| `AuthError` | Raised when authentication fails. |
+| `get_token(resource)` | Get a token using the default credential chain. |
+| `get_current_account()` | Return the current `az account show` output as a dict. |
+| `az_login(tenant=None)` | Launch interactive browser login. |
+| `ensure_logged_in(resource, tenant)` | Get a token, triggering login if needed. |
+
+**Example:**
+
+```python
+from pyfabric.client.auth import FabricCredential
+
+cred = FabricCredential(tenant="contoso")
+token = cred.fabric_token
+```
+
+### pyfabric.client.http
+
+HTTP client for the Fabric REST API v1 with retry, pagination, and LRO polling.
+
+| Function / Class | Description |
+|-----------------|-------------|
+| `FabricClient(credential=None)` | HTTP client. Accepts FabricCredential, token string, or None (creates default). |
+| `FabricClient.get(path, params)` | GET a single resource. |
+| `FabricClient.get_paged(path, params)` | GET all pages of a paginated collection. |
+| `FabricClient.post(path, body)` | POST with sync (200) and async (202/LRO) support. |
+| `FabricClient.patch(path, body)` | PATCH with sync and async support. |
+| `FabricClient.delete(path)` | DELETE a resource. |
+| `FabricError` | Raised on HTTP 4xx/5xx. Contains status, body, and URL for diagnostics. |
+
+**Example:**
+
+```python
+from pyfabric.client.http import FabricClient
+
+client = FabricClient(cred)
+items = client.get_paged("workspaces/ws-id/items")
+```
+
+### pyfabric.client.graph
+
+Client for the Fabric Graph Model REST API.
+
+| Function / Class | Description |
+|-----------------|-------------|
+| `GraphClient(client, workspace_id)` | Wrapper for graph model operations. |
+| `GraphClient.list_graph_models()` | List all graph models in the workspace. |
+| `GraphClient.get_definition_decoded(graph_id)` | Get definition with base64 payloads decoded. |
+| `GraphClient.execute_query(graph_id, query)` | Execute a GQL query. |
+| `GraphClient.refresh(graph_id, wait=True)` | Trigger an on-demand graph refresh. |
+
+### pyfabric.client.livy
+
+Client for the Fabric Livy API (Spark SQL execution).
+
+| Function / Class | Description |
+|-----------------|-------------|
+| `LivyClient(credential, workspace_id, lakehouse_id)` | Spark session client. Supports context manager protocol. |
+| `LivyClient.create_session()` | Create a new Spark session and wait for idle state. |
+| `LivyClient.sql(statement)` | Execute a Spark SQL statement. |
+| `LivyClient.execute(code, kind)` | Execute arbitrary Spark/PySpark code. |
+| `LivyClient.close_session()` | Delete the Spark session. |
+
+**Example:**
+
+```python
+from pyfabric.client.livy import LivyClient
+
+with LivyClient(cred, ws_id, lh_id) as livy:
+    livy.sql("CREATE TABLE t (id STRING) USING DELTA")
+    result = livy.sql("SELECT * FROM t")
+```
+
+### pyfabric.client.ontology
+
+Ontology CRUD, builder, and definition helpers for Fabric IQ.
+
+| Function / Class | Description |
+|-----------------|-------------|
+| `OntologyBuilder()` | High-level builder for ontology definitions. |
+| `OntologyBuilder.add_entity_type(name, properties)` | Add an entity type. Returns entity type ID. |
+| `OntologyBuilder.add_data_binding(entity_type_id, ...)` | Bind entity properties to a lakehouse table. |
+| `OntologyBuilder.add_relationship(name, source_id, target_id)` | Add a relationship between entity types. |
+| `OntologyBuilder.validate()` | Validate the ontology. Returns list of error messages. |
+| `OntologyBuilder.to_bundle(display_name)` | Build an ArtifactBundle for git-sync format. |
+| `list_ontologies(client, ws_id)` | List all ontologies in a workspace. |
+| `create_ontology(client, ws_id, display_name)` | Create an ontology via REST API. |
+| `decode_definition(raw)` | Decode an API definition response. |
+| `encode_definition(parts)` | Encode parts back to API format. |
+| `build_from_config(config)` | Build ontology from a JSON config dict. |
+
+### pyfabric.client.ontology_sync
+
+Synchronize ontology entity types to Lakehouse tables and data bindings.
+
+| Function / Class | Description |
+|-----------------|-------------|
+| `sync_all_entities(client, ws_id, ontology_id, livy, lh_id)` | Sync all entities to tables and bindings in one round trip. |
+| `sync_entity_to_lakehouse(client, ws_id, ontology_id, entity_type_id, livy, lh_id, table_name)` | Sync a single entity type. |
+
+---
+
+## pyfabric.items — Fabric Item Definitions
+
+### pyfabric.items.types
+
+Item type definitions and `.platform` file parsing.
+
+| Function / Class | Description |
+|-----------------|-------------|
+| `ITEM_TYPES` | Dict mapping type names to `ItemType` definitions. Registered types: Notebook, Lakehouse, Dataflow, Environment, VariableLibrary, SemanticModel, Report, Pipeline, Warehouse, Map. |
+| `ItemType` | Dataclass with `type_name`, `required_files`, `optional_files`. |
+| `parse_platform(content)` | Parse a `.platform` JSON file. Returns `PlatformFile` with metadata and config. |
+| `PlatformFile` | Parsed `.platform` with `metadata.type`, `metadata.display_name`, `config.logical_id`. |
+
+### pyfabric.items.validate
+
+Validate Fabric item directory structures before git-syncing.
+
+| Function / Class | Description |
+|-----------------|-------------|
+| `validate_item(item_dir)` | Validate a single item directory. Returns `ValidationResult`. |
+| `validate_workspace(workspace_dir)` | Validate all items in a workspace directory. Returns list of results. |
+| `ValidationResult` | Contains `valid` (bool), `errors`, `warnings`, `item_type`, `item_path`. |
+| `ValidationError` | A single error or warning with `message` and optional `path`. |
+
+**Example:**
+
+```python
+from pyfabric.items.validate import validate_item
+from pathlib import Path
+
+result = validate_item(Path("ws/nb_test.Notebook"))
+if not result.valid:
+    for e in result.errors:
+        print(f"ERROR: {e.message}")
+```
+
+### pyfabric.items.bundle
+
+Build and manage Fabric item definitions in git-sync format.
+
+| Function / Class | Description |
+|-----------------|-------------|
+| `ArtifactBundle(item_type, display_name, parts)` | A complete Fabric item definition. |
+| `save_to_disk(bundle, output_dir)` | Write artifact in git-sync directory format. |
+| `load_from_disk(artifact_dir)` | Read a git-sync artifact directory into a bundle. |
+| `upload_to_workspace(bundle, client, ws_id)` | Push artifact to workspace via REST API. |
+| `diff_bundles(local, remote)` | Compare two bundles. Returns added, removed, modified paths. |
+
+### pyfabric.items.crud
+
+CRUD operations for Fabric workspace items via REST API.
+
+| Function / Class | Description |
+|-----------------|-------------|
+| `list_items(client, workspace_id, item_type=None)` | List all items in a workspace. |
+| `get_item(client, workspace_id, item_id)` | Get a single item. |
+| `create_item(client, workspace_id, display_name, item_type)` | Create a workspace item. |
+| `update_item(client, workspace_id, item_id, display_name=None)` | Update item metadata. |
+| `delete_item(client, workspace_id, item_id)` | Delete a workspace item. |
+| `encode_part(path, content)` | Build a definition part dict for the API. |
+| `decode_part(part)` | Decode base64 payload from a part dict. |
+
+---
+
+## pyfabric.data — Data Access
+
+### pyfabric.data.onelake
+
+OneLake DFS (Data Lake Storage Gen2) helpers.
+
+| Function / Class | Description |
+|-----------------|-------------|
+| `abfss_url(ws_id, item_id, path)` | Build an `abfss://` URL for Delta lake access. |
+| `list_paths(token, ws_id, item_id, path)` | List paths using the DFS filesystem API. |
+| `list_files(token, ws_id, item_id, path)` | List non-directory entries, optionally filtered by suffix. |
+| `read_file(token, ws_id, item_id, path)` | Download a file as bytes. |
+| `upload_file(token, ws_id, item_id, path, data)` | Upload bytes using the 3-step DFS protocol. |
+| `read_parquet_df(token, ws_id, item_id, path)` | Download Parquet files and return a DataFrame. |
+
+### pyfabric.data.sql
+
+SQL analytics endpoint client for Fabric lakehouses and warehouses.
+
+| Function / Class | Description |
+|-----------------|-------------|
+| `FabricSql(server, database, credential)` | SQL connection using pyodbc with AAD tokens. |
+| `FabricSql.query_df(sql, params)` | Execute SELECT and return a pandas DataFrame. |
+| `FabricSql.execute(sql, params)` | Execute DDL/DML. Returns affected row count. |
+| `FabricSql.table_exists(table, schema)` | Check if a table exists. |
+| `FabricSql.list_tables(schema)` | List table names in a schema. |
+| `connect_lakehouse(client, credential, ws_id, lakehouse_name)` | Auto-resolve SQL endpoint from REST API. |
+| `SqlError` | Raised on SQL connection or query errors. |
+
+### pyfabric.data.lakehouse
+
+High-level lakehouse table operations with SQL-first reads and DFS Delta writes.
+
+| Function / Class | Description |
+|-----------------|-------------|
+| `write_table(credential, ws_id, lh_id, table_name, data)` | Write a DataFrame as a Delta table. |
+| `read_table(credential, ws_id, lh_id, table_name)` | Read a table (SQL first, DFS fallback). |
+| `WriteResult` | Result dataclass with table_path, row_count, mode, dry_run. |
+
+---
+
+## pyfabric.workspace — Workspace Management
+
+### pyfabric.workspace.workspaces
+
+CRUD operations for Fabric workspaces.
+
+| Function / Class | Description |
+|-----------------|-------------|
+| `list_workspaces(client)` | List all accessible workspaces. |
+| `get_workspace(client, workspace_id)` | Get a single workspace. |
+| `create_workspace(client, display_name)` | Create a new workspace. |
+| `update_workspace(client, workspace_id)` | Update workspace name or description. |
+| `delete_workspace(client, workspace_id)` | Delete a workspace. |
+| `assign_to_capacity(client, workspace_id, capacity_id)` | Assign workspace to a Fabric capacity. |
+| `add_role_assignment(client, workspace_id, principal_id, principal_type, role)` | Add a role assignment. |
+
+---
+
+## pyfabric.testing — Local Testing Utilities
+
+### pyfabric.testing.duckdb_spark
+
+DuckDB-backed Spark session mock for local notebook testing.
+
+| Function / Class | Description |
+|-----------------|-------------|
+| `DuckDBSparkSession(lakehouse_root=None)` | Drop-in SparkSession replacement. |
+| `DuckDBSparkSession.sql(query)` | Execute SQL with automatic Delta table rewriting. |
+| `DuckDBSparkSession.catalog.listTables(dbName)` | List Delta tables in a lakehouse directory. |
+| `DuckDBSparkSession.catalog.tableExists(tableName)` | Check if a table exists. |
+| `DataFrame` | PySpark DataFrame replacement with `collect()`, `show()`, `count()`, `toPandas()`. |
+| `Row` | PySpark Row replacement with index and column-name access. |
+
+### pyfabric.testing.mock_notebookutils
+
+Mock for Fabric notebookutils / mssparkutils.
+
+| Function / Class | Description |
+|-----------------|-------------|
+| `MockNotebookUtils(root=None)` | Drop-in notebookutils replacement. |
+| `.fs.ls(path)` | List files at path. |
+| `.fs.mkdirs(path)` | Create directories. |
+| `.fs.cp(src, dst, recurse)` | Copy file or directory. |
+| `.fs.rm(path, recurse)` | Remove file or directory. |
+| `.fs.put(path, content)` | Write content to a file. |
+| `.fs.head(path)` | Read the first bytes of a file. |
+| `.notebook.run(name)` | No-op (logs the call). |
+| `.notebook.exit(value)` | No-op (logs the value). |
+| `.credentials.getToken(audience)` | Raises `NotImplementedError` with guidance. |
+
+### pyfabric.testing.fixtures
+
+Pytest fixtures auto-registered via plugin entry point.
+
+| Fixture | Description |
+|---------|-------------|
+| `fabric_spark` | DuckDBSparkSession with a temporary lakehouse root. |
+| `mock_notebookutils` | MockNotebookUtils with a temporary filesystem root. |
+| `lakehouse_root` | Path to the temporary lakehouse directory. |
+
+### pyfabric.testing.analyze
+
+AI-powered test and log analysis (placeholder for future Ollama integration).
+
+| Function | Description |
+|----------|-------------|
+| `analyze_test_report(report_path, model)` | Analyze pytest JSON report with local LLM. (Not yet implemented.) |
+| `analyze_log_file(log_path, model)` | Analyze structlog JSON log file with local LLM. (Not yet implemented.) |
+
+---
+
+## pyfabric._logging — Structured Logging
+
+Dual-output logging using structlog: console (terse) and JSON Lines file (verbose).
+
+| Function / Class | Description |
+|-----------------|-------------|
+| `setup_logging(script_name, verbose=False)` | Configure structured logging. Returns the log file path. |
+| `get_log_path(script_name)` | Return the log file path for a script. |
+| `mask_tokens_processor(logger, method_name, event_dict)` | Structlog processor that redacts JWT tokens. |
+| `TokenMaskingFilter` | Stdlib logging filter for token redaction (backward compatibility). |
+
+## pyfabric.cli — Command-Line Interface
+
+Standard CLI argument parsing and script execution wrapper.
+
+| Function / Class | Description |
+|-----------------|-------------|
+| `add_standard_args(parser, project)` | Add `--env`, `--dry-run`, `--tenant`, `--verbose` to argparse. |
+| `run_main(fn, parser)` | Parse args, set up logging, run function, handle errors. |
+| `register_env(project, env_name, config)` | Register an environment config. |
+| `resolve_env(project, env_name)` | Look up an environment config. |
+| `get_credential(args)` | Build a FabricCredential from CLI args. |

--- a/docs/prompts.md
+++ b/docs/prompts.md
@@ -1,0 +1,237 @@
+# AI Prompts for Fabric Development
+
+This document provides sample prompts for Claude and Copilot to create
+Microsoft Fabric items, validate them, and run local tests using pyfabric.
+
+## Creating Fabric items
+
+### Notebook
+
+```
+Create a Fabric notebook called nb_load_customers that:
+1. Reads a CSV file from OneLake path Tables/dbo/raw_customers
+2. Transforms the data: uppercase the name column, parse date strings to timestamps
+3. Writes the result to lh_silver.dbo.customers as a Delta table
+4. Uses the pyfabric Fabric notebook format with METADATA, CELL, and MARKDOWN sections
+5. Save it in git-sync format at ws_dev/nb_load_customers.Notebook/
+
+The notebook-content.py should use the standard Fabric format with
+# METADATA, # CELL, and # MARKDOWN section markers.
+```
+
+### Lakehouse
+
+```
+Create a Fabric lakehouse definition called lh_silver in git-sync format.
+It should have:
+- defaultSchema set to "dbo"
+- No shortcuts
+- Standard ALM settings
+
+Save at ws_dev/lh_silver.Lakehouse/ with .platform, lakehouse.metadata.json,
+and alm.settings.json files.
+
+Use pyfabric.items.bundle.ArtifactBundle and save_to_disk() to generate the files.
+```
+
+### Environment
+
+```
+Create a Fabric environment definition called env_data_processing.
+It should:
+- Include pip dependencies: pandas>=2.0, pyarrow>=14.0, deltalake>=0.17
+- Set Spark runtime version to 1.3
+- Enable dynamic executor allocation (1 to 9 executors)
+- Driver: 8 cores, 56g memory
+- Executor: 8 cores, 56g memory
+
+Save in git-sync format at ws_dev/env_data_processing.Environment/
+with the correct nested directory structure:
+  Libraries/PublicLibraries/environment.yml
+  Setting/Sparkcompute.yml
+```
+
+### Variable Library
+
+```
+Create a Fabric variable library called vl_config with:
+- Variables: workspace_id (String), lakehouse_id (String), env_name (String)
+- Default values for a dev environment
+- Two value sets: UAT and PROD with appropriate overrides
+- Use the correct Fabric JSON schemas for variables.json, settings.json, and valueSets/*.json
+
+Save in git-sync format at ws_dev/vl_config.VariableLibrary/
+
+Remember: variable types use short names (String, Integer, Boolean, Guid)
+not suffixed names (StringVariable, etc.).
+```
+
+### Dataflow
+
+```
+Create a Fabric dataflow definition called df_load_source_data.
+It needs:
+- A .platform file with type "Dataflow"
+- A queryMetadata.json with formatVersion "202502"
+- A placeholder mashup.pq file
+
+Save in git-sync format at ws_dev/df_load_source_data.Dataflow/
+```
+
+### Semantic Model
+
+```
+Create a Fabric semantic model definition called sm_sales_analytics.
+It needs:
+- A .platform file with type "SemanticModel"
+- A model.bim file with a basic tabular model containing one table (Sales)
+  with columns: SaleId (Int64), Amount (Decimal), SaleDate (DateTime)
+
+Save in git-sync format at ws_dev/sm_sales_analytics.SemanticModel/
+```
+
+### Pipeline
+
+```
+Create a Fabric pipeline definition called pl_daily_refresh.
+It needs:
+- A .platform file with type "Pipeline"
+- A pipeline-content.json with a simple pipeline that has two activities:
+  1. A notebook activity that runs nb_load_customers
+  2. A notebook activity that runs nb_transform_data
+
+Save in git-sync format at ws_dev/pl_daily_refresh.Pipeline/
+```
+
+## Validating items
+
+### Validate a single item
+
+```
+Use pyfabric to validate the Fabric item at ws_dev/nb_load_customers.Notebook/.
+Check that:
+- The .platform file has valid JSON with type, displayName, and logicalId
+- All required files for a Notebook are present
+- The directory name matches the displayName in .platform
+
+Use pyfabric.items.validate.validate_item() and print any errors.
+```
+
+### Validate an entire workspace
+
+```
+Use pyfabric to validate all Fabric items in the workspace at ws_dev/.
+Print a summary showing which items pass and which fail.
+Use pyfabric.items.validate.validate_workspace().
+```
+
+## Writing and running local tests
+
+### Test a notebook's SQL logic
+
+```
+Write a pytest test for nb_load_customers that:
+1. Uses the fabric_spark fixture (DuckDB-backed SparkSession)
+2. Creates a test Delta table at lh_bronze/Tables/raw_customers with sample data
+3. Calls the notebook's transform function
+4. Asserts the output has the correct schema and transformed values
+5. Run with: pytest tests/test_nb_load_customers.py -v
+```
+
+### Test with notebookutils
+
+```
+Write a pytest test that verifies notebook file operations:
+1. Uses the mock_notebookutils fixture
+2. Creates directories with fs.mkdirs
+3. Writes test data with fs.put
+4. Reads it back with fs.head
+5. Verifies the content matches
+6. Cleans up with fs.rm
+
+Run with: pytest tests/test_file_operations.py -v
+```
+
+### Test data quality
+
+```
+Write pytest tests that validate data quality in a DuckDB table:
+1. Use the sample_db fixture from pyfabric's test fixtures
+2. Check for NULL values in required columns
+3. Check for empty strings vs NULLs
+4. Verify foreign key relationships (all order.customer_id values exist in customers)
+5. Check for anomalous values (e.g., negative prices, future dates)
+6. Print results in a format useful for debugging
+
+Run with: pytest tests/test_data_quality.py -v --tb=long
+```
+
+### Run validation against a real workspace
+
+```
+Run pyfabric's E2E validation tests against my local Fabric workspace:
+
+PYFABRIC_TEST_WORKSPACE=C:/path/to/my/workspace/dev pytest tests/items/test_validate_e2e.py -v
+
+If any items fail validation, explain what's wrong and how to fix it.
+```
+
+## Analyzing test failures
+
+### Read a test report
+
+```
+Read the pytest JSON report at .test-report.json and:
+1. List all failed tests with their error messages
+2. For each failure, identify the root cause
+3. Suggest specific code fixes
+4. Prioritize by severity (errors that block functionality vs warnings)
+```
+
+### Read log files
+
+```
+Read the structlog JSON log file at .logs/my_script_20250401.jsonl and:
+1. Find all ERROR and WARNING entries
+2. Group related log entries by timestamp and context
+3. Identify the root cause of any failures
+4. Check for any masked [TOKEN] entries that might indicate credential issues
+```
+
+## Using pyfabric programmatically
+
+### List workspace items
+
+```
+Using pyfabric, connect to my Fabric tenant and:
+1. List all workspaces I have access to
+2. For a specific workspace, list all items grouped by type
+3. Show the display name, type, and ID for each item
+
+Use FabricCredential with my tenant, FabricClient, and list_items().
+```
+
+### Create and upload an item
+
+```
+Using pyfabric, create a new Notebook called nb_hello_world with a simple
+print statement, then:
+1. Build an ArtifactBundle
+2. Save it to disk in git-sync format
+3. Validate it with validate_item()
+4. If validation passes, print "Ready to commit"
+
+Use pyfabric.items.bundle and pyfabric.items.validate.
+```
+
+### Read lakehouse data
+
+```
+Using pyfabric, read data from my Fabric lakehouse:
+1. Connect with FabricCredential
+2. Use read_table() to read dbo.customers from lh_bronze
+3. Print the first 10 rows
+4. Show the column names and data types
+
+Try the SQL endpoint first; if that fails, fall back to DFS Delta read.
+```

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -1,0 +1,215 @@
+# Testing Guide
+
+This guide explains how to test Microsoft Fabric notebooks and pipelines
+locally using pyfabric's testing framework.
+
+## Installation
+
+```bash
+pip install pyfabric[testing]
+```
+
+This installs DuckDB, deltalake, and pytest along with the pyfabric testing
+utilities. The pytest fixtures are auto-registered — no conftest imports needed.
+
+## Available fixtures
+
+After installing `pyfabric[testing]`, these fixtures are available in all
+your test files automatically:
+
+| Fixture | Type | Description |
+|---------|------|-------------|
+| `fabric_spark` | `DuckDBSparkSession` | Drop-in SparkSession backed by DuckDB |
+| `mock_notebookutils` | `MockNotebookUtils` | Drop-in for Fabric notebookutils |
+| `lakehouse_root` | `Path` | Temporary directory for lakehouse data |
+
+## Testing notebook SQL logic
+
+The `fabric_spark` fixture provides a DuckDB-backed SparkSession replacement.
+It supports `spark.sql()`, `DataFrame.collect()`, `.show()`, `.count()`,
+and automatic Delta table discovery.
+
+### Basic SQL test
+
+```python
+def test_simple_query(fabric_spark):
+    df = fabric_spark.sql("SELECT 1 AS id, 'hello' AS message")
+    rows = df.collect()
+    assert len(rows) == 1
+    assert rows[0]["id"] == 1
+    assert rows[0]["message"] == "hello"
+```
+
+### Testing with Delta tables
+
+Place Delta tables in the lakehouse directory structure that Fabric expects:
+
+```python
+import pyarrow as pa
+from deltalake import write_deltalake
+
+def test_with_delta_table(fabric_spark, lakehouse_root):
+    # Create a lakehouse with a Delta table
+    table_dir = lakehouse_root / "lh_test" / "Tables" / "products"
+    table_dir.mkdir(parents=True)
+    
+    table = pa.table({
+        "product_id": pa.array([1, 2, 3]),
+        "name": pa.array(["Widget A", "Widget B", "Widget C"]),
+        "price": pa.array([9.99, 19.99, 29.99]),
+    })
+    write_deltalake(str(table_dir), table)
+    
+    # Query using Fabric-style table references
+    df = fabric_spark.sql("SELECT * FROM lh_test.products WHERE price > 15")
+    assert df.count() == 2
+```
+
+### SHOW TABLES
+
+```python
+def test_show_tables(fabric_spark, lakehouse_root):
+    # (create Delta tables first, as above)
+    df = fabric_spark.sql("SHOW TABLES IN lh_test")
+    tables = [row[1] for row in df.collect()]
+    assert "products" in tables
+```
+
+### Catalog operations
+
+```python
+def test_catalog(fabric_spark, lakehouse_root):
+    # (create Delta tables first)
+    tables = fabric_spark.catalog.listTables("lh_test")
+    assert any(t.name == "products" for t in tables)
+    
+    assert fabric_spark.catalog.tableExists("products")
+    assert not fabric_spark.catalog.tableExists("nonexistent")
+```
+
+## Testing notebookutils operations
+
+The `mock_notebookutils` fixture provides a local filesystem replacement for
+Fabric's `notebookutils` / `mssparkutils`.
+
+### File operations
+
+```python
+def test_file_operations(mock_notebookutils):
+    # Create directories
+    mock_notebookutils.fs.mkdirs("/output/tables")
+    
+    # Write a file
+    mock_notebookutils.fs.put("/output/tables/result.csv", "id,name\n1,test")
+    
+    # Read it back
+    content = mock_notebookutils.fs.head("/output/tables/result.csv")
+    assert "id,name" in content
+    
+    # List files
+    files = mock_notebookutils.fs.ls("/output/tables")
+    assert len(files) == 1
+    
+    # Copy and remove
+    mock_notebookutils.fs.cp("/output/tables/result.csv", "/output/backup.csv")
+    mock_notebookutils.fs.rm("/output/tables/result.csv")
+```
+
+### Notebook execution (no-op in local mode)
+
+```python
+def test_notebook_run(mock_notebookutils):
+    # notebook.run() is a no-op locally — it logs the call but does not execute
+    result = mock_notebookutils.notebook.run(
+        "nb_process_data",
+        timeout_seconds=600,
+        arguments={"env": "dev", "date": "2025-04-01"},
+    )
+    assert result == ""
+```
+
+### Credentials (raises in local mode)
+
+```python
+import pytest
+
+def test_credentials_raise(mock_notebookutils):
+    with pytest.raises(NotImplementedError, match="not available in local mode"):
+        mock_notebookutils.credentials.getToken("https://api.fabric.microsoft.com")
+```
+
+Use `pyfabric.client.auth.FabricCredential` instead for local authentication.
+
+## Testing a real notebook function
+
+A common pattern is to extract notebook logic into testable functions:
+
+```python
+# In your notebook or a shared module:
+def process_data(spark, source_table, target_table):
+    """Transform data from source to target table."""
+    df = spark.sql(f"SELECT id, UPPER(name) AS name FROM {source_table}")
+    return df
+
+# In your test file:
+import pyarrow as pa
+from deltalake import write_deltalake
+
+def test_process_data(fabric_spark, lakehouse_root):
+    # Set up test data
+    table_dir = lakehouse_root / "lh_bronze" / "Tables" / "raw_customers"
+    table_dir.mkdir(parents=True)
+    write_deltalake(str(table_dir), pa.table({
+        "id": pa.array([1, 2]),
+        "name": pa.array(["alice", "bob"]),
+    }))
+    
+    # Run the function under test
+    result = process_data(fabric_spark, "lh_bronze.raw_customers", "lh_silver.customers")
+    
+    # Verify
+    rows = result.collect()
+    assert rows[0]["name"] == "ALICE"
+    assert rows[1]["name"] == "BOB"
+```
+
+## Running tests
+
+```bash
+# Run all tests
+pytest
+
+# Run with coverage
+pytest --cov=src/pyfabric --cov-branch --cov-report=term-missing
+
+# Run only your project tests (not pyfabric internal tests)
+pytest tests/
+
+# Generate JSON report for AI analysis
+pytest --json-report --json-report-file=test-report.json
+```
+
+## Validating Fabric workspace structure
+
+Use `validate_workspace()` to check item structures before git-syncing:
+
+```python
+from pathlib import Path
+from pyfabric.items.validate import validate_workspace
+
+results = validate_workspace(Path("path/to/workspace"))
+for r in results:
+    if r.valid:
+        print(f"OK: {r.item_path.name}")
+    else:
+        print(f"FAIL: {r.item_path.name}")
+        for e in r.errors:
+            print(f"  {e.message}")
+```
+
+You can also set the `PYFABRIC_TEST_WORKSPACE` environment variable to run
+E2E validation as part of your test suite:
+
+```bash
+PYFABRIC_TEST_WORKSPACE=/path/to/workspace pytest -m e2e
+```


### PR DESCRIPTION
## Summary

Add comprehensive documentation for all sub-packages, written in clear English for easy localization with browser translation or automated tools.

### New files

| File | Content |
|------|---------|
| `docs/api.md` | Complete API reference — every public function/class across all 6 sub-packages with signatures, descriptions, and examples |
| `docs/testing.md` | Step-by-step guide for local notebook testing with DuckDB Spark mock, Delta fixtures, notebookutils mock, and validation |
| `docs/prompts.md` | Sample Claude/Copilot prompts for creating each Fabric item type (Notebook, Lakehouse, Environment, VariableLibrary, Dataflow, SemanticModel, Pipeline), plus prompts for validation, local testing, and failure analysis |

### Updated files

| File | Change |
|------|--------|
| `README.md` | Expanded with quick start examples, documentation table, sub-package overview |

## Test plan
- [ ] CI passes (no code changes, only docs)
- [ ] Docs render correctly on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)