### PR TITLE
Add LocalLakehouse: DuckDB-backed local mirror with OneLake push/pull

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,30 @@
+# See https://pre-commit.com for more information
+# Run `pre-commit install` once after cloning to enable hooks.
+repos:
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.15.10
+    hooks:
+      - id: ruff
+        args: [--fix, --exit-non-zero-on-fix]
+      - id: ruff-format
+
+  - repo: https://github.com/pre-commit/mirrors-mypy
+    rev: v1.20.0
+    hooks:
+      - id: mypy
+        args: [--config-file=pyproject.toml]
+        additional_dependencies:
+          - structlog>=24.0
+          - pytest>=8.0
+        pass_filenames: false
+        entry: mypy src/
+
+  - repo: local
+    hooks:
+      - id: pytest
+        name: pytest
+        entry: python -m pytest --no-header -q
+        language: system
+        pass_filenames: false
+        always_run: true
+        stages: [pre-push]

--- a/src/pyfabric/data/__init__.py
+++ b/src/pyfabric/data/__init__.py
@@ -1,1 +1,3 @@
 """Data access for OneLake, SQL endpoints, and lakehouse tables."""
+
+from pyfabric.data.local_lakehouse import LocalLakehouse  # noqa: F401

--- a/src/pyfabric/data/local_lakehouse.py
+++ b/src/pyfabric/data/local_lakehouse.py
@@ -1,0 +1,321 @@
+"""
+Local DuckDB-backed lakehouse for development and batch processing.
+
+Provides a local staging area that mirrors a Fabric lakehouse schema.
+Process data locally (no Spark session), validate in DuckDB, then push
+Delta tables to OneLake in bulk.
+
+Usage:
+    from pyfabric.client.auth import FabricCredential
+    from pyfabric.data.local_lakehouse import LocalLakehouse
+
+    cred = FabricCredential()
+    local = LocalLakehouse(
+        db_path="my_extract.duckdb",
+        ws_id="9b0973...",
+        lh_id="01a9eea7...",
+        schema="ddb",
+    )
+
+    # Create tables from DDL strings
+    local.execute_ddl([
+        "CREATE TABLE IF NOT EXISTS ddb.products (id VARCHAR, name VARCHAR)",
+    ])
+
+    # Insert rows
+    local.insert("products", [{"id": "1", "name": "Widget"}])
+
+    # Query locally
+    df = local.query_df("SELECT * FROM ddb.products")
+
+    # Push all non-empty tables to OneLake as Delta
+    local.push_all(cred)
+
+    # Push a single table
+    local.push_table(cred, "products")
+
+    # Pull a table from OneLake into local DuckDB
+    local.pull_table(cred, "products")
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import structlog
+
+if TYPE_CHECKING:
+    import duckdb as duckdb_mod
+    import pandas as pd
+    import pyarrow as pa
+
+    from pyfabric.client.auth import FabricCredential
+
+log = structlog.get_logger()
+
+
+class LocalLakehouse:
+    """DuckDB-backed local mirror of a Fabric lakehouse.
+
+    Args:
+        db_path:    Path to DuckDB file (created if missing).
+        ws_id:      Fabric workspace ID.
+        lh_id:      Fabric lakehouse ID.
+        schema:     DuckDB schema name — also used as the OneLake table path
+                    prefix: ``Tables/{schema}/{table_name}/``.
+        read_only:  Open DuckDB in read-only mode.
+    """
+
+    def __init__(
+        self,
+        db_path: str | Path,
+        ws_id: str,
+        lh_id: str,
+        schema: str = "ddb",
+        *,
+        read_only: bool = False,
+    ):
+        import duckdb as duckdb_mod
+
+        self.db_path = Path(db_path)
+        self.ws_id = ws_id
+        self.lh_id = lh_id
+        self.schema = schema
+        self._conn = duckdb_mod.connect(str(self.db_path), read_only=read_only)
+        self._conn.execute(f"CREATE SCHEMA IF NOT EXISTS {schema}")
+        log.info("LocalLakehouse opened", db=str(self.db_path), schema=schema)
+
+    @property
+    def conn(self) -> "duckdb_mod.DuckDBPyConnection":
+        """Raw DuckDB connection for advanced queries."""
+        return self._conn
+
+    # ── Schema management ────────────────────────────────────────────────────
+
+    def execute_ddl(self, statements: list[str]) -> int:
+        """Execute a list of DDL statements (CREATE TABLE, etc.).
+
+        Returns the number of statements executed.
+        """
+        for stmt in statements:
+            self._conn.execute(stmt)
+        return len(statements)
+
+    def table_names(self) -> list[str]:
+        """List table names in the local schema."""
+        rows = self._conn.execute(
+            "SELECT table_name FROM information_schema.tables "
+            "WHERE table_schema = ?",
+            [self.schema],
+        ).fetchall()
+        return [r[0] for r in rows]
+
+    def row_count(self, table_name: str) -> int:
+        """Return row count for a table."""
+        result = self._conn.execute(
+            f"SELECT COUNT(*) FROM {self.schema}.{table_name}"
+        ).fetchone()
+        return result[0] if result else 0
+
+    def table_counts(self) -> dict[str, int]:
+        """Return {table_name: row_count} for all non-empty tables."""
+        counts = {}
+        for name in self.table_names():
+            c = self.row_count(name)
+            if c > 0:
+                counts[name] = c
+        return counts
+
+    # ── Local data operations ────────────────────────────────────────────────
+
+    def insert(self, table_name: str, rows: list[dict]) -> int:
+        """Insert rows into a local DuckDB table.
+
+        Args:
+            table_name: Table name (without schema prefix).
+            rows:       List of row dicts. Keys must match column names.
+
+        Returns:
+            Number of rows inserted.
+        """
+        if not rows:
+            return 0
+
+        # Get column names from the table schema
+        cols_info = self._conn.execute(
+            "SELECT column_name FROM information_schema.columns "
+            "WHERE table_schema = ? AND table_name = ? ORDER BY ordinal_position",
+            [self.schema, table_name],
+        ).fetchall()
+        col_names = [c[0] for c in cols_info]
+
+        if not col_names:
+            raise ValueError(
+                f"Table {self.schema}.{table_name} not found or has no columns"
+            )
+
+        placeholders = ", ".join(["?"] * len(col_names))
+        cols_sql = ", ".join(col_names)
+        sql = f"INSERT INTO {self.schema}.{table_name} ({cols_sql}) VALUES ({placeholders})"
+
+        values = []
+        for row in rows:
+            vals = []
+            for cn in col_names:
+                val = row.get(cn)
+                # Convert datetime/date objects to strings for DuckDB VARCHAR columns
+                if val is not None and hasattr(val, "isoformat"):
+                    val = val.isoformat() if hasattr(val, "hour") else str(val)
+                vals.append(val)
+            values.append(tuple(vals))
+
+        self._conn.executemany(sql, values)
+        return len(values)
+
+    def query_df(self, sql: str) -> "pd.DataFrame":
+        """Execute SQL and return a pandas DataFrame."""
+        return self._conn.execute(sql).fetchdf()
+
+    def query_arrow(self, sql: str) -> "pa.Table":
+        """Execute SQL and return a PyArrow Table."""
+        return self._conn.execute(sql).arrow()
+
+    def commit(self) -> None:
+        """Commit the current transaction."""
+        self._conn.commit()
+
+    # ── OneLake push ─────────────────────────────────────────────────────────
+
+    def push_table(
+        self,
+        credential: "FabricCredential",
+        table_name: str,
+        *,
+        mode: str = "overwrite",
+    ) -> int:
+        """Push a single DuckDB table to OneLake as a Delta table.
+
+        Writes to ``Tables/{schema}/{table_name}/`` in the lakehouse.
+
+        Args:
+            credential: FabricCredential for storage token.
+            table_name: Table name (without schema prefix).
+            mode:       "overwrite" or "append".
+
+        Returns:
+            Number of rows written.
+        """
+        from pyfabric.data.lakehouse import write_table
+
+        # .arrow() returns RecordBatchReader; .read_all() materializes to Table
+        reader = self._conn.execute(
+            f"SELECT * FROM {self.schema}.{table_name}"
+        ).arrow()
+        arrow_table = reader.read_all() if hasattr(reader, "read_all") else reader
+
+        if arrow_table.num_rows == 0:
+            log.info("Skipping empty table: %s", table_name)
+            return 0
+
+        result = write_table(
+            credential,
+            self.ws_id,
+            self.lh_id,
+            table_name,
+            arrow_table,
+            schema=self.schema,
+            mode=mode,
+            source="LocalLakehouse.push_table",
+        )
+        return result.row_count
+
+    def push_all(
+        self,
+        credential: "FabricCredential",
+        *,
+        mode: str = "overwrite",
+        tables: list[str] | None = None,
+    ) -> dict[str, int]:
+        """Push all non-empty tables (or a subset) to OneLake.
+
+        Args:
+            credential: FabricCredential for storage token.
+            mode:       "overwrite" or "append".
+            tables:     Optional list of table names to push. If None, pushes all.
+
+        Returns:
+            Dict of {table_name: rows_written} for tables that were pushed.
+        """
+        target_tables = tables or self.table_names()
+        results = {}
+
+        for name in target_tables:
+            count = self.row_count(name)
+            if count == 0:
+                continue
+            log.info("Pushing %s (%d rows)", name, count)
+            try:
+                written = self.push_table(credential, name, mode=mode)
+                results[name] = written
+            except Exception as e:
+                log.error("Failed to push %s: %s", name, e)
+                results[name] = -1  # signal failure
+
+        total = sum(v for v in results.values() if v > 0)
+        log.info(
+            "Push complete: %d rows across %d tables",
+            total,
+            sum(1 for v in results.values() if v > 0),
+        )
+        return results
+
+    # ── OneLake pull ─────────────────────────────────────────────────────────
+
+    def pull_table(
+        self,
+        credential: "FabricCredential",
+        table_name: str,
+        *,
+        replace: bool = True,
+    ) -> int:
+        """Pull a Delta table from OneLake into local DuckDB.
+
+        Args:
+            credential: FabricCredential for storage token.
+            table_name: Table name (without schema prefix).
+            replace:    If True, DROP and recreate local table from remote data.
+                        If False, append to existing local data.
+
+        Returns:
+            Number of rows pulled.
+        """
+        from pyfabric.data.lakehouse import read_table
+
+        df = read_table(
+            credential, self.ws_id, self.lh_id, table_name, schema=self.schema
+        )
+
+        if replace:
+            self._conn.execute(f"DROP TABLE IF EXISTS {self.schema}.{table_name}")
+            self._conn.execute(
+                f"CREATE TABLE {self.schema}.{table_name} AS SELECT * FROM df"
+            )
+        else:
+            self._conn.execute(
+                f"INSERT INTO {self.schema}.{table_name} SELECT * FROM df"
+            )
+
+        return len(df)
+
+    # ── Lifecycle ────────────────────────────────────────────────────────────
+
+    def close(self) -> None:
+        """Close the DuckDB connection."""
+        self._conn.close()
+
+    def __enter__(self) -> "LocalLakehouse":
+        return self
+
+    def __exit__(self, *args) -> None:
+        self.close()

--- a/src/pyfabric/data/local_lakehouse.py
+++ b/src/pyfabric/data/local_lakehouse.py
@@ -87,7 +87,7 @@ class LocalLakehouse:
         log.info("LocalLakehouse opened", db=str(self.db_path), schema=schema)
 
     @property
-    def conn(self) -> "duckdb_mod.DuckDBPyConnection":
+    def conn(self) -> duckdb_mod.DuckDBPyConnection:
         """Raw DuckDB connection for advanced queries."""
         return self._conn
 
@@ -105,8 +105,7 @@ class LocalLakehouse:
     def table_names(self) -> list[str]:
         """List table names in the local schema."""
         rows = self._conn.execute(
-            "SELECT table_name FROM information_schema.tables "
-            "WHERE table_schema = ?",
+            "SELECT table_name FROM information_schema.tables WHERE table_schema = ?",
             [self.schema],
         ).fetchall()
         return [r[0] for r in rows]
@@ -173,11 +172,11 @@ class LocalLakehouse:
         self._conn.executemany(sql, values)
         return len(values)
 
-    def query_df(self, sql: str) -> "pd.DataFrame":
+    def query_df(self, sql: str) -> pd.DataFrame:
         """Execute SQL and return a pandas DataFrame."""
         return self._conn.execute(sql).fetchdf()
 
-    def query_arrow(self, sql: str) -> "pa.Table":
+    def query_arrow(self, sql: str) -> pa.Table:
         """Execute SQL and return a PyArrow Table."""
         return self._conn.execute(sql).arrow()
 
@@ -189,7 +188,7 @@ class LocalLakehouse:
 
     def push_table(
         self,
-        credential: "FabricCredential",
+        credential: FabricCredential,
         table_name: str,
         *,
         mode: str = "overwrite",
@@ -209,9 +208,7 @@ class LocalLakehouse:
         from pyfabric.data.lakehouse import write_table
 
         # .arrow() returns RecordBatchReader; .read_all() materializes to Table
-        reader = self._conn.execute(
-            f"SELECT * FROM {self.schema}.{table_name}"
-        ).arrow()
+        reader = self._conn.execute(f"SELECT * FROM {self.schema}.{table_name}").arrow()
         arrow_table = reader.read_all() if hasattr(reader, "read_all") else reader
 
         if arrow_table.num_rows == 0:
@@ -232,7 +229,7 @@ class LocalLakehouse:
 
     def push_all(
         self,
-        credential: "FabricCredential",
+        credential: FabricCredential,
         *,
         mode: str = "overwrite",
         tables: list[str] | None = None,
@@ -274,7 +271,7 @@ class LocalLakehouse:
 
     def pull_table(
         self,
-        credential: "FabricCredential",
+        credential: FabricCredential,
         table_name: str,
         *,
         replace: bool = True,
@@ -314,7 +311,7 @@ class LocalLakehouse:
         """Close the DuckDB connection."""
         self._conn.close()
 
-    def __enter__(self) -> "LocalLakehouse":
+    def __enter__(self) -> LocalLakehouse:
         return self
 
     def __exit__(self, *args) -> None:


### PR DESCRIPTION
## Summary
- Adds `pyfabric.data.LocalLakehouse` class: DuckDB-backed local staging area that mirrors a Fabric lakehouse schema
- Supports local data operations (DDL, insert, query) then push/pull Delta tables to/from OneLake
- Enables local PDF extraction and validation without burning Fabric Spark capacity

## Test plan
- [ ] Unit tests for LocalLakehouse (DuckDB operations, push/pull mocking)
- [ ] Integration test: push a small table to OneLake, verify via SQL endpoint
- [ ] Verify import from `pyfabric.data.LocalLakehouse` works

🤖 Generated with [Claude Code](https://claude.com/claude-code)