### PR TITLE
Add pyfabric.data.schema: Col/TableDef + typed insert

### DIFF
--- a/src/pyfabric/data/__init__.py
+++ b/src/pyfabric/data/__init__.py
@@ -1,3 +1,4 @@
 """Data access for OneLake, SQL endpoints, and lakehouse tables."""
 
 from pyfabric.data.local_lakehouse import LocalLakehouse  # noqa: F401
+from pyfabric.data.schema import Col, TableDef  # noqa: F401

--- a/src/pyfabric/data/local_lakehouse.py
+++ b/src/pyfabric/data/local_lakehouse.py
@@ -45,6 +45,8 @@ from typing import TYPE_CHECKING
 
 import structlog
 
+from pyfabric.data.schema import TableDef
+
 if TYPE_CHECKING:
     import duckdb as duckdb_mod
     import pandas as pd
@@ -84,6 +86,7 @@ class LocalLakehouse:
         self.schema = schema
         self._conn = duckdb_mod.connect(str(self.db_path), read_only=read_only)
         self._conn.execute(f"CREATE SCHEMA IF NOT EXISTS {schema}")
+        self._tables: dict[str, TableDef] = {}
         log.info("LocalLakehouse opened", db=str(self.db_path), schema=schema)
 
     @property
@@ -101,6 +104,27 @@ class LocalLakehouse:
         for stmt in statements:
             self._conn.execute(stmt)
         return len(statements)
+
+    def register(self, tables: TableDef | tuple[TableDef, ...] | list[TableDef]) -> int:
+        """Register one or more TableDefs and create the DuckDB tables.
+
+        Registered tables are used by ``insert_typed`` to validate rows
+        before insert. Existing tables are not dropped — DDL uses
+        ``CREATE TABLE IF NOT EXISTS``.
+
+        Returns the number of tables registered.
+        """
+        if isinstance(tables, TableDef):
+            tables = (tables,)
+
+        for table in tables:
+            self._tables[table.name] = table
+            self._conn.execute(table.to_duckdb_ddl(self.schema))
+        return len(tables)
+
+    def registered_tables(self) -> dict[str, TableDef]:
+        """Return a copy of the registered TableDef map."""
+        return dict(self._tables)
 
     def table_names(self) -> list[str]:
         """List table names in the local schema."""
@@ -169,6 +193,68 @@ class LocalLakehouse:
                 vals.append(val)
             values.append(tuple(vals))
 
+        self._conn.executemany(sql, values)
+        return len(values)
+
+    def insert_typed(self, table_name: str, rows: list[dict]) -> int:
+        """Insert rows with strict type validation against a registered TableDef.
+
+        Unlike :meth:`insert`, this method:
+          - Requires the table to have been registered via :meth:`register`.
+          - Validates every row against the TableDef, raising ``ValueError``
+            if any row has a missing non-nullable column, a type mismatch,
+            or an empty string on a non-string column.
+          - Passes date/datetime values through as native objects rather
+            than silently stringifying them.
+
+        Args:
+            table_name: Table name (without schema prefix). Must be registered.
+            rows:       List of row dicts. Keys should match column names.
+
+        Returns:
+            Number of rows inserted.
+
+        Raises:
+            KeyError:   If the table has not been registered.
+            ValueError: If any row fails validation. The message lists each
+                        invalid row's index together with all of its errors.
+        """
+        if not rows:
+            return 0
+
+        if table_name not in self._tables:
+            raise KeyError(
+                f"Table {table_name!r} is not registered. "
+                "Call register() with the TableDef first, "
+                "or use insert() for untyped inserts."
+            )
+
+        table = self._tables[table_name]
+        col_names = table.column_names()
+
+        errors: list[str] = []
+        for idx, row in enumerate(rows):
+            unknown = set(row) - set(col_names)
+            if unknown:
+                errors.append(f"row[{idx}]: unknown columns {sorted(unknown)}")
+            for msg in table.validate_row(row):
+                errors.append(f"row[{idx}]: {msg}")
+
+        if errors:
+            joined = "\n  ".join(errors)
+            raise ValueError(
+                f"insert_typed rejected {len(rows)} row(s) into "
+                f"{self.schema}.{table_name}:\n  {joined}"
+            )
+
+        placeholders = ", ".join(["?"] * len(col_names))
+        cols_sql = ", ".join(col_names)
+        sql = (
+            f"INSERT INTO {self.schema}.{table_name} "
+            f"({cols_sql}) VALUES ({placeholders})"
+        )
+
+        values = [tuple(row.get(cn) for cn in col_names) for row in rows]
         self._conn.executemany(sql, values)
         return len(values)
 

