### PR TITLE
Add vision and roadmap docs, fix API docs

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -153,7 +153,7 @@ Synchronize ontology entity types to Lakehouse tables and data bindings.
 
 | Function / Class | Description |
 |-----------------|-------------|
-| `sync_all_entities(client, ws_id, ontology_id, livy, lh_id)` | Sync all entities to tables and bindings in one round trip. |
+| `sync_all_entities(client, ws_id, ontology_id, livy, lh_id, *, entity_ids=None, table_map=None)` | Sync all (or specified) entities to tables and bindings in one round trip. |
 | `sync_entity_to_lakehouse(client, ws_id, ontology_id, entity_type_id, livy, lh_id, table_name)` | Sync a single entity type. |
 
 ---

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,0 +1,62 @@
+# Roadmap
+
+This document tracks the implementation plan for pyfabric across four
+phases, from library foundation through LLM-powered data analysis.
+
+## Phase 1: Library Foundation (Complete)
+
+Built the core library scaffold, ported fabric-libs, added validation,
+testing, documentation, and refactored for maintainability.
+
+| Step | Description | PR |
+|------|------------|----|
+| 1 | Library scaffold — project structure, CI/CD, supply chain security | #1 |
+| 2 | Port fabric-libs into pyfabric sub-package structure | #4 |
+| 3 | Fabric item type definitions + structure validation (TDD) | #5 |
+| 4 | Comprehensive test coverage (104 tests + error paths + E2E fixes) | #6, #7 |
+| 5 | Migrate stdlib logging to structlog | #8 |
+| 6 | Testing sub-package — DuckDB Spark mock, notebookutils, pytest fixtures | #9 |
+| 7 | Documentation — API reference, testing guide, AI prompt samples | #10 |
+| 8 | OOP refactoring — cohesion, coupling, testability, performance | #11 |
+| 9 | PyPI publication (tag + trusted publisher OIDC) | — |
+
+## Phase 2: Fabric Item Authoring Depth
+
+Expand supported Fabric item types beyond basic validation to full
+programmatic authoring. The current `ITEM_TYPES` registry has basic
+definitions for: Notebook, Lakehouse, Dataflow, Environment,
+VariableLibrary, SemanticModel, Report, Pipeline, Warehouse, Map.
+
+This phase adds deep authoring support:
+
+- **Semantic Models** — full tabular model authoring (model.bim with
+  tables, columns, measures, relationships)
+- **Reports** (Power BI) — report definition authoring tied to semantic
+  models
+- **Ontologies** — extend OntologyBuilder for full git-sync authoring
+- **Dataflow Gen2** — mashup/Power Query authoring support
+- **Pipelines** — activity graph authoring (notebook activities, copy
+  activities, orchestration)
+- **Data Agents** — programmatic data agent definitions
+- **Lakehouses** — add new tables with schemas (not just the lakehouse
+  shell)
+
+## Phase 3: Event-Driven Automation
+
+- **Activators with EventStreams** — listen to a lakehouse files folder
+  for activity (file uploaded, file changed) and automatically trigger a
+  pipeline or notebook
+- Wire up event-driven patterns for CI/CD and data pipeline automation
+
+## Phase 4: LLM-Powered Data Analysis
+
+Local or online, PHI-compliant data quality analysis:
+
+- Pull production data from Fabric locally
+- Mask/scramble production data for safe local testing with near-real data
+- Run notebook/pipeline transformations locally against DuckDB
+- Integrate Ollama + user's choice of local LLM model for deep data QA
+- Compare tables and analyze data state differences using LLM of choice
+  (online or local, depending on sensitivity and cost)
+- Anomaly detection, data quality analysis, all on-box when needed
+- Placeholder exists in `pyfabric.testing.analyze` module

--- a/docs/vision.md
+++ b/docs/vision.md
@@ -1,0 +1,47 @@
+# Vision
+
+pyfabric empowers data engineers to leverage Microsoft Fabric's git sync
+capability to author Fabric artifacts locally using tools like Claude Code
+and GitHub Copilot with VS Code (or standalone CLIs) and have them sync
+into Fabric with no changes needed on import.
+
+## Design Principles
+
+### Git sync clean
+
+Every artifact pyfabric produces must be valid for Fabric git sync import
+with zero modifications. If Fabric can't import it cleanly, it's a bug.
+
+### Human-first, AI-augmented
+
+pyfabric provides command-line capabilities — Python scripts a human can
+run within PowerShell — to interact with Fabric: query data via SQL
+endpoints or directly, manage Fabric items with a light wrapper around
+Fabric REST APIs. A human can run these tools and see results without
+burning AI tokens. AI can run them equally well when the human desires.
+
+Humans and AI working hand-in-hand, as efficiently and cost-effectively
+as possible.
+
+### Structured logging for dual audiences
+
+A human can find the root cause of a failure quickly from the structured
+logs. A human can also hand those same logs to an AI to evaluate and
+suggest fixes. The logging system (structlog with JSON output and console
+rendering) serves both audiences by design.
+
+### LLM-flexible data analysis
+
+Deep data analysis — for example, comparing two tables and figuring out
+what's the same and different about the data states — powered by the
+user's choice of LLM: online (Claude, Copilot) or local-only (Ollama)
+depending on data sensitivity and cost preference. Not locked to any
+single AI provider.
+
+## Evaluating features
+
+Every feature should be evaluated against these principles:
+
+- If it requires the Fabric UI to fix something on import, it's not done.
+- If it can only be used by AI and not a human at a terminal, it's not done.
+- If it forces a specific LLM provider, it's not done.


### PR DESCRIPTION
## Summary
- Add `docs/vision.md` — project mission and design principles (git-sync-clean artifacts, human+AI collaboration, LLM-flexible data analysis)
- Add `docs/roadmap.md` — 4-phase implementation plan with current status
- Fix `sync_all_entities` signature in `docs/api.md` to include `entity_ids` and `table_map` keyword args from PR #11

## Test plan
- [ ] Verify markdown renders correctly on GitHub
- [ ] Confirm api.md signature matches actual code

🤖 Generated with [Claude Code](https://claude.com/claude-code)