### PR TITLE
fix(ci): upgrade pip before pip-audit to clear CVE-2026-1703 noise

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,6 +17,7 @@ jobs:
       - uses: actions/setup-python@v6
         with:
           python-version: "3.12"
+      - run: python -m pip install --upgrade pip
       - run: pip install build pip-audit
       - run: pip-audit
       - run: python -m build


### PR DESCRIPTION
## Summary

- Add `python -m pip install --upgrade pip` before the `pip-audit` step in the publish workflow.
- The hosted runner's bundled pip (25.3 at time of writing) is flagged for [CVE-2026-1703](https://github.com/advisories/GHSA-6vgw-5pg2-w6jp) (path traversal during malicious wheel extraction, CVSS 2.0 Low, fixed in pip 26.0).
- The workflow only installs `build` + `pip-audit` from the main PyPI index, so practical risk is zero — but pip-audit exits non-zero on any finding and would fail the build step, blocking any release until this is fixed.

Chose `--upgrade pip` over `pip-audit --ignore-vuln` because upgrading is standard CI hygiene and keeps the security gate intact for future advisories.

## Test plan

- [x] CI on the branch must pass (lint/format/type/test are unaffected; pre-push pytest already green locally).
- [ ] Merge to `main`, then cut `v0.1.0b4` release to verify the publish workflow reaches the `pypa/gh-action-pypi-publish` step without pip-audit failing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)