--- a/src/pyfabric/data/schema.py
+++ b/src/pyfabric/data/schema.py
@@ -1,0 +1,217 @@
+"""Schema-as-code for lakehouse tables.
+
+Define column and table schemas once; generate Spark DDL, DuckDB DDL, and
+PyArrow schemas from the same definitions. Used by consumers that need to
+mirror a Fabric lakehouse locally in DuckDB, validate rows before insert,
+and push Delta tables back to OneLake.
+
+Example:
+
+    from pyfabric.data.schema import Col, TableDef
+
+    PRODUCTS = TableDef(
+        name="products",
+        description="Product catalog",
+        columns=(
+            Col("product_id", "int", nullable=False, pk=True),
+            Col("name", "string", nullable=False),
+            Col("price", "double"),
+            Col("is_active", "boolean"),
+        ),
+    )
+
+    spark_ddl = PRODUCTS.to_spark_ddl(schema="dbo")
+    duck_ddl = PRODUCTS.to_duckdb_ddl(schema="ddb")
+    arrow_schema = PRODUCTS.to_arrow_schema()
+"""
+
+import datetime as _dt
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    import pyarrow as pa
+
+
+# Internal type keys are the single source of truth. Maps below translate
+# them to the vocabulary of each backend.
+
+SPARK_TYPES: dict[str, str] = {
+    "string": "STRING",
+    "int": "INT",
+    "bigint": "BIGINT",
+    "double": "DOUBLE",
+    "boolean": "BOOLEAN",
+    "date": "DATE",
+    "timestamp": "TIMESTAMP",
+}
+
+DUCKDB_TYPES: dict[str, str] = {
+    "string": "VARCHAR",
+    "int": "INTEGER",
+    "bigint": "BIGINT",
+    "double": "DOUBLE",
+    "boolean": "BOOLEAN",
+    "date": "DATE",
+    "timestamp": "TIMESTAMP",
+}
+
+# Accepted Python types per type_key for row validation. `bool` is excluded
+# from numeric types even though `isinstance(True, int)` is True — passing
+# a bool for an int column is almost always a mistake.
+PYTHON_TYPES: dict[str, tuple[type, ...]] = {
+    "string": (str,),
+    "int": (int,),
+    "bigint": (int,),
+    "double": (int, float),
+    "boolean": (bool,),
+    "date": (_dt.date,),
+    "timestamp": (_dt.datetime,),
+}
+
+
+@dataclass(frozen=True)
+class Col:
+    """A column definition.
+
+    Attributes:
+        name:      Column name.
+        type_key:  Internal type key — one of the keys in SPARK_TYPES etc.
+        nullable:  Whether the column allows NULL.
+        pk:        Primary key flag (informational — not enforced in Delta).
+    """
+
+    name: str
+    type_key: str
+    nullable: bool = True
+    pk: bool = False
+
+    def __post_init__(self) -> None:
+        if self.type_key not in SPARK_TYPES:
+            raise ValueError(
+                f"Unknown type_key {self.type_key!r} for column {self.name!r}. "
+                f"Valid keys: {sorted(SPARK_TYPES)}"
+            )
+
+
+@dataclass(frozen=True)
+class TableDef:
+    """A table definition."""
+
+    name: str
+    columns: tuple[Col, ...]
+    description: str = ""
+
+    def column_names(self) -> list[str]:
+        return [c.name for c in self.columns]
+
+    def pk_columns(self) -> list[str]:
+        return [c.name for c in self.columns if c.pk]
+
+    def column(self, name: str) -> Col:
+        for c in self.columns:
+            if c.name == name:
+                return c
+        raise KeyError(f"Column {name!r} not found in table {self.name!r}")
+
+    def to_spark_ddl(self, schema: str = "dbo") -> str:
+        """CREATE TABLE statement using Spark/Delta types."""
+        lines = []
+        for c in self.columns:
+            spark_type = SPARK_TYPES[c.type_key]
+            null = "" if c.nullable else " NOT NULL"
+            lines.append(f"  `{c.name}` {spark_type}{null}")
+        cols = ",\n".join(lines)
+        return (
+            f"CREATE TABLE IF NOT EXISTS {schema}.{self.name} (\n{cols}\n) USING DELTA"
+        )
+
+    def to_duckdb_ddl(self, schema: str | None = None) -> str:
+        """CREATE TABLE statement using DuckDB types."""
+        lines = []
+        for c in self.columns:
+            duck_type = DUCKDB_TYPES[c.type_key]
+            null = "" if c.nullable else " NOT NULL"
+            lines.append(f"  {c.name} {duck_type}{null}")
+        cols = ",\n".join(lines)
+        qualified = f"{schema}.{self.name}" if schema else self.name
+        return f"CREATE TABLE IF NOT EXISTS {qualified} (\n{cols}\n)"
+
+    def to_arrow_schema(self) -> "pa.Schema":
+        """PyArrow Schema suitable for constructing a RecordBatch/Table."""
+        import pyarrow as pa
+
+        arrow_types = {
+            "string": pa.string(),
+            "int": pa.int32(),
+            "bigint": pa.int64(),
+            "double": pa.float64(),
+            "boolean": pa.bool_(),
+            "date": pa.date32(),
+            "timestamp": pa.timestamp("us"),
+        }
+        fields = [
+            pa.field(c.name, arrow_types[c.type_key], nullable=c.nullable)
+            for c in self.columns
+        ]
+        return pa.schema(fields)
+
+    def validate_row(self, row: dict[str, Any]) -> list[str]:
+        """Return a list of validation error messages, empty if row is valid.
+
+        Enforces:
+          - Non-nullable columns present and not None.
+          - Python type matches the column's type_key (see PYTHON_TYPES).
+          - Empty strings are NOT accepted as a substitute for None on
+            non-string columns — a common source of silent data corruption.
+          - For `boolean` columns, reject values that happen to be ``int``
+            (e.g. ``0``/``1``) to match the strict semantics elsewhere.
+        """
+        errors: list[str] = []
+        for c in self.columns:
+            if c.name not in row:
+                if not c.nullable:
+                    errors.append(f"missing required column {c.name!r}")
+                continue
+
+            val = row[c.name]
+
+            if val is None:
+                if not c.nullable:
+                    errors.append(f"column {c.name!r} is NOT NULL but got None")
+                continue
+
+            if c.type_key != "string" and isinstance(val, str) and val == "":
+                errors.append(
+                    f"column {c.name!r} ({c.type_key}) got empty string; "
+                    "use None for missing values on non-string columns"
+                )
+                continue
+
+            allowed = PYTHON_TYPES[c.type_key]
+            if c.type_key in ("int", "bigint", "double") and isinstance(val, bool):
+                errors.append(
+                    f"column {c.name!r} ({c.type_key}) got bool; expected "
+                    f"{[t.__name__ for t in allowed]}"
+                )
+                continue
+
+            if not isinstance(val, allowed):
+                errors.append(
+                    f"column {c.name!r} ({c.type_key}) got "
+                    f"{type(val).__name__}; expected "
+                    f"{[t.__name__ for t in allowed]}"
+                )
+        return errors
+
+
+def all_spark_ddl(tables: tuple[TableDef, ...], schema: str = "dbo") -> list[str]:
+    """CREATE TABLE statements for a tuple of tables (Spark/Delta)."""
+    return [t.to_spark_ddl(schema) for t in tables]
+
+
+def all_duckdb_ddl(
+    tables: tuple[TableDef, ...], schema: str | None = None
+) -> list[str]:
+    """CREATE TABLE statements for a tuple of tables (DuckDB)."""
+    return [t.to_duckdb_ddl(schema) for t in tables]

