### PR TITLE
Fix publish workflow SBOM permissions

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,13 +4,12 @@ on:
   release:
     types: [published]
 
-permissions:
-  contents: read
-
 jobs:
   build:
     name: Build distribution
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v6
         with:


### PR DESCRIPTION
## Summary
- Move permissions from workflow level to job level in publish.yml
- Build job gets `contents: write` (needed by anchore/sbom-action to upload SBOM as release asset)
- Publish job keeps minimal `id-token: write`, `attestations: write`, `contents: read`

Fixes v0.1.0a1 publish failure: `Resource not accessible by integration`

## Test plan
- [ ] Re-run release after merge to verify SBOM uploads successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)