### PR TITLE
Fix author email in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ readme = "README.md"
 license = "MIT"
 requires-python = ">=3.12"
 authors = [
-    { name = "Creative Planning", email = "engineering@creativeplanning.com" },
+    { name = "Creative Planning", email = "20804442+hughdecatte@users.noreply.github.com" },
 ]
 classifiers = [
     "Development Status :: 3 - Alpha",


### PR DESCRIPTION
## Summary
- Replace bogus `engineering@creativeplanning.com` with GitHub noreply address
- Prevents publishing a package with an email that may belong to someone else

## Test plan
- [ ] Verify next release shows correct email on PyPI

🤖 Generated with [Claude Code](https://claude.com/claude-code)