--- a/tests/data/test_schema.py
+++ b/tests/data/test_schema.py
@@ -1,0 +1,337 @@
+"""Unit tests for pyfabric.data.schema and LocalLakehouse.insert_typed.
+
+The typed insert path exists to catch data-shape bugs at the DuckDB
+boundary instead of at the Spark/Delta boundary in Fabric. The most
+important regression guarded here is empty-string-for-int silently
+coercing in DuckDB but failing later when the Delta writer sees a
+mixed-type column.
+"""
+
+import datetime as dt
+
+import pytest
+
+from pyfabric.data import Col, LocalLakehouse, TableDef
+from pyfabric.data.schema import (
+    DUCKDB_TYPES,
+    SPARK_TYPES,
+    all_duckdb_ddl,
+    all_spark_ddl,
+)
+
+# ── Col / TableDef basics ───────────────────────────────────────────────────
+
+
+class TestColValidation:
+    def test_rejects_unknown_type_key(self):
+        with pytest.raises(ValueError, match="Unknown type_key 'decimal'"):
+            Col("price", "decimal")
+
+    def test_frozen_dataclass(self):
+        c = Col("id", "int")
+        with pytest.raises(Exception):  # noqa: B017 — dataclasses.FrozenInstanceError
+            c.name = "other"
+
+    def test_type_maps_are_aligned(self):
+        assert set(SPARK_TYPES) == set(DUCKDB_TYPES)
+
+
+class TestTableDefIntrospection:
+    def test_column_names_and_pks(self):
+        t = TableDef(
+            name="widgets",
+            columns=(
+                Col("id", "int", nullable=False, pk=True),
+                Col("name", "string", nullable=False),
+                Col("price", "double"),
+            ),
+        )
+        assert t.column_names() == ["id", "name", "price"]
+        assert t.pk_columns() == ["id"]
+
+    def test_column_lookup(self):
+        t = TableDef(
+            name="widgets",
+            columns=(Col("id", "int"), Col("name", "string")),
+        )
+        assert t.column("name").type_key == "string"
+        with pytest.raises(KeyError):
+            t.column("missing")
+
+
+class TestDDLGeneration:
+    def test_spark_ddl_shape(self):
+        t = TableDef(
+            name="widgets",
+            columns=(
+                Col("id", "int", nullable=False),
+                Col("name", "string"),
+            ),
+        )
+        ddl = t.to_spark_ddl(schema="dbo")
+        assert "CREATE TABLE IF NOT EXISTS dbo.widgets" in ddl
+        assert "`id` INT NOT NULL" in ddl
+        assert "`name` STRING" in ddl
+        assert ddl.rstrip().endswith("USING DELTA")
+
+    def test_duckdb_ddl_shape(self):
+        t = TableDef(
+            name="widgets",
+            columns=(
+                Col("id", "int", nullable=False),
+                Col("name", "string"),
+                Col("created_at", "timestamp"),
+            ),
+        )
+        ddl = t.to_duckdb_ddl(schema="ddb")
+        assert "CREATE TABLE IF NOT EXISTS ddb.widgets" in ddl
+        assert "id INTEGER NOT NULL" in ddl
+        assert "name VARCHAR" in ddl
+        assert "created_at TIMESTAMP" in ddl
+
+    def test_duckdb_ddl_without_schema(self):
+        t = TableDef(name="widgets", columns=(Col("id", "int"),))
+        ddl = t.to_duckdb_ddl()
+        assert "CREATE TABLE IF NOT EXISTS widgets" in ddl
+
+    def test_arrow_schema_matches_columns(self):
+        pa = pytest.importorskip("pyarrow")
+        t = TableDef(
+            name="widgets",
+            columns=(
+                Col("id", "int", nullable=False),
+                Col("amount", "bigint"),
+                Col("price", "double"),
+                Col("when", "timestamp"),
+                Col("active", "boolean"),
+            ),
+        )
+        schema = t.to_arrow_schema()
+        assert schema.field("id").type == pa.int32()
+        assert not schema.field("id").nullable
+        assert schema.field("amount").type == pa.int64()
+        assert schema.field("price").type == pa.float64()
+        assert schema.field("when").type == pa.timestamp("us")
+        assert schema.field("active").type == pa.bool_()
+
+    def test_all_ddl_helpers(self):
+        tables = (
+            TableDef(name="a", columns=(Col("id", "int"),)),
+            TableDef(name="b", columns=(Col("id", "int"),)),
+        )
+        assert len(all_spark_ddl(tables)) == 2
+        assert len(all_duckdb_ddl(tables, schema="ddb")) == 2
+
+
+# ── Row validation (the core regression guards) ────────────────────────────
+
+
+class TestRowValidation:
+    def test_empty_string_rejected_for_int_column(self):
+        """The MGC regression — ``""`` for an int column must not pass."""
+        t = TableDef(
+            name="reports",
+            columns=(
+                Col("id", "int", nullable=False),
+                Col("projection_number", "int"),
+            ),
+        )
+        errs = t.validate_row({"id": 1, "projection_number": ""})
+        assert any("empty string" in e for e in errs)
+        assert any("projection_number" in e for e in errs)
+
+    def test_empty_string_accepted_for_string_column(self):
+        t = TableDef(name="x", columns=(Col("note", "string"),))
+        assert t.validate_row({"note": ""}) == []
+
+    def test_none_rejected_for_non_nullable(self):
+        t = TableDef(name="x", columns=(Col("id", "int", nullable=False),))
+        errs = t.validate_row({"id": None})
+        assert errs == ["column 'id' is NOT NULL but got None"]
+
+    def test_missing_column_rejected_for_non_nullable(self):
+        t = TableDef(name="x", columns=(Col("id", "int", nullable=False),))
+        errs = t.validate_row({})
+        assert errs == ["missing required column 'id'"]
+
+    def test_missing_nullable_column_is_ok(self):
+        t = TableDef(
+            name="x",
+            columns=(Col("id", "int", nullable=False), Col("note", "string")),
+        )
+        assert t.validate_row({"id": 1}) == []
+
+    def test_bool_rejected_for_int_column(self):
+        t = TableDef(name="x", columns=(Col("count", "int"),))
+        errs = t.validate_row({"count": True})
+        assert errs and "bool" in errs[0]
+
+    def test_wrong_type_rejected(self):
+        t = TableDef(name="x", columns=(Col("price", "double"),))
+        errs = t.validate_row({"price": "12.50"})
+        assert errs and "expected" in errs[0]
+
+    def test_date_and_timestamp_accept_native_objects(self):
+        t = TableDef(
+            name="x",
+            columns=(
+                Col("when_date", "date"),
+                Col("when_ts", "timestamp"),
+            ),
+        )
+        errs = t.validate_row(
+            {
+                "when_date": dt.date(2026, 4, 16),
+                "when_ts": dt.datetime(2026, 4, 16, 12, 0, 0),
+            }
+        )
+        assert errs == []
+
+    def test_date_string_rejected(self):
+        """Strings where date/datetime is expected must be caught."""
+        t = TableDef(name="x", columns=(Col("when", "date"),))
+        errs = t.validate_row({"when": "2026-04-16"})
+        assert errs and "date" in errs[0]
+
+
+# ── LocalLakehouse.register + insert_typed ──────────────────────────────────
+
+
+@pytest.fixture
+def local_lh(tmp_path):
+    duckdb = pytest.importorskip("duckdb")  # noqa: F841 — trigger skip if missing
+    lh = LocalLakehouse(
+        db_path=tmp_path / "test.duckdb",
+        ws_id="ws",
+        lh_id="lh",
+        schema="ddb",
+    )
+    yield lh
+    lh.close()
+
+
+@pytest.fixture
+def widgets_table():
+    return TableDef(
+        name="widgets",
+        columns=(
+            Col("id", "int", nullable=False, pk=True),
+            Col("name", "string", nullable=False),
+            Col("price", "double"),
+            Col("projection_number", "int"),
+            Col("is_active", "boolean"),
+            Col("when_ts", "timestamp"),
+        ),
+    )
+
+
+class TestRegister:
+    def test_register_creates_table(self, local_lh, widgets_table):
+        count = local_lh.register(widgets_table)
+        assert count == 1
+        assert "widgets" in local_lh.table_names()
+        assert "widgets" in local_lh.registered_tables()
+
+    def test_register_tuple(self, local_lh):
+        tables = (
+            TableDef(name="a", columns=(Col("id", "int"),)),
+            TableDef(name="b", columns=(Col("id", "int"),)),
+        )
+        assert local_lh.register(tables) == 2
+        assert set(local_lh.registered_tables()) == {"a", "b"}
+
+    def test_register_is_idempotent(self, local_lh, widgets_table):
+        local_lh.register(widgets_table)
+        local_lh.register(widgets_table)  # should not raise
+        assert len(local_lh.registered_tables()) == 1
+
+
+class TestInsertTyped:
+    def test_happy_path(self, local_lh, widgets_table):
+        local_lh.register(widgets_table)
+        n = local_lh.insert_typed(
+            "widgets",
+            [
+                {
+                    "id": 1,
+                    "name": "alpha",
+                    "price": 9.99,
+                    "projection_number": 3,
+                    "is_active": True,
+                    "when_ts": dt.datetime(2026, 4, 16, 12, 0, 0),
+                },
+            ],
+        )
+        assert n == 1
+        assert local_lh.row_count("widgets") == 1
+
+    def test_rejects_empty_string_for_int(self, local_lh, widgets_table):
+        """MGC regression — empty string for int projection_number must raise."""
+        local_lh.register(widgets_table)
+        with pytest.raises(ValueError, match="empty string") as exc_info:
+            local_lh.insert_typed(
+                "widgets",
+                [
+                    {
+                        "id": 1,
+                        "name": "alpha",
+                        "projection_number": "",
+                    }
+                ],
+            )
+        assert "projection_number" in str(exc_info.value)
+        assert local_lh.row_count("widgets") == 0
+
+    def test_rejects_none_for_non_nullable(self, local_lh, widgets_table):
+        local_lh.register(widgets_table)
+        with pytest.raises(ValueError, match="NOT NULL"):
+            local_lh.insert_typed(
+                "widgets",
+                [{"id": 1, "name": None}],
+            )
+
+    def test_rejects_unknown_columns(self, local_lh, widgets_table):
+        local_lh.register(widgets_table)
+        with pytest.raises(ValueError, match="unknown columns"):
+            local_lh.insert_typed(
+                "widgets",
+                [{"id": 1, "name": "alpha", "bogus": 42}],
+            )
+
+    def test_rejects_unregistered_table(self, local_lh):
+        with pytest.raises(KeyError, match="not registered"):
+            local_lh.insert_typed("widgets", [{"id": 1}])
+
+    def test_empty_rows_is_noop(self, local_lh, widgets_table):
+        local_lh.register(widgets_table)
+        assert local_lh.insert_typed("widgets", []) == 0
+
+    def test_error_message_lists_all_bad_rows(self, local_lh, widgets_table):
+        local_lh.register(widgets_table)
+        with pytest.raises(ValueError) as exc_info:
+            local_lh.insert_typed(
+                "widgets",
+                [
+                    {"id": 1, "name": "ok"},
+                    {"id": "bad", "name": "also-bad", "projection_number": ""},
+                ],
+            )
+        msg = str(exc_info.value)
+        assert "row[1]" in msg
+        assert "projection_number" in msg
+
+    def test_datetime_not_stringified(self, local_lh, widgets_table):
+        """insert_typed should preserve datetime semantics (no auto-isoformat)."""
+        local_lh.register(widgets_table)
+        ts = dt.datetime(2026, 4, 16, 12, 34, 56)
+        local_lh.insert_typed(
+            "widgets",
+            [{"id": 1, "name": "alpha", "when_ts": ts}],
+        )
+        row = local_lh.conn.execute(
+            "SELECT when_ts FROM ddb.widgets WHERE id = 1"
+        ).fetchone()
+        assert row is not None
+        # DuckDB returns a datetime for TIMESTAMP columns — not a string.
+        assert isinstance(row[0], dt.datetime)
+        assert row[0] == ts


