### PR TITLE
Combined follow-ups: logging rename, processing_log, upload retry, schema drift

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -335,7 +335,7 @@ AI-powered test and log analysis (placeholder for future Ollama integration).
 
 ---
 
-## pyfabric._logging — Structured Logging
+## pyfabric.logging — Structured Logging
 
 Dual-output logging using structlog: console (terse) and JSON Lines file (verbose).
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,6 +48,7 @@ data = [
 testing = [
     "duckdb>=1.1",
     "deltalake>=0.21",
+    "pyarrow>=17",
     "pytest>=8.0",
 ]
 all = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -143,7 +143,6 @@ module = [
     "pyfabric.items.bundle",
     "pyfabric.items.crud",
     "pyfabric.cli",
-    "pyfabric._logging",
 ]
 ignore_errors = true
 

--- a/src/pyfabric/cli.py
+++ b/src/pyfabric/cli.py
@@ -24,8 +24,8 @@ from pathlib import Path
 
 import structlog
 
-from pyfabric._logging import setup_logging
 from pyfabric.client.auth import FabricCredential
+from pyfabric.logging import setup_logging
 
 log = structlog.get_logger()
 

--- a/src/pyfabric/data/__init__.py
+++ b/src/pyfabric/data/__init__.py
@@ -1,4 +1,5 @@
 """Data access for OneLake, SQL endpoints, and lakehouse tables."""
 
 from pyfabric.data.local_lakehouse import LocalLakehouse  # noqa: F401
+from pyfabric.data.processing_log import ProcessingLog  # noqa: F401
 from pyfabric.data.schema import Col, TableDef  # noqa: F401

--- a/src/pyfabric/data/onelake.py
+++ b/src/pyfabric/data/onelake.py
@@ -14,6 +14,7 @@ Schema-enabled lakehouses use Tables/dbo/{table}, others use Tables/{table}.
 import hashlib
 import io
 import os
+import time
 import urllib.parse
 from collections.abc import Iterator, Sequence
 from pathlib import Path
@@ -332,28 +333,69 @@ def upload_file(
     item_id: str,
     path: str,
     data: bytes,
+    *,
+    max_attempts: int = 3,
+    backoff_seconds: float = 1.0,
 ) -> None:
     """Upload bytes to {item_id}/{path} using the DFS 3-step protocol.
 
     Protocol: PUT ?resource=file -> PATCH ?action=append -> PATCH ?action=flush
+
+    The shared session already retries individual 429/503 responses. This
+    function adds whole-operation retry: if a later step (e.g. the ``flush``
+    PATCH) fails transiently after the session has exhausted per-request
+    retries, the entire 3-step sequence is re-attempted from ``PUT`` so the
+    upload ends in a consistent state.
+
+    Retries apply to ``requests.RequestException`` and HTTP 5xx responses.
+    4xx responses other than 429 (already handled by the session) fail fast.
+
+    Args:
+        max_attempts:     Total attempts including the first. ``1`` disables
+                          whole-operation retry.
+        backoff_seconds:  Base for exponential backoff between attempts
+                          (``backoff * 2**n``). Set to ``0`` to disable sleep.
     """
     url = _dfs_url(ws_id, item_id, path)
     hdrs = _hdrs(token)
 
-    _get_session().put(
-        url, headers=hdrs, params={"resource": "file"}
-    ).raise_for_status()
-    _get_session().patch(
-        url,
-        headers={**hdrs, "Content-Type": "application/octet-stream"},
-        params={"action": "append", "position": "0"},
-        data=data,
-    ).raise_for_status()
-    _get_session().patch(
-        url,
-        headers=hdrs,
-        params={"action": "flush", "position": str(len(data))},
-    ).raise_for_status()
+    last_exc: Exception | None = None
+    for attempt in range(1, max_attempts + 1):
+        try:
+            _get_session().put(
+                url, headers=hdrs, params={"resource": "file"}
+            ).raise_for_status()
+            _get_session().patch(
+                url,
+                headers={**hdrs, "Content-Type": "application/octet-stream"},
+                params={"action": "append", "position": "0"},
+                data=data,
+            ).raise_for_status()
+            _get_session().patch(
+                url,
+                headers=hdrs,
+                params={"action": "flush", "position": str(len(data))},
+            ).raise_for_status()
+            return
+        except requests.HTTPError as e:
+            status = e.response.status_code if e.response is not None else 0
+            if 400 <= status < 500 and status != 429:
+                raise
+            last_exc = e
+        except requests.RequestException as e:
+            last_exc = e
+
+        if attempt < max_attempts and backoff_seconds > 0:
+            time.sleep(backoff_seconds * (2 ** (attempt - 1)))
+            log.warning(
+                "upload_file retry",
+                path=path,
+                attempt=attempt,
+                error=str(last_exc),
+            )
+
+    assert last_exc is not None
+    raise last_exc
 
 
 def delete_file(token: str, ws_id: str, item_id: str, path: str) -> bool:

--- a/src/pyfabric/data/processing_log.py
+++ b/src/pyfabric/data/processing_log.py
@@ -1,0 +1,209 @@
+"""
+Processing log (watermark) table for incremental/idempotent extraction jobs.
+
+A common pipeline pattern: walk a source, process each item once, and remember
+what's already been done so a re-run skips it. This module provides a generic
+watermark table with a small API around four operations:
+
+  - :meth:`ProcessingLog.is_processed` — should we skip this source item?
+  - :meth:`ProcessingLog.record_success` — mark an item as done.
+  - :meth:`ProcessingLog.record_failure` — mark an item as failed (will retry).
+  - :meth:`ProcessingLog.failures` — list rows that failed, for replay.
+
+Backed by a :class:`~pyfabric.data.local_lakehouse.LocalLakehouse` (DuckDB).
+The table is registered and created on instantiation using the shipped default
+schema, or a caller-provided :class:`~pyfabric.data.schema.TableDef`.
+
+Usage:
+    from pyfabric.data.local_lakehouse import LocalLakehouse
+    from pyfabric.data.processing_log import ProcessingLog
+
+    lake = LocalLakehouse(db_path="extract.duckdb", ws_id="...", lh_id="...")
+    plog = ProcessingLog(lake)
+
+    for pdf_path, content_hash in iter_sources():
+        if plog.is_processed(pdf_path, content_hash=content_hash):
+            continue
+        try:
+            n = extract(pdf_path)
+            plog.record_success(pdf_path, content_hash=content_hash, rows_written=n)
+        except Exception as e:
+            plog.record_failure(pdf_path, content_hash=content_hash, error=str(e))
+
+Re-running the job is safe: already-successful rows are skipped, and
+``plog.failures()`` surfaces what to retry.
+"""
+
+from __future__ import annotations
+
+import datetime as _dt
+from typing import TYPE_CHECKING
+
+import structlog
+
+from pyfabric.data.schema import Col, TableDef
+
+if TYPE_CHECKING:
+    from pyfabric.data.local_lakehouse import LocalLakehouse
+
+log = structlog.get_logger()
+
+
+STATUS_SUCCESS = "success"
+STATUS_FAILURE = "failure"
+
+
+DEFAULT_TABLE = TableDef(
+    name="processing_log",
+    description="Watermark/audit table for incremental extraction jobs.",
+    columns=(
+        Col("source_path", "string", nullable=False, pk=True),
+        Col("content_hash", "string"),
+        Col("status", "string", nullable=False),
+        Col("rows_written", "bigint"),
+        Col("error_summary", "string"),
+        Col("processed_at", "timestamp", nullable=False),
+    ),
+)
+
+
+class ProcessingLog:
+    """Watermark table backed by a LocalLakehouse.
+
+    Args:
+        lakehouse:  A :class:`LocalLakehouse` to host the table.
+        table_def:  Optional custom :class:`TableDef`. If given, it must
+                    contain at least a ``source_path`` (string, pk) column
+                    and a ``status`` (string) column. Defaults to
+                    :data:`DEFAULT_TABLE`.
+    """
+
+    def __init__(
+        self,
+        lakehouse: LocalLakehouse,
+        *,
+        table_def: TableDef | None = None,
+    ) -> None:
+        self.lakehouse = lakehouse
+        self.table_def = table_def or DEFAULT_TABLE
+        self._validate_shape()
+        lakehouse.register(self.table_def)
+
+    def _validate_shape(self) -> None:
+        names = set(self.table_def.column_names())
+        missing = {"source_path", "status"} - names
+        if missing:
+            raise ValueError(
+                f"ProcessingLog table_def is missing required columns: "
+                f"{sorted(missing)}"
+            )
+        sp = self.table_def.column("source_path")
+        if sp.type_key != "string" or not sp.pk:
+            raise ValueError("'source_path' must be a string primary-key column")
+
+    # ── Queries ──────────────────────────────────────────────────────────────
+
+    def is_processed(
+        self,
+        source_path: str,
+        *,
+        content_hash: str | None = None,
+    ) -> bool:
+        """Return True iff source_path has a recorded success row.
+
+        If ``content_hash`` is given, the stored row's ``content_hash`` must
+        match; a hash mismatch means the source changed and should be re-processed.
+        A row with status != success is treated as not-processed so it
+        will be retried.
+        """
+        qualified = f"{self.lakehouse.schema}.{self.table_def.name}"
+        row = self.lakehouse.conn.execute(
+            f"SELECT status, content_hash FROM {qualified} WHERE source_path = ?",
+            [source_path],
+        ).fetchone()
+        if not row:
+            return False
+        status, stored_hash = row[0], row[1]
+        if status != STATUS_SUCCESS:
+            return False
+        return not (content_hash is not None and stored_hash != content_hash)
+
+    def failures(self) -> list[dict]:
+        """Return failed rows as list of dicts (for replay workflows)."""
+        qualified = f"{self.lakehouse.schema}.{self.table_def.name}"
+        cols = self.table_def.column_names()
+        rows = self.lakehouse.conn.execute(
+            f"SELECT {', '.join(cols)} FROM {qualified} WHERE status = ?",
+            [STATUS_FAILURE],
+        ).fetchall()
+        return [dict(zip(cols, r, strict=True)) for r in rows]
+
+    # ── Writes ───────────────────────────────────────────────────────────────
+
+    def record_success(
+        self,
+        source_path: str,
+        *,
+        content_hash: str | None = None,
+        rows_written: int | None = None,
+        extra: dict | None = None,
+    ) -> None:
+        row = {
+            "source_path": source_path,
+            "content_hash": content_hash,
+            "status": STATUS_SUCCESS,
+            "rows_written": rows_written,
+            "error_summary": None,
+            "processed_at": _dt.datetime.now(tz=_dt.UTC),
+        }
+        if extra:
+            row.update(extra)
+        self._upsert(row)
+
+    def record_failure(
+        self,
+        source_path: str,
+        *,
+        error: str,
+        content_hash: str | None = None,
+        extra: dict | None = None,
+    ) -> None:
+        row = {
+            "source_path": source_path,
+            "content_hash": content_hash,
+            "status": STATUS_FAILURE,
+            "rows_written": None,
+            "error_summary": error[:4000],
+            "processed_at": _dt.datetime.now(tz=_dt.UTC),
+        }
+        if extra:
+            row.update(extra)
+        self._upsert(row)
+
+    def _upsert(self, row: dict) -> None:
+        errors = self.table_def.validate_row(row)
+        if errors:
+            raise ValueError(
+                f"ProcessingLog row invalid for {row.get('source_path')!r}: "
+                + "; ".join(errors)
+            )
+        qualified = f"{self.lakehouse.schema}.{self.table_def.name}"
+        cols = self.table_def.column_names()
+        placeholders = ", ".join(["?"] * len(cols))
+        values = tuple(row.get(c) for c in cols)
+        # DuckDB DDL doesn't emit a PRIMARY KEY constraint (pk on Col is
+        # informational), so emulate upsert with DELETE + INSERT in a txn.
+        conn = self.lakehouse.conn
+        conn.execute("BEGIN")
+        try:
+            conn.execute(
+                f"DELETE FROM {qualified} WHERE source_path = ?", [row["source_path"]]
+            )
+            conn.execute(
+                f"INSERT INTO {qualified} ({', '.join(cols)}) VALUES ({placeholders})",
+                values,
+            )
+            conn.execute("COMMIT")
+        except Exception:
+            conn.execute("ROLLBACK")
+            raise

--- a/src/pyfabric/data/schema.py
+++ b/src/pyfabric/data/schema.py
@@ -215,3 +215,107 @@ def all_duckdb_ddl(
 ) -> list[str]:
     """CREATE TABLE statements for a tuple of tables (DuckDB)."""
     return [t.to_duckdb_ddl(schema) for t in tables]
+
+
+# ── Schema drift detection ──────────────────────────────────────────────────
+#
+# Each backend reports column types in its own vocabulary. We normalize them
+# to the internal type_key so drift checks are uniform. Maps live here rather
+# than on TableDef because they're reverse lookups.
+
+_DUCKDB_TO_TYPE_KEY: dict[str, str] = {
+    "VARCHAR": "string",
+    "INTEGER": "int",
+    "BIGINT": "bigint",
+    "DOUBLE": "double",
+    "BOOLEAN": "boolean",
+    "DATE": "date",
+    "TIMESTAMP": "timestamp",
+}
+
+
+def validate_duckdb_schema(
+    table_def: "TableDef",
+    conn: Any,
+    *,
+    schema: str | None = None,
+) -> list[str]:
+    """Compare ``table_def`` against the live DuckDB table. Returns discrepancies.
+
+    Checks for missing columns, extra columns, and type mismatches. Returns
+    an empty list when the actual table matches the definition.
+
+    Args:
+        conn:    DuckDB connection.
+        schema:  DuckDB schema name. ``None`` means the default schema.
+    """
+    if schema:
+        rows = conn.execute(
+            "SELECT column_name, data_type FROM information_schema.columns "
+            "WHERE table_schema = ? AND table_name = ? ORDER BY ordinal_position",
+            [schema, table_def.name],
+        ).fetchall()
+    else:
+        rows = conn.execute(
+            "SELECT column_name, data_type FROM information_schema.columns "
+            "WHERE table_name = ? ORDER BY ordinal_position",
+            [table_def.name],
+        ).fetchall()
+    actual = {name: (data_type or "").upper() for name, data_type in rows}
+    return _diff(table_def, actual, _DUCKDB_TO_TYPE_KEY)
+
+
+_ARROW_TO_TYPE_KEY: dict[str, str] = {
+    "string": "string",
+    "large_string": "string",
+    "int32": "int",
+    "int64": "bigint",
+    "double": "double",
+    "float": "double",
+    "bool": "boolean",
+    "date32[day]": "date",
+    "timestamp": "timestamp",
+}
+
+
+def validate_arrow_schema(table_def: "TableDef", arrow_schema: Any) -> list[str]:
+    """Compare ``table_def`` against a PyArrow Schema. Returns discrepancies."""
+    actual: dict[str, str] = {}
+    for field in arrow_schema:
+        t = str(field.type)
+        # Timestamps carry unit/tz suffixes; normalize to "timestamp".
+        if t.startswith("timestamp"):
+            t = "timestamp"
+        actual[field.name] = t
+    return _diff(table_def, actual, _ARROW_TO_TYPE_KEY)
+
+
+def _diff(
+    table_def: "TableDef",
+    actual: dict[str, str],
+    mapping: dict[str, str],
+) -> list[str]:
+    errors: list[str] = []
+    if not actual:
+        return [f"table {table_def.name!r} not found"]
+
+    expected_names = {c.name for c in table_def.columns}
+    for c in table_def.columns:
+        if c.name not in actual:
+            errors.append(f"missing column {c.name!r} ({c.type_key})")
+            continue
+        actual_key = mapping.get(actual[c.name])
+        if actual_key is None:
+            errors.append(
+                f"column {c.name!r} has unrecognized backend type {actual[c.name]!r}"
+            )
+            continue
+        if actual_key != c.type_key:
+            errors.append(
+                f"column {c.name!r} type mismatch: expected {c.type_key}, "
+                f"got {actual_key} ({actual[c.name]})"
+            )
+
+    for extra in sorted(set(actual) - expected_names):
+        errors.append(f"unexpected column {extra!r} ({actual[extra]})")
+    return errors

--- a/src/pyfabric/logging.py
+++ b/src/pyfabric/logging.py
@@ -5,7 +5,7 @@ Dual output: terse console + verbose JSON Lines file.
 All log output is machine-parseable (JSON) for AI-assisted analysis.
 
 Usage in scripts:
-    from pyfabric._logging import setup_logging, get_log_path
+    from pyfabric.logging import setup_logging, get_log_path
     log_path = setup_logging("my_script")
 
 Usage in library modules:
@@ -19,7 +19,9 @@ import datetime
 import logging
 import re
 import sys
+from collections.abc import Mapping, MutableMapping
 from pathlib import Path
+from typing import Any
 
 import structlog
 
@@ -39,7 +41,11 @@ def _mask_tokens(text: str) -> str:
     return _TOKEN_RE.sub("[TOKEN]", text)
 
 
-def mask_tokens_processor(logger: object, method_name: str, event_dict: dict) -> dict:
+def mask_tokens_processor(
+    logger: Any,
+    method_name: str,
+    event_dict: MutableMapping[str, Any],
+) -> Mapping[str, Any]:
     """Structlog processor that redacts JWT tokens from all event values."""
     for key, value in event_dict.items():
         if isinstance(value, str):

--- a/src/pyfabric/testing/analyze.py
+++ b/src/pyfabric/testing/analyze.py
@@ -60,7 +60,7 @@ def analyze_log_file(
     the local LLM to summarize findings and recommend actions.
 
     Args:
-        log_path: Path to a .jsonl log file from pyfabric._logging.
+        log_path: Path to a .jsonl log file from pyfabric.logging.
         model: Ollama model name (default: gemma3).
         host: Ollama API endpoint.
 

--- a/tests/data/test_processing_log.py
+++ b/tests/data/test_processing_log.py
@@ -1,0 +1,114 @@
+"""Tests for pyfabric.data.processing_log.ProcessingLog."""
+
+import pytest
+
+from pyfabric.data.local_lakehouse import LocalLakehouse
+from pyfabric.data.processing_log import (
+    DEFAULT_TABLE,
+    STATUS_FAILURE,
+    STATUS_SUCCESS,
+    ProcessingLog,
+)
+from pyfabric.data.schema import Col, TableDef
+
+
+@pytest.fixture
+def lake(tmp_path):
+    return LocalLakehouse(
+        db_path=tmp_path / "plog.duckdb",
+        ws_id="ws",
+        lh_id="lh",
+        schema="ddb",
+    )
+
+
+class TestSetup:
+    def test_creates_table_on_init(self, lake):
+        plog = ProcessingLog(lake)
+        assert DEFAULT_TABLE.name in lake.table_names()
+        assert plog.table_def is DEFAULT_TABLE
+
+    def test_rejects_tabledef_without_source_path(self, lake):
+        bad = TableDef(
+            name="bad_log",
+            columns=(
+                Col("file", "string", nullable=False, pk=True),
+                Col("status", "string", nullable=False),
+            ),
+        )
+        with pytest.raises(ValueError, match="source_path"):
+            ProcessingLog(lake, table_def=bad)
+
+    def test_rejects_tabledef_where_source_path_not_pk(self, lake):
+        bad = TableDef(
+            name="bad_log",
+            columns=(
+                Col("source_path", "string", nullable=False),  # not pk
+                Col("status", "string", nullable=False),
+            ),
+        )
+        with pytest.raises(ValueError, match="primary-key"):
+            ProcessingLog(lake, table_def=bad)
+
+
+class TestSuccessFlow:
+    def test_record_success_then_is_processed(self, lake):
+        plog = ProcessingLog(lake)
+        plog.record_success("a.pdf", content_hash="h1", rows_written=10)
+        assert plog.is_processed("a.pdf") is True
+
+    def test_is_processed_false_for_unseen(self, lake):
+        plog = ProcessingLog(lake)
+        assert plog.is_processed("never.pdf") is False
+
+    def test_content_hash_mismatch_means_not_processed(self, lake):
+        plog = ProcessingLog(lake)
+        plog.record_success("a.pdf", content_hash="h1", rows_written=1)
+        assert plog.is_processed("a.pdf", content_hash="h1") is True
+        assert plog.is_processed("a.pdf", content_hash="h2") is False
+
+
+class TestFailureFlow:
+    def test_failure_is_not_processed(self, lake):
+        plog = ProcessingLog(lake)
+        plog.record_failure("a.pdf", content_hash="h1", error="parse error")
+        assert plog.is_processed("a.pdf") is False
+
+    def test_failures_listing(self, lake):
+        plog = ProcessingLog(lake)
+        plog.record_failure("a.pdf", error="bad")
+        plog.record_success("b.pdf", rows_written=1)
+        plog.record_failure("c.pdf", error="bad2")
+        failures = plog.failures()
+        assert {r["source_path"] for r in failures} == {"a.pdf", "c.pdf"}
+        assert {r["status"] for r in failures} == {STATUS_FAILURE}
+
+    def test_retry_after_failure_overwrites(self, lake):
+        plog = ProcessingLog(lake)
+        plog.record_failure("a.pdf", error="bad")
+        plog.record_success("a.pdf", rows_written=5)
+        assert plog.is_processed("a.pdf") is True
+        assert plog.failures() == []
+
+    def test_error_summary_truncated(self, lake):
+        plog = ProcessingLog(lake)
+        big = "X" * 10000
+        plog.record_failure("a.pdf", error=big)
+        row = plog.failures()[0]
+        assert len(row["error_summary"]) == 4000
+
+
+class TestUpsertSemantics:
+    def test_second_success_updates_not_duplicates(self, lake):
+        plog = ProcessingLog(lake)
+        plog.record_success("a.pdf", content_hash="h1", rows_written=1)
+        plog.record_success("a.pdf", content_hash="h2", rows_written=2)
+        rows = lake.conn.execute(
+            "SELECT content_hash, rows_written FROM ddb.processing_log "
+            "WHERE source_path = 'a.pdf'"
+        ).fetchall()
+        assert rows == [("h2", 2)]
+
+    def test_status_column_is_success_constant(self):
+        assert STATUS_SUCCESS == "success"
+        assert STATUS_FAILURE == "failure"

--- a/tests/data/test_schema_validation.py
+++ b/tests/data/test_schema_validation.py
@@ -1,0 +1,123 @@
+"""Tests for validate_duckdb_schema and validate_arrow_schema."""
+
+import duckdb
+import pyarrow as pa
+import pytest
+
+from pyfabric.data.schema import (
+    Col,
+    TableDef,
+    validate_arrow_schema,
+    validate_duckdb_schema,
+)
+
+
+@pytest.fixture
+def products() -> TableDef:
+    return TableDef(
+        name="products",
+        columns=(
+            Col("id", "int", nullable=False, pk=True),
+            Col("name", "string", nullable=False),
+            Col("price", "double"),
+            Col("active", "boolean"),
+        ),
+    )
+
+
+# ── DuckDB ──────────────────────────────────────────────────────────────────
+
+
+class TestValidateDuckDB:
+    def test_matching_table(self, products):
+        conn = duckdb.connect(":memory:")
+        conn.execute(products.to_duckdb_ddl())
+        assert validate_duckdb_schema(products, conn) == []
+
+    def test_table_in_schema(self, products):
+        conn = duckdb.connect(":memory:")
+        conn.execute("CREATE SCHEMA ddb")
+        conn.execute(products.to_duckdb_ddl(schema="ddb"))
+        assert validate_duckdb_schema(products, conn, schema="ddb") == []
+
+    def test_missing_table(self, products):
+        conn = duckdb.connect(":memory:")
+        errors = validate_duckdb_schema(products, conn)
+        assert any("not found" in e for e in errors)
+
+    def test_missing_column(self, products):
+        conn = duckdb.connect(":memory:")
+        conn.execute("CREATE TABLE products (id INTEGER, name VARCHAR)")
+        errors = validate_duckdb_schema(products, conn)
+        assert any("missing column 'price'" in e for e in errors)
+        assert any("missing column 'active'" in e for e in errors)
+
+    def test_type_mismatch(self, products):
+        conn = duckdb.connect(":memory:")
+        conn.execute(
+            "CREATE TABLE products "
+            "(id VARCHAR, name VARCHAR, price DOUBLE, active BOOLEAN)"
+        )
+        errors = validate_duckdb_schema(products, conn)
+        assert any("'id' type mismatch" in e for e in errors)
+
+    def test_extra_column(self, products):
+        conn = duckdb.connect(":memory:")
+        conn.execute(
+            "CREATE TABLE products "
+            "(id INTEGER, name VARCHAR, price DOUBLE, active BOOLEAN, notes VARCHAR)"
+        )
+        errors = validate_duckdb_schema(products, conn)
+        assert any("unexpected column 'notes'" in e for e in errors)
+
+
+# ── PyArrow ─────────────────────────────────────────────────────────────────
+
+
+class TestValidateArrow:
+    def test_matching_schema(self, products):
+        assert validate_arrow_schema(products, products.to_arrow_schema()) == []
+
+    def test_missing_column(self, products):
+        schema = pa.schema(
+            [
+                pa.field("id", pa.int32()),
+                pa.field("name", pa.string()),
+            ]
+        )
+        errors = validate_arrow_schema(products, schema)
+        assert any("missing column 'price'" in e for e in errors)
+
+    def test_type_mismatch(self, products):
+        schema = pa.schema(
+            [
+                pa.field("id", pa.int64()),  # wrong: should be int32
+                pa.field("name", pa.string()),
+                pa.field("price", pa.float64()),
+                pa.field("active", pa.bool_()),
+            ]
+        )
+        errors = validate_arrow_schema(products, schema)
+        assert any("'id' type mismatch" in e for e in errors)
+
+    def test_timestamp_unit_does_not_matter(self):
+        """timestamp[us] vs timestamp[ms] both map to 'timestamp'."""
+        td = TableDef(
+            name="events",
+            columns=(Col("ts", "timestamp", nullable=False),),
+        )
+        schema = pa.schema([pa.field("ts", pa.timestamp("ms"))])
+        assert validate_arrow_schema(td, schema) == []
+
+    def test_extra_column(self, products):
+        schema = pa.schema(
+            [
+                pa.field("id", pa.int32()),
+                pa.field("name", pa.string()),
+                pa.field("price", pa.float64()),
+                pa.field("active", pa.bool_()),
+                pa.field("extra", pa.string()),
+            ]
+        )
+        errors = validate_arrow_schema(products, schema)
+        assert any("unexpected column 'extra'" in e for e in errors)

--- a/tests/data/test_upload_retry.py
+++ b/tests/data/test_upload_retry.py
@@ -1,0 +1,112 @@
+"""Tests for whole-operation retry in onelake.upload_file."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+import requests
+
+from pyfabric.data.onelake import upload_file
+
+
+def _ok_response() -> MagicMock:
+    resp = MagicMock()
+    resp.status_code = 200
+    resp.raise_for_status.return_value = None
+    return resp
+
+
+def _http_error(status: int) -> requests.HTTPError:
+    resp = MagicMock()
+    resp.status_code = status
+    err = requests.HTTPError(f"HTTP {status}")
+    err.response = resp
+    return err
+
+
+class TestUploadRetry:
+    def test_success_first_attempt(self):
+        session = MagicMock()
+        session.put.return_value = _ok_response()
+        session.patch.return_value = _ok_response()
+        with patch("pyfabric.data.onelake._get_session", return_value=session):
+            upload_file("tok", "ws", "lh", "Files/x", b"data", backoff_seconds=0)
+        assert session.put.call_count == 1
+        assert session.patch.call_count == 2
+
+    def test_retries_on_5xx(self):
+        """A 500 on flush PATCH re-runs the whole 3-step protocol."""
+        session = MagicMock()
+        session.put.return_value = _ok_response()
+        # First flush fails with 500, second attempt succeeds on all three steps.
+        ok = _ok_response()
+        failing = MagicMock()
+        failing.raise_for_status.side_effect = _http_error(500)
+        session.patch.side_effect = [ok, failing, ok, ok]
+        with patch("pyfabric.data.onelake._get_session", return_value=session):
+            upload_file("tok", "ws", "lh", "Files/x", b"data", backoff_seconds=0)
+        assert session.put.call_count == 2  # 1 initial + 1 retry
+        assert session.patch.call_count == 4  # append+flush twice
+
+    def test_retries_on_connection_error(self):
+        session = MagicMock()
+        session.put.side_effect = [
+            requests.ConnectionError("boom"),
+            _ok_response(),
+        ]
+        session.patch.return_value = _ok_response()
+        with patch("pyfabric.data.onelake._get_session", return_value=session):
+            upload_file("tok", "ws", "lh", "Files/x", b"data", backoff_seconds=0)
+        assert session.put.call_count == 2
+
+    def test_4xx_fails_fast(self):
+        """403/404 etc must NOT trigger whole-operation retry."""
+        session = MagicMock()
+        failing = MagicMock()
+        failing.raise_for_status.side_effect = _http_error(403)
+        session.put.return_value = failing
+        with (
+            patch("pyfabric.data.onelake._get_session", return_value=session),
+            pytest.raises(requests.HTTPError),
+        ):
+            upload_file("tok", "ws", "lh", "Files/x", b"data", backoff_seconds=0)
+        assert session.put.call_count == 1
+
+    def test_exhausts_attempts_then_raises(self):
+        session = MagicMock()
+        failing = MagicMock()
+        failing.raise_for_status.side_effect = _http_error(503)
+        session.put.return_value = failing
+        with (
+            patch("pyfabric.data.onelake._get_session", return_value=session),
+            pytest.raises(requests.HTTPError),
+        ):
+            upload_file(
+                "tok",
+                "ws",
+                "lh",
+                "Files/x",
+                b"data",
+                max_attempts=3,
+                backoff_seconds=0,
+            )
+        assert session.put.call_count == 3
+
+    def test_max_attempts_one_disables_retry(self):
+        session = MagicMock()
+        failing = MagicMock()
+        failing.raise_for_status.side_effect = _http_error(500)
+        session.put.return_value = failing
+        with (
+            patch("pyfabric.data.onelake._get_session", return_value=session),
+            pytest.raises(requests.HTTPError),
+        ):
+            upload_file(
+                "tok",
+                "ws",
+                "lh",
+                "Files/x",
+                b"data",
+                max_attempts=1,
+                backoff_seconds=0,
+            )
+        assert session.put.call_count == 1

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -2,7 +2,7 @@
 
 import logging
 
-from pyfabric._logging import (
+from pyfabric.logging import (
     AsciiFormatter,
     JsonLinesFormatter,
     TokenMaskingFilter,


### PR DESCRIPTION
## Summary

Three related additions from the MCG projections work, bundled per request.

### 1. Promote `pyfabric._logging` → `pyfabric.logging`
- Renames the module so callers use the public name.
- Stdlib `import logging` still resolves absolutely inside the module.
- Removes the module from the mypy `ignore_errors` override in `pyproject.toml` and fixes the two latent typing issues that surfaced once type-checked.

### 2. `pyfabric.data.processing_log.ProcessingLog`
- Generic watermark/audit table pattern on top of `LocalLakehouse`.
- Default schema: `source_path` (pk), `content_hash`, `status`, `rows_written`, `error_summary`, `processed_at`.
- Methods: `is_processed(source_path, *, content_hash=None)`, `record_success(...)`, `record_failure(...)`, `failures()`.
- Upsert via `DELETE` + `INSERT` in a txn (DuckDB DDL from `TableDef` doesn't emit a `PRIMARY KEY` so `ON CONFLICT` isn't an option without schema changes).
- Accepts a caller-provided `TableDef` as long as it has `source_path` (string pk) and `status` (string) columns.

### 3. Whole-operation retry in `onelake.upload_file` + schema-drift helpers
- `upload_file` gets `max_attempts` (default 3) and `backoff_seconds`. The session adapter already retries individual 429/503 responses; this handles the case where a later step in the 3-step DFS protocol (e.g. `flush`) fails transiently so the upload ends in a consistent state. 4xx (except 429) fails fast.
- `validate_duckdb_schema(table_def, conn, schema=None)` and `validate_arrow_schema(table_def, arrow_schema)` in `pyfabric.data.schema`. Return a list of discrepancies (missing column / extra column / type mismatch); empty list means the actual schema matches the definition.

## Tests

- 11 new tests for `ProcessingLog` (success/failure flow, upsert semantics, validation of custom `TableDef`, error truncation).
- 6 new tests for `upload_file` retry (first-attempt success, 5xx retry re-runs full protocol, 4xx fails fast, exhaustion, `max_attempts=1` disables retry).
- 12 new tests for schema validation across DuckDB and PyArrow backends.
- 10 existing logging tests pass against the renamed module.
- Full suite: **371 passed / 1 skipped** locally.

## Test plan

- [x] `pytest -q`
- [x] `ruff check` / `ruff format --check`
- [x] `mypy src`
- [x] Pre-push hook (pytest) green

🤖 Generated with [Claude Code](https://claude.com/claude-code)