### PR TITLE
Add install-claude-memory + emit-context CLI subcommands

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,38 @@ pip install pyfabric[testing]  # DuckDB Spark mock and pytest fixtures
 pip install pyfabric[all]      # All optional dependencies
 ```
 
+### AI assistant context (optional)
+
+pyfabric ships with reference memories so any AI coding assistant can learn
+the library without you re-explaining it every session. Two ways to install,
+depending on your assistant:
+
+**Claude Code** — one command, installs into your active Claude profile:
+
+```bash
+pyfabric install-claude-memory            # $CLAUDE_CONFIG_DIR/memory or ~/.claude/memory
+pyfabric install-claude-memory --dry-run  # show what would change
+pyfabric install-claude-memory --force    # overwrite locally-edited copies
+```
+
+Safe to re-run after upgrades — `MEMORY.md` is merged (never overwritten), and
+individual `.md` files are skipped unless `--force` is passed.
+
+**Any other assistant** — emit the memories as portable markdown and redirect
+to whatever file your tool reads:
+
+```bash
+pyfabric emit-context > .github/copilot-instructions.md   # GitHub Copilot
+pyfabric emit-context > .cursorrules                      # Cursor
+pyfabric emit-context > .continuerules                    # Continue
+pyfabric emit-context > CONVENTIONS.md                    # Aider
+```
+
+`emit-context` strips Claude-specific frontmatter and skips the index file,
+so the output is plain markdown any LLM can consume. Commit the generated
+file so teammates' assistants pick it up too, and re-run after upgrading
+pyfabric.
+
 ## Quick start
 
 ### Validate a Fabric workspace

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,6 +80,9 @@ version-file = "src/pyfabric/_version.py"
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/pyfabric"]
+# Non-.py files under src/pyfabric/ (e.g. claude_memory/*.md, py.typed) are
+# included automatically by hatchling. `pyfabric install-claude-memory`
+# relies on the claude_memory/ .md files shipping with the wheel.
 
 # -- Ruff ------------------------------------------------------------------
 

--- a/src/pyfabric/claude_install.py
+++ b/src/pyfabric/claude_install.py
@@ -1,0 +1,265 @@
+"""
+Install pyfabric's Claude reference memories into the user's active Claude
+profile (or the default profile if none is active).
+
+Exposed via the `pyfabric` CLI as:
+
+    pyfabric install-claude-memory [--target DIR] [--force] [--dry-run]
+
+Memory source lives inside the installed package at
+``pyfabric/claude_memory/*.md`` and ships with every PyPI release, so a
+`pip install --pre pyfabric` followed by `pyfabric install-claude-memory`
+is all a colleague needs to get Claude (or any Claude-compatible assistant
+that honours file-based memory) primed for pyfabric work.
+"""
+
+from __future__ import annotations
+
+import argparse
+import contextlib
+import os
+import re
+import shutil
+import sys
+from importlib import resources
+from pathlib import Path
+from typing import TextIO
+
+_MEMORY_PKG = "pyfabric.claude_memory"
+_INDEX_FILE = "MEMORY.md"
+_LINK_RX = re.compile(r"\(([^)]+\.md)\)")
+_FRONTMATTER_RX = re.compile(r"\A---\r?\n.*?\r?\n---\r?\n", re.DOTALL)
+
+
+def _default_memory_dir() -> Path:
+    """Resolve the Claude memory directory for the current shell.
+
+    Prefers ``$CLAUDE_CONFIG_DIR/memory`` (an active Claude Sessions profile),
+    otherwise falls back to ``~/.claude/memory`` (the default Claude config).
+    """
+    claude_cfg = os.environ.get("CLAUDE_CONFIG_DIR")
+    root = Path(claude_cfg) if claude_cfg else Path.home() / ".claude"
+    return root / "memory"
+
+
+def _iter_package_memory() -> list[tuple[str, str]]:
+    """Return (filename, content) for every .md file shipped under claude_memory/."""
+    out: list[tuple[str, str]] = []
+    pkg = resources.files(_MEMORY_PKG)
+    for entry in pkg.iterdir():
+        if not entry.is_file():
+            continue
+        if not entry.name.lower().endswith(".md"):
+            continue
+        out.append((entry.name, entry.read_text(encoding="utf-8")))
+    # Stable order: index first, then alphabetical
+    out.sort(key=lambda nc: (nc[0] != _INDEX_FILE, nc[0].lower()))
+    return out
+
+
+def _merge_memory_index(existing: str | None, additions: str) -> tuple[str, int]:
+    """Merge `additions` into an existing MEMORY.md without duplicating entries.
+
+    Entries are matched by the .md file name(s) they link to (``[text](file.md)``).
+    Returns (merged_content, newly_added_line_count).
+    """
+    existing = existing or ""
+    existing_lines = existing.splitlines()
+    seen: set[str] = set()
+    for line in existing_lines:
+        seen.update(_LINK_RX.findall(line))
+
+    new_lines: list[str] = []
+    for line in additions.splitlines():
+        links = _LINK_RX.findall(line)
+        if links and all(link in seen for link in links):
+            continue
+        if links:
+            new_lines.append(line)
+            seen.update(links)
+        # Non-entry lines (blank, header, etc.) are dropped — MEMORY.md is an
+        # index, and we don't want to duplicate headers or blank spacing.
+
+    if not new_lines:
+        return existing, 0
+
+    body = existing
+    if body and not body.endswith("\n"):
+        body += "\n"
+    body += "\n".join(new_lines) + "\n"
+    return body, len(new_lines)
+
+
+def install(
+    target: Path | None = None,
+    *,
+    force: bool = False,
+    dry_run: bool = False,
+    out: TextIO | None = None,
+) -> int:
+    """Install claude_memory/*.md into the target memory directory.
+
+    Returns a process exit code (0 success, non-zero on error).
+    """
+    out = out or sys.stdout
+    target = target or _default_memory_dir()
+    try:
+        memories = _iter_package_memory()
+    except ModuleNotFoundError:
+        print(
+            f"ERROR: package '{_MEMORY_PKG}' not found. "
+            f"Is pyfabric installed correctly?",
+            file=sys.stderr,
+        )
+        return 2
+
+    if not memories:
+        print(
+            "No claude_memory/*.md files bundled with this pyfabric install.",
+            file=out,
+        )
+        return 0
+
+    action = "[dry-run] would" if dry_run else ""
+    if not dry_run:
+        target.mkdir(parents=True, exist_ok=True)
+
+    copied = 0
+    merged_lines = 0
+    skipped = 0
+
+    for name, content in memories:
+        dest = target / name
+        if name == _INDEX_FILE:
+            existing = dest.read_text(encoding="utf-8") if dest.exists() else None
+            merged, added = _merge_memory_index(existing, content)
+            if added == 0:
+                print(f"  {name}: already up-to-date", file=out)
+                continue
+            print(f"  {name}: {action or 'merged'} {added} new entry line(s)", file=out)
+            if not dry_run:
+                dest.write_text(merged, encoding="utf-8")
+            merged_lines += added
+            continue
+
+        if dest.exists() and not force:
+            print(f"  {name}: already present (use --force to overwrite)", file=out)
+            skipped += 1
+            continue
+        print(f"  {name}: {action or 'installed'}", file=out)
+        if not dry_run:
+            shutil.copyfile(
+                str(resources.files(_MEMORY_PKG) / name),
+                str(dest),
+            )
+        copied += 1
+
+    print("", file=out)
+    print(f"Target  : {target}", file=out)
+    print(
+        f"Summary : {copied} copied, {skipped} skipped, "
+        f"{merged_lines} index line(s) merged" + (" (dry-run)" if dry_run else ""),
+        file=out,
+    )
+    if not os.environ.get("CLAUDE_CONFIG_DIR"):
+        print(
+            "Note    : no CLAUDE_CONFIG_DIR set — memories went to the default "
+            "~/.claude/. If you activate a profile later, re-run this command "
+            "to install them into that profile.",
+            file=out,
+        )
+    return 0
+
+
+def _strip_frontmatter(text: str) -> str:
+    return _FRONTMATTER_RX.sub("", text, count=1).lstrip()
+
+
+def emit_context(out: TextIO | None = None) -> int:
+    """Write concatenated, frontmatter-stripped memory bodies to ``out``.
+
+    Intended for piping into whatever file the user's AI assistant expects,
+    e.g.::
+
+        pyfabric emit-context > .github/copilot-instructions.md
+        pyfabric emit-context > .cursorrules
+
+    The MEMORY.md index is skipped — it's a pointer list that only makes
+    sense inside Claude's memory directory. Each included file is preceded
+    by an ``## <filename>`` heading so readers can see section boundaries.
+    """
+    if out is None:
+        # Default stdout on Windows is often cp1252, which chokes on the em-dashes
+        # and arrows in the memory files. Force UTF-8 so `> file.md` works everywhere.
+        reconfigure = getattr(sys.stdout, "reconfigure", None)
+        if reconfigure is not None:
+            with contextlib.suppress(OSError):
+                reconfigure(encoding="utf-8")
+        out = sys.stdout
+    try:
+        memories = _iter_package_memory()
+    except ModuleNotFoundError:
+        print(
+            f"ERROR: package '{_MEMORY_PKG}' not found. "
+            f"Is pyfabric installed correctly?",
+            file=sys.stderr,
+        )
+        return 2
+
+    body_files = [(n, c) for n, c in memories if n != _INDEX_FILE]
+    if not body_files:
+        print("No memory files bundled with this pyfabric install.", file=sys.stderr)
+        return 0
+
+    print(
+        "<!-- Generated by `pyfabric emit-context`. Safe to re-run; do not hand-edit — re-generate after upgrading pyfabric. -->",
+        file=out,
+    )
+    print("", file=out)
+    print("# pyfabric reference context", file=out)
+    print("", file=out)
+    for i, (name, content) in enumerate(body_files):
+        if i > 0:
+            print("", file=out)
+            print("---", file=out)
+            print("", file=out)
+        print(f"## {name}", file=out)
+        print("", file=out)
+        print(_strip_frontmatter(content).rstrip(), file=out)
+    return 0
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="pyfabric install-claude-memory",
+        description=(
+            "Install pyfabric's Claude reference memories into your active "
+            "Claude profile (or ~/.claude if no profile is active)."
+        ),
+    )
+    parser.add_argument(
+        "--target",
+        type=Path,
+        default=None,
+        help="Override target memory dir (default: $CLAUDE_CONFIG_DIR/memory or ~/.claude/memory)",
+    )
+    parser.add_argument(
+        "--force",
+        action="store_true",
+        help="Overwrite existing individual memory files (MEMORY.md is always merged, never overwritten)",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Show what would change without writing anything",
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    return install(target=args.target, force=args.force, dry_run=args.dry_run)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/pyfabric/claude_memory/MEMORY.md
+++ b/src/pyfabric/claude_memory/MEMORY.md
@@ -1,0 +1,1 @@
+- [pyfabric reference](pyfabric.md) — how to use pyfabric (auth, workspaces, lakehouse access) from Python in any repo

--- a/src/pyfabric/claude_memory/pyfabric.md
+++ b/src/pyfabric/claude_memory/pyfabric.md
@@ -1,0 +1,72 @@
+---
+name: pyfabric reference
+description: How to use the pyfabric Python library for Microsoft Fabric workspace CRUD, OneLake/DuckDB data access, and auth. Use when the user imports pyfabric or asks about Fabric workspaces, lakehouses, OneLake, or git-sync items.
+type: reference
+---
+
+**Package:** [pyfabric](https://pypi.org/project/pyfabric/) — Python library
+helping AI coding assistants create and locally validate Microsoft Fabric
+items compatible with Fabric git sync. Also provides workspace CRUD, OneLake
+access, and a pytest plugin.
+
+**Status:** beta (`0.1.0b*`). Always install with `--pre`:
+
+```bash
+pip install --pre pyfabric[all]
+```
+
+**Extras** (composable):
+- `azure` — `azure-identity`, `requests` (auth + HTTP)
+- `data` — `pyodbc`, `azure-storage-file-datalake` (OneLake DFS client)
+- `testing` — `duckdb`, `deltalake`, `pytest` (local lakehouse mirror +
+  pytest plugin exposed under `pyfabric.testing`)
+
+**Imports worth knowing:**
+
+```python
+from pyfabric.client.auth import FabricCredential   # az-identity wrapper
+from pyfabric.workspace import workspaces           # workspace CRUD
+from pyfabric.data import ...                       # OneLake / DuckDB helpers
+from pyfabric.cli import add_standard_args, run_main  # CLI script scaffolding
+```
+
+`pyfabric.cli.run_main(fn, parser)` is a standard wrapper: parses args, sets
+up structured logging, captures exceptions to a log file, prints one-line
+summary on failure. Use it for any new script — don't roll your own.
+
+**Auth model:** `FabricCredential` wraps `azure.identity.DefaultAzureCredential`
+(with `AzureCliCredential` first). Whichever tenant `az login` is signed into
+for the current shell is the tenant pyfabric talks to. Pass `tenant=` to
+`FabricCredential` to override.
+
+**Pitfalls:**
+- `pip install pyfabric` (without `--pre`) fails or resolves a stub while the
+  package is in beta.
+- If `az` isn't signed into the target tenant, pyfabric calls return 401/403.
+  Fix by signing into the right tenant in **this shell only** — don't
+  polluate other windows. If the environment provides per-window tenant
+  isolation (e.g. `AZURE_CONFIG_DIR` set per session), use that.
+- `pyfabric.testing.plugin` registers as a pytest11 entry point — if pytest
+  discovers it unexpectedly, verify you actually meant to install the
+  `testing` extra.
+- Lakehouse GUIDs are easiest to grab from the Fabric UI (Settings →
+  Identifier). Workspace GUIDs come from listing workspaces via pyfabric.
+
+**Common operations:**
+
+```python
+# List workspaces
+from pyfabric.workspace import workspaces
+for ws in workspaces.list(cred):
+    print(ws.id, ws.display_name)
+
+# Query a lakehouse table via OneLake + DuckDB
+from pyfabric.data import LocalLakehouse
+lh = LocalLakehouse(cred, workspace_id=WS, lakehouse_id=LH)
+df = lh.query("SELECT * FROM {table} LIMIT 10", table="customers")
+```
+
+**Further reading:**
+- PyPI: <https://pypi.org/project/pyfabric/>
+- Source: <https://github.com/Creative-Planning/pyfabric>
+- `pyfabric install-claude-memory --help` — refresh these memories after upgrading pyfabric

--- a/src/pyfabric/cli.py
+++ b/src/pyfabric/cli.py
@@ -150,10 +150,61 @@ def run_main(
         sys.exit(1)
 
 
-def main() -> int:
+def main(argv: list[str] | None = None) -> int:
     """Run the pyfabric command-line interface."""
-    print("pyfabric: no commands implemented yet")
-    return 0
+    argv = list(sys.argv[1:] if argv is None else argv)
+
+    # First positional arg is the subcommand. Keep dispatch dead-simple so
+    # each subcommand can own its own argparse instance (and --help text).
+    if not argv or argv[0] in ("-h", "--help"):
+        print(
+            "pyfabric — Microsoft Fabric helpers for Python\n"
+            "\n"
+            "Usage:\n"
+            "  pyfabric install-claude-memory [--target DIR] [--force] [--dry-run]\n"
+            "      Install pyfabric's reference memories into your active\n"
+            "      Claude profile (or ~/.claude if none is active).\n"
+            "\n"
+            "  pyfabric emit-context\n"
+            "      Print the memories as portable markdown (no Claude-specific\n"
+            "      frontmatter). Pipe into whatever file your AI assistant\n"
+            "      expects, e.g.:\n"
+            "        pyfabric emit-context > .github/copilot-instructions.md\n"
+            "        pyfabric emit-context > .cursorrules\n"
+            "\n"
+            "  pyfabric --help\n"
+            "      Show this help.\n"
+        )
+        return 0 if argv else 1
+
+    subcommand = argv[0]
+    rest = argv[1:]
+
+    if subcommand == "install-claude-memory":
+        from pyfabric.claude_install import main as install_main
+
+        return install_main(rest)
+
+    if subcommand == "emit-context":
+        from pyfabric.claude_install import emit_context
+
+        if rest and rest[0] in ("-h", "--help"):
+            print(
+                "pyfabric emit-context — print reference memories as portable "
+                "markdown.\n"
+                "\n"
+                "Redirect to whatever file your assistant reads:\n"
+                "  .github/copilot-instructions.md  (GitHub Copilot)\n"
+                "  .cursorrules                     (Cursor)\n"
+                "  .continuerules                   (Continue)\n"
+                "  CONVENTIONS.md                   (Aider)\n"
+            )
+            return 0
+        return emit_context()
+
+    print(f"pyfabric: unknown command '{subcommand}'", file=sys.stderr)
+    print("Run 'pyfabric --help' for available commands.", file=sys.stderr)
+    return 2
 
 
 if __name__ == "__main__":

--- a/tests/test_claude_install.py
+++ b/tests/test_claude_install.py
@@ -1,0 +1,118 @@
+"""Tests for pyfabric.claude_install — memory installer."""
+
+from __future__ import annotations
+
+import io
+from pathlib import Path
+
+from pyfabric.claude_install import (
+    _iter_package_memory,
+    _merge_memory_index,
+    _strip_frontmatter,
+    emit_context,
+    install,
+)
+
+
+class TestPackagedMemory:
+    def test_ships_index_and_pyfabric_md(self):
+        names = [n for n, _ in _iter_package_memory()]
+        assert "MEMORY.md" in names
+        assert "pyfabric.md" in names
+
+    def test_index_sorted_first(self):
+        names = [n for n, _ in _iter_package_memory()]
+        assert names[0] == "MEMORY.md"
+
+
+class TestMergeMemoryIndex:
+    def test_merge_into_empty(self):
+        merged, added = _merge_memory_index(None, "- [a](a.md) — desc\n")
+        assert "a.md" in merged
+        assert added == 1
+
+    def test_skips_duplicate_by_filename(self):
+        existing = "- [a](a.md) — desc\n"
+        additions = "- [a](a.md) — different text but same link\n"
+        merged, added = _merge_memory_index(existing, additions)
+        assert added == 0
+        assert merged == existing
+
+    def test_appends_new_entry_alongside_existing(self):
+        existing = "- [a](a.md) — first\n"
+        additions = "- [b](b.md) — second\n"
+        merged, added = _merge_memory_index(existing, additions)
+        assert added == 1
+        assert "a.md" in merged
+        assert "b.md" in merged
+
+    def test_drops_non_entry_noise(self):
+        # Blank lines and headers in additions should not make it through;
+        # MEMORY.md is a pure index.
+        additions = "\n# Heading\n\n- [c](c.md) — ok\n"
+        merged, added = _merge_memory_index("", additions)
+        assert added == 1
+        assert "Heading" not in merged
+
+
+class TestInstall:
+    def test_fresh_install(self, tmp_path: Path):
+        buf = io.StringIO()
+        rc = install(target=tmp_path, out=buf)
+        assert rc == 0
+        assert (tmp_path / "MEMORY.md").exists()
+        assert (tmp_path / "pyfabric.md").exists()
+        assert "pyfabric.md" in (tmp_path / "MEMORY.md").read_text()
+
+    def test_rerun_is_idempotent(self, tmp_path: Path):
+        install(target=tmp_path, out=io.StringIO())
+        first = (tmp_path / "pyfabric.md").read_text()
+
+        # Tamper with pyfabric.md — without --force it should NOT be overwritten
+        (tmp_path / "pyfabric.md").write_text("LOCAL EDITS\n")
+        buf = io.StringIO()
+        install(target=tmp_path, out=buf)
+        assert (tmp_path / "pyfabric.md").read_text() == "LOCAL EDITS\n"
+        assert "already present" in buf.getvalue()
+
+        # With --force, the package version wins
+        install(target=tmp_path, force=True, out=io.StringIO())
+        assert (tmp_path / "pyfabric.md").read_text() == first
+
+    def test_dry_run_writes_nothing(self, tmp_path: Path):
+        rc = install(target=tmp_path, dry_run=True, out=io.StringIO())
+        assert rc == 0
+        assert not (tmp_path / "MEMORY.md").exists()
+        assert not (tmp_path / "pyfabric.md").exists()
+
+    def test_strip_frontmatter(self):
+        text = "---\nname: X\ntype: reference\n---\n\nBody here.\n"
+        assert _strip_frontmatter(text) == "Body here.\n"
+
+        # No frontmatter: leave intact
+        plain = "Just body.\n"
+        assert _strip_frontmatter(plain) == plain
+
+    def test_emit_context_skips_index_and_strips_frontmatter(self):
+        buf = io.StringIO()
+        rc = emit_context(out=buf)
+        assert rc == 0
+        out = buf.getvalue()
+        assert "pyfabric reference context" in out
+        assert "## pyfabric.md" in out
+        assert "## MEMORY.md" not in out  # index excluded
+        assert "---\nname:" not in out  # frontmatter stripped
+
+    def test_merge_preserves_foreign_entries(self, tmp_path: Path):
+        (tmp_path).mkdir(parents=True, exist_ok=True)
+        (tmp_path / "MEMORY.md").write_text(
+            "- [other](other.md) -- installed by some other tool\n",
+            encoding="utf-8",
+        )
+        (tmp_path / "other.md").write_text("placeholder\n", encoding="utf-8")
+
+        install(target=tmp_path, out=io.StringIO())
+
+        idx = (tmp_path / "MEMORY.md").read_text()
+        assert "other.md" in idx  # foreign entry preserved
+        assert "pyfabric.md" in idx  # our entry added


### PR DESCRIPTION
## Summary

- Ships AI reference memories as package data under `src/pyfabric/claude_memory/` so `pip install pyfabric` brings them along.
- Adds `pyfabric install-claude-memory` — installs memories into an active Claude profile (`$CLAUDE_CONFIG_DIR/memory` or `~/.claude/memory`). Merge-aware MEMORY.md, idempotent, `--force` / `--dry-run`.
- Adds `pyfabric emit-context` — prints the memories as portable markdown (frontmatter stripped, index skipped) for piping into `.github/copilot-instructions.md`, `.cursorrules`, `CONVENTIONS.md`, etc. Forces UTF-8 on stdout so redirection works on Windows.
- Starter content: one `pyfabric.md` reference memory covering install, imports, auth model, common operations, and pitfalls.

## Test plan

- [x] `python -m pytest tests/test_claude_install.py tests/test_cli.py` — 18 passed
- [x] `ruff check` / `ruff format --check` — clean
- [x] `mypy src/pyfabric/claude_install.py` — clean
- [x] `python -m build --wheel` — verified claude_memory/*.md included in wheel
- [x] `pyfabric install-claude-memory` into a temp dir — fresh install, merge preserves foreign entries, re-run is idempotent, `--force` overwrites
- [x] `pyfabric emit-context > /tmp/ctx.md` — UTF-8 preserved (em-dashes intact), MEMORY.md excluded, frontmatter stripped
- [ ] After merge: run `pyfabric install-claude-memory` locally to seed each dev's Claude profile

🤖 Generated with [Claude Code](https://claude.com/claude-code)