### PR DESCRIPTION
## Summary

Introduces schema-as-code for lakehouse tables and a typed-insert path on `LocalLakehouse` that validates rows against a registered `TableDef` before they hit DuckDB.

- **`pyfabric/data/schema.py`** — `Col`, `TableDef`, `SPARK_TYPES`, `DUCKDB_TYPES`, `PYTHON_TYPES`, and generators `to_spark_ddl()`, `to_duckdb_ddl()`, `to_arrow_schema()`. Package-level helpers `all_spark_ddl()` / `all_duckdb_ddl()`.
- **`LocalLakehouse.register(tables)`** — store `TableDef`(s) and execute their DuckDB DDL.
- **`LocalLakehouse.insert_typed(table_name, rows)`** — validate every row against the registered `TableDef` and insert. Raises `ValueError` with row-index + column-named errors on failure. Accepts native `datetime`/`date` objects without silently stringifying.

## Why

DuckDB silently coerces `""` to `0` on INTEGER columns. Downstream, the Delta writer sees a mixed-type column and fails — often far from the source of the bad row. `insert_typed` catches this and other data-shape bugs at the DuckDB boundary where the error message still names the row and column.

This was exposed by a production regression in the MCG projection pipeline (extraction crashing mid-run on an empty-string `projection_number`) and is now guarded at two layers: the consuming project's own schema module, and here upstream for future consumers.

## Test plan

- [x] `ruff check` / `ruff format --check` clean
- [x] `mypy --strict` clean
- [x] 30 new tests in `tests/data/test_schema.py` — type-key validation, frozen-dataclass invariants, DDL shape for Spark/DuckDB/Arrow, row validation (empty-string-for-int, None-for-NOT-NULL, missing-required, bool-for-int, wrong-type, native date/datetime, date-string rejected), register (single/tuple/idempotent), insert_typed (happy path, rejections, unknown columns, unregistered table, multi-row error messages, datetime preserved)
- [x] 327 total tests pass (297 existing + 30 new)

🤖 Generated with [Claude Code](https://claude.com/claude-code)