### PR TITLE
Add get_token() convenience function to auth module

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -16,9 +16,10 @@ Authentication and credential management for Microsoft Fabric.
 | `FabricCredential.storage_token` | Token for OneLake DFS (storage.azure.com). |
 | `FabricCredential.sql_token` | Token for SQL analytics endpoints. |
 | `AuthError` | Raised when authentication fails. |
+| `get_token(resource=FABRIC_RESOURCE)` | Get a token using the default credential chain. Convenience free function for scripts. |
 | `get_current_account()` | Return the current `az account show` output as a dict. |
 | `az_login(tenant=None)` | Launch interactive browser login. |
-| `ensure_logged_in(resource, tenant)` | Get a token, triggering login if needed. Creates a fresh credential each call (no global state). |
+| `ensure_logged_in(resource, tenant)` | Get a token, triggering login if needed. Resets the default credential after re-login. |
 
 **Example:**
 

--- a/src/pyfabric/client/auth.py
+++ b/src/pyfabric/client/auth.py
@@ -224,6 +224,24 @@ class FabricCredential:
 
 # ── Free functions ────────────────────────────────────────────────────────────
 
+_default_credential: FabricCredential | None = None
+
+
+def _get_default() -> FabricCredential:
+    global _default_credential
+    if _default_credential is None:
+        _default_credential = FabricCredential()
+    return _default_credential
+
+
+def get_token(resource: str = FABRIC_RESOURCE) -> str:
+    """Get a token using the default credential chain.
+
+    Uses a module-level credential instance (created on first call).
+    For scripts that need a quick one-liner without managing a credential object.
+    """
+    return _get_default().get_token(resource)
+
 
 def get_current_account() -> dict:
     """Return the current az account show output as a dict, or {} if not logged in."""
@@ -263,12 +281,13 @@ def az_login(tenant: str | None = None) -> dict:
 def ensure_logged_in(resource: str = FABRIC_RESOURCE, tenant: str | None = None) -> str:
     """Get a token, triggering interactive login if needed.
 
-    Creates a fresh FabricCredential for each call (no global state).
+    Resets the default credential after re-login so subsequent
+    get_token() calls use the new session.
     """
-    cred = FabricCredential(tenant=tenant)
     try:
-        return cred.get_token(resource)
+        return get_token(resource)
     except AuthError:
         az_login(tenant)
-        cred = FabricCredential(tenant=tenant)
-        return cred.get_token(resource)
+        global _default_credential
+        _default_credential = None  # reset after re-login
+        return get_token(resource)


### PR DESCRIPTION
## Summary
- Adds `get_token()` free function with a lazily-created module-level `FabricCredential` singleton for scripts that need a quick one-liner
- Updates `ensure_logged_in()` to use `get_token()` and reset the default credential after re-login
- Documents the new function in `docs/api.md`

## Motivation
mgc's `fabric_utils` wrapper layer relies on a `get_token()` free function pattern. Rather than shimming this in the consumer, we're adding it to pyfabric so all downstream projects benefit.

## Test plan
- [x] All 290 existing pyfabric tests pass
- [x] `ruff check` and `ruff format --check` pass
- [ ] Verify `get_token()` returns a valid token in a live environment

🤖 Generated with [Claude Code](https://claude.com/claude-code)