### PR TITLE
Add onelake.walk() + download_with_cache() + md5_file()

### DIFF
--- a/src/pyfabric/data/onelake.py
+++ b/src/pyfabric/data/onelake.py
@@ -11,8 +11,12 @@ OneLake paths are structured as:
 Schema-enabled lakehouses use Tables/dbo/{table}, others use Tables/{table}.
 """
 
+import hashlib
 import io
+import os
 import urllib.parse
+from collections.abc import Iterator, Sequence
+from pathlib import Path
 from typing import TYPE_CHECKING
 
 import requests
@@ -120,6 +124,61 @@ def list_files(
     return files
 
 
+def walk(
+    token: str,
+    ws_id: str,
+    item_id: str,
+    path: str,
+    *,
+    suffix: str | None = None,
+) -> Iterator[dict]:
+    """Recursively yield file entries under {item_id}/{path}.
+
+    Convenience wrapper around :func:`list_paths` for the common "find all
+    PDFs under this folder" pattern. Handles two things callers otherwise
+    reimplement:
+
+      1. Filters out directory entries.
+      2. Normalizes the ``name`` field — DFS returns paths relative to the
+         workspace (``{item_id}/Files/...``), so each entry is augmented
+         with a ``rel_path`` key giving the path relative to ``item_id``
+         (for pass-through to :func:`read_file`) and a ``size`` int.
+
+    Args:
+        suffix: Optional filename suffix filter (case-sensitive).
+
+    Yields:
+        Dicts with at least ``name`` (DFS-native path), ``rel_path``
+        (path relative to item_id), ``size`` (int bytes), plus any other
+        fields returned by the DFS API.
+    """
+    prefix = f"{item_id}/"
+    for entry in list_paths(token, ws_id, item_id, path, recursive=True):
+        if entry.get("isDirectory", "false") == "true":
+            continue
+        name = entry.get("name", "")
+        if suffix and not name.endswith(suffix):
+            continue
+        rel_path = name[len(prefix) :] if name.startswith(prefix) else name
+        yield {
+            **entry,
+            "rel_path": rel_path,
+            "size": int(entry.get("contentLength", 0)),
+        }
+
+
+# ── Hash utility ─────────────────────────────────────────────────────────────
+
+
+def md5_file(path: str | Path, *, chunk_size: int = 8192) -> str:
+    """Compute MD5 hex digest of a file, streaming in chunks."""
+    h = hashlib.md5()
+    with open(path, "rb") as f:
+        for chunk in iter(lambda: f.read(chunk_size), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
 # ── Reading ──────────────────────────────────────────────────────────────────
 
 
@@ -137,6 +196,83 @@ def read_file_by_name(token: str, ws_id: str, ws_relative_name: str) -> bytes:
     r = _get_session().get(url, headers=_hdrs(token))
     r.raise_for_status()
     return r.content
+
+
+def download_with_cache(
+    token: str,
+    ws_id: str,
+    item_id: str,
+    rel_path: str,
+    cache_dir: str | Path,
+    *,
+    read_only_caches: Sequence[str | Path] = (),
+    expected_size: int | None = None,
+    expected_md5: str | None = None,
+) -> Path:
+    """Resolve a OneLake file to a local path, downloading only if needed.
+
+    Search order:
+      1. Each directory in ``read_only_caches`` (shared fixture sets,
+         previously downloaded bulk extracts, etc.) — checked in order.
+      2. ``cache_dir`` — the writable cache for this run.
+      3. OneLake — downloaded into ``cache_dir``.
+
+    A cached copy is accepted only if it passes the validation the caller
+    provided. If ``expected_md5`` is given, the file's MD5 must match; else
+    if ``expected_size`` is given, the file's byte size must match; else
+    any existing file at that path is accepted (size check is recommended
+    for any caller that has the metadata).
+
+    Args:
+        rel_path:          File path relative to ``item_id`` (as produced by
+                           :func:`walk`'s ``rel_path`` field).
+        cache_dir:         Writable cache directory. Created if missing.
+        read_only_caches:  Additional directories to check first. Never
+                           written to by this function.
+        expected_size:     Expected byte size for cache validation.
+        expected_md5:      Expected MD5 hex digest for cache validation.
+
+    Returns:
+        Path to the local file.
+
+    Raises:
+        ValueError: If the downloaded file fails ``expected_md5`` check.
+    """
+    rel_os = rel_path.replace("/", os.sep)
+
+    for ro_dir in read_only_caches:
+        candidate = Path(ro_dir) / rel_os
+        if _cache_hit(candidate, expected_size, expected_md5):
+            return candidate
+
+    cache_dir_path = Path(cache_dir)
+    local_path = cache_dir_path / rel_os
+
+    if _cache_hit(local_path, expected_size, expected_md5):
+        return local_path
+
+    local_path.parent.mkdir(parents=True, exist_ok=True)
+    data = read_file(token, ws_id, item_id, rel_path)
+    local_path.write_bytes(data)
+
+    if expected_md5 is not None:
+        actual = hashlib.md5(data).hexdigest()
+        if actual != expected_md5:
+            raise ValueError(
+                f"MD5 mismatch for {rel_path}: expected {expected_md5}, got {actual}"
+            )
+
+    return local_path
+
+
+def _cache_hit(path: Path, expected_size: int | None, expected_md5: str | None) -> bool:
+    if not path.exists():
+        return False
+    if expected_md5 is not None:
+        return md5_file(path) == expected_md5
+    if expected_size is not None:
+        return path.stat().st_size == expected_size
+    return True
 
 
 def read_parquet_df(

--- a/tests/data/test_onelake_walk_cache.py
+++ b/tests/data/test_onelake_walk_cache.py
@@ -1,0 +1,260 @@
+"""Tests for onelake.walk() and onelake.download_with_cache().
+
+Mocks the shared HTTP session so no network calls are made. Validates
+the patterns that extraction pipelines reimplement today:
+  - walking a directory tree recursively to find files by suffix
+  - resolving a OneLake file through read-only fixture caches and a
+    writable run cache, falling back to download only when needed
+"""
+
+import hashlib
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from pyfabric.data.onelake import (
+    download_with_cache,
+    list_paths,
+    md5_file,
+    walk,
+)
+
+
+def _mock_session_with_pages(*pages: list[dict]) -> MagicMock:
+    """Build a mock session whose GET returns the given pages in order.
+
+    Each page is a list of path entries returned by the DFS filesystem API.
+    The last page has no continuation header; earlier pages do.
+    """
+    responses = []
+    for i, page in enumerate(pages):
+        resp = MagicMock()
+        resp.status_code = 200
+        resp.json.return_value = {"paths": page}
+        is_last = i == len(pages) - 1
+        resp.headers = {} if is_last else {"x-ms-continuation": f"tok-{i}"}
+        responses.append(resp)
+
+    session = MagicMock()
+    session.get.side_effect = responses
+    return session
+
+
+# ── walk() ──────────────────────────────────────────────────────────────────
+
+
+class TestWalk:
+    def test_yields_files_not_directories(self):
+        entries = [
+            {"name": "lh/Files/a.pdf", "contentLength": "100"},
+            {"name": "lh/Files/sub", "isDirectory": "true"},
+            {"name": "lh/Files/sub/b.pdf", "contentLength": "200"},
+        ]
+        with patch(
+            "pyfabric.data.onelake._get_session",
+            return_value=_mock_session_with_pages(entries),
+        ):
+            results = list(walk("tok", "ws", "lh", "Files"))
+        assert [r["rel_path"] for r in results] == ["Files/a.pdf", "Files/sub/b.pdf"]
+        assert [r["size"] for r in results] == [100, 200]
+
+    def test_suffix_filter(self):
+        entries = [
+            {"name": "lh/Files/a.pdf", "contentLength": "1"},
+            {"name": "lh/Files/b.txt", "contentLength": "2"},
+            {"name": "lh/Files/c.PDF", "contentLength": "3"},  # case-sensitive
+        ]
+        with patch(
+            "pyfabric.data.onelake._get_session",
+            return_value=_mock_session_with_pages(entries),
+        ):
+            results = list(walk("tok", "ws", "lh", "Files", suffix=".pdf"))
+        assert [r["rel_path"] for r in results] == ["Files/a.pdf"]
+
+    def test_empty_dir_yields_nothing(self):
+        with patch(
+            "pyfabric.data.onelake._get_session",
+            return_value=_mock_session_with_pages([]),
+        ):
+            results = list(walk("tok", "ws", "lh", "Files"))
+        assert results == []
+
+    def test_404_yields_nothing(self):
+        resp = MagicMock(status_code=404)
+        session = MagicMock()
+        session.get.return_value = resp
+        with patch(
+            "pyfabric.data.onelake._get_session",
+            return_value=session,
+        ):
+            results = list(walk("tok", "ws", "lh", "Files"))
+        assert results == []
+
+    def test_names_without_item_prefix_pass_through(self):
+        entries = [{"name": "Files/a.pdf", "contentLength": "1"}]
+        with patch(
+            "pyfabric.data.onelake._get_session",
+            return_value=_mock_session_with_pages(entries),
+        ):
+            results = list(walk("tok", "ws", "lh", "Files"))
+        assert results[0]["rel_path"] == "Files/a.pdf"
+
+
+# ── list_paths passes continuation tokens through ───────────────────────────
+
+
+class TestListPathsContinuation:
+    def test_paginates(self):
+        page1 = [{"name": "lh/Files/a.pdf"}]
+        page2 = [{"name": "lh/Files/b.pdf"}]
+        session = _mock_session_with_pages(page1, page2)
+        with patch("pyfabric.data.onelake._get_session", return_value=session):
+            results = list_paths("tok", "ws", "lh", "Files")
+        assert len(results) == 2
+        assert session.get.call_count == 2
+
+
+# ── md5_file ────────────────────────────────────────────────────────────────
+
+
+class TestMd5File:
+    def test_known_value(self, tmp_path):
+        p = tmp_path / "data.bin"
+        p.write_bytes(b"hello world")
+        assert md5_file(p) == hashlib.md5(b"hello world").hexdigest()
+
+    def test_streaming_matches_oneshot(self, tmp_path):
+        payload = b"x" * 100_000
+        p = tmp_path / "big.bin"
+        p.write_bytes(payload)
+        assert md5_file(p, chunk_size=4096) == hashlib.md5(payload).hexdigest()
+
+
+# ── download_with_cache ─────────────────────────────────────────────────────
+
+
+class TestDownloadWithCache:
+    def test_hits_readonly_cache_first(self, tmp_path):
+        ro = tmp_path / "readonly"
+        writable = tmp_path / "cache"
+        (ro / "Files").mkdir(parents=True)
+        (ro / "Files" / "a.pdf").write_bytes(b"from-readonly")
+
+        with patch("pyfabric.data.onelake.read_file") as mock_read:
+            result = download_with_cache(
+                "tok",
+                "ws",
+                "lh",
+                "Files/a.pdf",
+                cache_dir=writable,
+                read_only_caches=[ro],
+                expected_size=len(b"from-readonly"),
+            )
+        assert result == ro / "Files" / "a.pdf"
+        mock_read.assert_not_called()
+
+    def test_hits_writable_cache(self, tmp_path):
+        cache = tmp_path / "cache"
+        (cache / "Files").mkdir(parents=True)
+        (cache / "Files" / "a.pdf").write_bytes(b"cached")
+
+        with patch("pyfabric.data.onelake.read_file") as mock_read:
+            result = download_with_cache(
+                "tok",
+                "ws",
+                "lh",
+                "Files/a.pdf",
+                cache_dir=cache,
+                expected_size=len(b"cached"),
+            )
+        assert result == cache / "Files" / "a.pdf"
+        mock_read.assert_not_called()
+
+    def test_size_mismatch_re_downloads(self, tmp_path):
+        cache = tmp_path / "cache"
+        (cache / "Files").mkdir(parents=True)
+        stale = cache / "Files" / "a.pdf"
+        stale.write_bytes(b"stale-and-wrong-size")
+
+        with patch(
+            "pyfabric.data.onelake.read_file", return_value=b"fresh"
+        ) as mock_read:
+            result = download_with_cache(
+                "tok",
+                "ws",
+                "lh",
+                "Files/a.pdf",
+                cache_dir=cache,
+                expected_size=len(b"fresh"),
+            )
+        assert result.read_bytes() == b"fresh"
+        mock_read.assert_called_once_with("tok", "ws", "lh", "Files/a.pdf")
+
+    def test_downloads_when_absent(self, tmp_path):
+        cache = tmp_path / "cache"
+        with patch(
+            "pyfabric.data.onelake.read_file", return_value=b"new-bytes"
+        ) as mock_read:
+            result = download_with_cache(
+                "tok",
+                "ws",
+                "lh",
+                "Files/sub/a.pdf",
+                cache_dir=cache,
+            )
+        assert result == cache / "Files" / "sub" / "a.pdf"
+        assert result.read_bytes() == b"new-bytes"
+        mock_read.assert_called_once()
+
+    def test_md5_validation_on_download(self, tmp_path):
+        data = b"payload"
+        expected = hashlib.md5(data).hexdigest()
+        with patch("pyfabric.data.onelake.read_file", return_value=data):
+            result = download_with_cache(
+                "tok",
+                "ws",
+                "lh",
+                "Files/a.pdf",
+                cache_dir=tmp_path / "cache",
+                expected_md5=expected,
+            )
+        assert result.read_bytes() == data
+
+    def test_md5_mismatch_raises(self, tmp_path):
+        with (
+            patch("pyfabric.data.onelake.read_file", return_value=b"tampered"),
+            pytest.raises(ValueError, match="MD5 mismatch"),
+        ):
+            download_with_cache(
+                "tok",
+                "ws",
+                "lh",
+                "Files/a.pdf",
+                cache_dir=tmp_path / "cache",
+                expected_md5="deadbeef" * 4,
+            )
+
+    def test_md5_takes_precedence_over_size(self, tmp_path):
+        """When md5 is given, size check alone must not be enough."""
+        cache = tmp_path / "cache"
+        (cache / "Files").mkdir(parents=True)
+        wrong_but_right_size = cache / "Files" / "a.pdf"
+        wrong_but_right_size.write_bytes(b"XXXXXXX")  # 7 bytes
+        real_data = b"YYYYYYY"  # also 7 bytes, different hash
+        real_md5 = hashlib.md5(real_data).hexdigest()
+
+        with patch(
+            "pyfabric.data.onelake.read_file", return_value=real_data
+        ) as mock_read:
+            result = download_with_cache(
+                "tok",
+                "ws",
+                "lh",
+                "Files/a.pdf",
+                cache_dir=cache,
+                expected_size=7,
+                expected_md5=real_md5,
+            )
+        # Should have re-downloaded because md5 didn't match, despite size match.
+        mock_read.assert_called_once()
+        assert result.read_bytes() == real_data


### PR DESCRIPTION
## Summary

Three `pyfabric.data.onelake` utilities that every extraction pipeline currently reimplements:

- **`walk(token, ws_id, item_id, path, *, suffix=None)`** — generator over file entries under a OneLake path. Filters directories, optional suffix filter, and annotates each entry with `rel_path` (relative to `item_id`, ready to pass back to `read_file`) and `size` (int from `contentLength`).
- **`download_with_cache(token, ws_id, item_id, rel_path, cache_dir, *, read_only_caches=(), expected_size=None, expected_md5=None)`** — resolves a OneLake file via ordered search: read-only caches (shared fixture sets, previous extracts) → writable run cache → download. Validates cached copies by size or md5; verifies downloads against `expected_md5`.
- **`md5_file(path)`** — streaming MD5 hex digest for large files.

## Why

The MCG projection pipeline ended up writing its own `_walk_onelake`, `download_pdf`, and `compute_md5` helpers because pyfabric's `list_paths(recursive=True)` returns a list of unnormalized `name` fields and has no caching story. Same shape will appear in every batch-processing pipeline. Moving these upstream means consumers just import `walk`/`download_with_cache` and get the pagination, relative-path normalization, and cache-precedence logic for free.

## Test plan

- [x] `ruff check` / `ruff format --check` clean
- [x] `mypy --strict` clean
- [x] 15 new tests in `tests/data/test_onelake_walk_cache.py`. HTTP is mocked via `_get_session` — no network calls.
  - `walk`: filters directories, suffix filter, handles empty/404, pagination via continuation tokens, pass-through when `name` lacks item prefix
  - `md5_file`: known value, streaming vs one-shot equivalence
  - `download_with_cache`: read-only cache hit takes precedence, writable cache hit skips download, size mismatch triggers re-download, absent file downloads, md5 validation on download, md5 mismatch raises, md5 overrides size (two files same size different content must be distinguishable)
- [x] 312 total tests pass (297 existing + 15 new)

🤖 Generated with [Claude Code](https://claude.com/claude-code)