### PR TITLE
Add supply chain security docs and vision/roadmap links to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,8 @@ def test_my_notebook(fabric_spark, mock_notebookutils):
 
 | Document | Description |
 |----------|-------------|
+| [Vision](docs/vision.md) | Project mission and design principles |
+| [Roadmap](docs/roadmap.md) | Implementation phases and current status |
 | [API Reference](docs/api.md) | All sub-packages and their public functions |
 | [Testing Guide](docs/testing.md) | Local testing with DuckDB Spark mock and pytest fixtures |
 | [AI Prompts](docs/prompts.md) | Sample prompts for Claude and Copilot to create Fabric items |
@@ -87,6 +89,34 @@ def test_my_notebook(fabric_spark, mock_notebookutils):
 | `pyfabric.data` | OneLake, SQL endpoint, and lakehouse table operations | `pyfabric[data]` |
 | `pyfabric.workspace` | Workspace management (list, create, roles) | `pyfabric[azure]` |
 | `pyfabric.testing` | DuckDB Spark mock, notebookutils mock, pytest fixtures | `pyfabric[testing]` |
+
+## Supply Chain Security
+
+Every release of pyfabric includes supply chain security attestations:
+
+- **SLSA Build Provenance** — each release is built in GitHub Actions and
+  attested with [SLSA provenance](https://slsa.dev/), verifiable with
+  `gh attestation verify`
+- **SBOM (SPDX)** — a Software Bill of Materials in SPDX JSON format is
+  generated for every release and attached as a release asset
+- **PyPI Trusted Publisher** — packages are published to PyPI via
+  [OpenID Connect](https://docs.pypi.org/trusted-publishers/) with no
+  long-lived credentials
+- **Dependency Review** — every PR is scanned for known vulnerabilities
+  via `pip-audit` and GitHub's dependency review action
+
+### Verifying a release
+
+```bash
+# Verify SLSA provenance of a downloaded package
+gh attestation verify pyfabric-*.whl --repo Creative-Planning/pyfabric
+
+# Download the SBOM for a specific release
+gh release download v0.1.0a2 --repo Creative-Planning/pyfabric --pattern "*.spdx.json"
+```
+
+The SBOM for each release is available at:
+`https://github.com/Creative-Planning/pyfabric/releases/download/<tag>/pyfabric-build.spdx.json`
 
 ## Requirements
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -166,7 +166,7 @@ Item type definitions and `.platform` file parsing.
 
 | Function / Class | Description |
 |-----------------|-------------|
-| `ITEM_TYPES` | Dict mapping type names to `ItemType` definitions. Registered types: Notebook, Lakehouse, Dataflow, Environment, VariableLibrary, SemanticModel, Report, Pipeline, Warehouse, Map. |
+| `ITEM_TYPES` | Dict mapping type names to `ItemType` definitions. Registered types: Notebook, Lakehouse, Dataflow, Environment, VariableLibrary, SemanticModel, Report, Pipeline, Warehouse. |
 | `ItemType` | Dataclass with `type_name`, `required_files`, `optional_files`. |
 | `parse_platform(content)` | Parse a `.platform` JSON file. Returns `PlatformFile` with metadata and config. |
 | `PlatformFile` | Parsed `.platform` with `metadata.type`, `metadata.display_name`, `config.logical_id`. |

--- a/docs/prompts.md
+++ b/docs/prompts.md
@@ -14,47 +14,35 @@ Create a Fabric notebook called nb_load_customers that:
 3. Writes the result to lh_silver.dbo.customers as a Delta table
 4. Uses the pyfabric Fabric notebook format with METADATA, CELL, and MARKDOWN sections
 5. Save it in git-sync format at ws_dev/nb_load_customers.Notebook/
-
-The notebook-content.py should use the standard Fabric format with
-# METADATA, # CELL, and # MARKDOWN section markers.
 ```
 
 ### Lakehouse
 
 ```
-Create a Fabric lakehouse definition called lh_silver in git-sync format.
+Using pyfabric, create a Fabric lakehouse definition called lh_silver in git-sync format.
 It should have:
 - defaultSchema set to "dbo"
 - No shortcuts
 - Standard ALM settings
 
-Save at ws_dev/lh_silver.Lakehouse/ with .platform, lakehouse.metadata.json,
-and alm.settings.json files.
-
-Use pyfabric.items.bundle.ArtifactBundle and save_to_disk() to generate the files.
+Save at ws_dev/lh_silver.Lakehouse
 ```
 
 ### Environment
 
 ```
-Create a Fabric environment definition called env_data_processing.
+Using pyfabric, create a Fabric environment definition called env_data_processing.
 It should:
 - Include pip dependencies: pandas>=2.0, pyarrow>=14.0, deltalake>=0.17
-- Set Spark runtime version to 1.3
-- Enable dynamic executor allocation (1 to 9 executors)
-- Driver: 8 cores, 56g memory
-- Executor: 8 cores, 56g memory
 
 Save in git-sync format at ws_dev/env_data_processing.Environment/
-with the correct nested directory structure:
-  Libraries/PublicLibraries/environment.yml
-  Setting/Sparkcompute.yml
+with the correct nested directory structure
 ```
 
 ### Variable Library
 
 ```
-Create a Fabric variable library called vl_config with:
+Using pyfabric, create a Fabric variable library called vl_config with:
 - Variables: workspace_id (String), lakehouse_id (String), env_name (String)
 - Default values for a dev environment
 - Two value sets: UAT and PROD with appropriate overrides
@@ -69,12 +57,8 @@ not suffixed names (StringVariable, etc.).
 ### Dataflow
 
 ```
-Create a Fabric dataflow definition called df_load_source_data.
-It needs:
-- A .platform file with type "Dataflow"
-- A queryMetadata.json with formatVersion "202502"
-- A placeholder mashup.pq file
-
+Using pyfabric, create a Fabric dataflow definition called df_load_source_data that
+[TODO]
 Save in git-sync format at ws_dev/df_load_source_data.Dataflow/
 ```
 
@@ -82,25 +66,14 @@ Save in git-sync format at ws_dev/df_load_source_data.Dataflow/
 
 ```
 Create a Fabric semantic model definition called sm_sales_analytics.
-It needs:
-- A .platform file with type "SemanticModel"
-- A model.bim file with a basic tabular model containing one table (Sales)
-  with columns: SaleId (Int64), Amount (Decimal), SaleDate (DateTime)
-
+[TODO]
 Save in git-sync format at ws_dev/sm_sales_analytics.SemanticModel/
 ```
 
 ### Pipeline
 
 ```
-Create a Fabric pipeline definition called pl_daily_refresh.
-It needs:
-- A .platform file with type "Pipeline"
-- A pipeline-content.json with a simple pipeline that has two activities:
-  1. A notebook activity that runs nb_load_customers
-  2. A notebook activity that runs nb_transform_data
-
-Save in git-sync format at ws_dev/pl_daily_refresh.Pipeline/
+Using pyfabric, create a Fabric pipeline definition called pl_daily_refresh. It has two activities, first running nb_load_customers then when that completes successfully, runs nb_transform data.
 ```
 
 ## Validating items
@@ -108,21 +81,14 @@ Save in git-sync format at ws_dev/pl_daily_refresh.Pipeline/
 ### Validate a single item
 
 ```
-Use pyfabric to validate the Fabric item at ws_dev/nb_load_customers.Notebook/.
-Check that:
-- The .platform file has valid JSON with type, displayName, and logicalId
-- All required files for a Notebook are present
-- The directory name matches the displayName in .platform
-
-Use pyfabric.items.validate.validate_item() and print any errors.
+Use pyfabric to validate the nb_load_customers notebook
 ```
 
 ### Validate an entire workspace
 
 ```
-Use pyfabric to validate all Fabric items in the workspace at ws_dev/.
+Use pyfabric to validate all Fabric items in the workspace at ws_dev
 Print a summary showing which items pass and which fail.
-Use pyfabric.items.validate.validate_workspace().
 ```
 
 ## Writing and running local tests

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -22,24 +22,19 @@ testing, documentation, and refactored for maintainability.
 
 ## Phase 2: Fabric Item Authoring Depth
 
-Expand supported Fabric item types beyond basic validation to full
-programmatic authoring. The current `ITEM_TYPES` registry has basic
-definitions for: Notebook, Lakehouse, Dataflow, Environment,
-VariableLibrary, SemanticModel, Report, Pipeline, Warehouse, Map.
-
-This phase adds deep authoring support:
+Expand supported Fabric item types:
 
 - **Semantic Models** — full tabular model authoring (model.bim with
   tables, columns, measures, relationships)
 - **Reports** (Power BI) — report definition authoring tied to semantic
   models
-- **Ontologies** — extend OntologyBuilder for full git-sync authoring
 - **Dataflow Gen2** — mashup/Power Query authoring support
 - **Pipelines** — activity graph authoring (notebook activities, copy
   activities, orchestration)
 - **Data Agents** — programmatic data agent definitions
-- **Lakehouses** — add new tables with schemas (not just the lakehouse
+- **Lakehouses** — add new tables with schemas and data (not just the lakehouse
   shell)
+- Integration with Workspace Identity and Azure Key Vault for secure ETL/ELT
 
 ## Phase 3: Event-Driven Automation
 
@@ -47,16 +42,16 @@ This phase adds deep authoring support:
   for activity (file uploaded, file changed) and automatically trigger a
   pipeline or notebook
 - Wire up event-driven patterns for CI/CD and data pipeline automation
+- Integration with Power Automate flows
 
 ## Phase 4: LLM-Powered Data Analysis
 
-Local or online, PHI-compliant data quality analysis:
+Local or online data quality analysis:
 
 - Pull production data from Fabric locally
 - Mask/scramble production data for safe local testing with near-real data
 - Run notebook/pipeline transformations locally against DuckDB
-- Integrate Ollama + user's choice of local LLM model for deep data QA
+- Integrate Ollama + user's choice of local LLM model for deep data QA on sensitive data
 - Compare tables and analyze data state differences using LLM of choice
   (online or local, depending on sensitivity and cost)
-- Anomaly detection, data quality analysis, all on-box when needed
-- Placeholder exists in `pyfabric.testing.analyze` module
+- Anomaly detection, data quality analysis, all on-box when needed so sensitive data doesn't go off-box


### PR DESCRIPTION
## Summary
- Add Supply Chain Security section documenting SLSA provenance, SBOM (SPDX), PyPI trusted publisher (OIDC), and dependency review
- Include verification commands (`gh attestation verify`, `gh release download`)
- Document predictable SBOM download URL for each release
- Add Vision and Roadmap links to documentation table

## Test plan
- [ ] Verify markdown renders correctly on GitHub
- [ ] Verify SBOM URL pattern works with existing release

🤖 Generated with [Claude Code](https://claude.com/claude-code)