### PR TITLE
Document pre-commit hooks and dev setup prerequisites

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,6 +10,12 @@ the [MIT License](LICENSE).
 
 ## For Creative Planning Team Members
 
+### Prerequisites
+
+- **Python 3.12+** — required by the project and CI
+- **Git** — for cloning and the pre-commit hook system
+- **pre-commit** — installed automatically with `pip install -e ".[dev]"`, or standalone via `pip install pre-commit`
+
 ### Development Setup
 
 ```bash
@@ -18,9 +24,29 @@ cd pyfabric
 python -m venv .venv
 source .venv/bin/activate  # or .venv\Scripts\activate on Windows
 pip install -e ".[dev]"
+
+# Install git hooks (required — CI will reject what these hooks catch)
+pre-commit install
+pre-commit install --hook-type pre-push
 ```
 
-### Running Checks Locally
+The pre-commit hooks run automatically:
+
+| Hook | Runs on | What it does |
+|------|---------|--------------|
+| `ruff check` | `git commit` | Lint with auto-fix |
+| `ruff format` | `git commit` | Format check |
+| `mypy` | `git commit` | Type checking |
+| `pytest` | `git push` | Full test suite |
+
+To run all hooks manually against the full repo:
+
+```bash
+pre-commit run --all-files       # commit-stage hooks
+pre-commit run --all-files --hook-stage pre-push  # push-stage hooks
+```
+
+### Running Checks Individually
 
 ```bash
 ruff check .               # Lint

--- a/README.md
+++ b/README.md
@@ -122,6 +122,19 @@ The SBOM for each release is available at:
 
 - Python 3.12 or later
 
+### Developer setup
+
+After cloning, install dev dependencies and git hooks so that lint, format,
+type check, and tests run automatically before commit/push:
+
+```bash
+pip install -e ".[dev]"
+pre-commit install
+pre-commit install --hook-type pre-push
+```
+
+See [CONTRIBUTING.md](CONTRIBUTING.md) for full details.
+
 ## Contributing
 
 This project is maintained by [Creative Planning](https://www.creativeplanning.com).


### PR DESCRIPTION
## Summary
- Add prerequisites section to CONTRIBUTING.md (Python 3.12+, Git, pre-commit)
- Document pre-commit hook install steps and what each hook does (ruff on commit, pytest on push)
- Add developer setup section to README pointing to CONTRIBUTING.md

## Test plan
- [ ] Verify markdown renders correctly on GitHub
- [ ] Confirm `pre-commit install` instructions match `.pre-commit-config.yaml` from #19

🤖 Generated with [Claude Code](https://claude.com/claude-code)