### PR TITLE
fix(claude-install): slug non-alphanumeric chars (dots, underscores)

### DIFF
--- a/src/pyfabric/claude_install.py
+++ b/src/pyfabric/claude_install.py
@@ -41,16 +41,14 @@ def _slugify_path(p: Path) -> str:
     """Convert an absolute path to the project-slug format Claude uses.
 
     Claude Code stores per-project state under ``<config>/projects/<slug>/``
-    where the slug is the absolute path with ``:``, ``\\``, and ``/``
-    replaced by ``-``. Examples:
+    where the slug is the absolute path with every non-alphanumeric
+    character (except ``-``) replaced by ``-`` — so not just separators,
+    but also ``.`` in user names and ``_`` in repo names. Examples:
 
-    - ``C:\\Users\\dave\\repo`` -> ``C--Users-dave-repo``
-    - ``/home/dave/repo``       -> ``-home-dave-repo``
+    - ``C:\\Users\\dave.catlett\\repos\\my_repo`` -> ``C--Users-dave-catlett-repos-my-repo``
+    - ``/home/dave/repo``                         -> ``-home-dave-repo``
     """
-    out = []
-    for ch in str(p.resolve()):
-        out.append("-" if ch in (":", "\\", "/") else ch)
-    return "".join(out)
+    return re.sub(r"[^A-Za-z0-9-]", "-", str(p.resolve()))
 
 
 def _find_project_root(start: Path) -> Path:

--- a/src/pyfabric/data/lakehouse.py
+++ b/src/pyfabric/data/lakehouse.py
@@ -113,6 +113,26 @@ def write_table(
     if mode not in ("overwrite", "append"):
         raise ValueError(f"Invalid mode '{mode}'. Use 'overwrite' or 'append'.")
 
+    # Naive (tz-less) timestamp columns become Delta TIMESTAMP_NTZ, which the
+    # Fabric SQL analytics endpoint rejects with "Columns of the specified
+    # data types are not supported". Warn once per write so callers can
+    # either add tz='UTC' to the Arrow schema or cast to string before
+    # writing. The warning is informational — the write still proceeds.
+    naive_ts_cols = [
+        f.name
+        for f in arrow_table.schema
+        if pa_mod.types.is_timestamp(f.type) and f.type.tz is None
+    ]
+    if naive_ts_cols:
+        log.warning(
+            "Naive timestamp columns %s will be written as Delta TIMESTAMP_NTZ, "
+            "which the Fabric SQL analytics endpoint does not support. Convert "
+            "to tz-aware UTC (e.g. pa.timestamp('us', tz='UTC')) or cast to "
+            "string (ISO-8601) before writing if downstream consumers use the "
+            "SQL endpoint or Power BI DirectLake.",
+            naive_ts_cols,
+        )
+
     if dry_run:
         log.info(
             "[DRY RUN] Would write %d rows to %s.%s (mode=%s)",

--- a/src/pyfabric/data/lakehouse.py
+++ b/src/pyfabric/data/lakehouse.py
@@ -83,13 +83,22 @@ def write_table(
     except ImportError:
         raise RuntimeError("pip install deltalake pyarrow") from None
 
-    import pandas as pd_mod
+    # pandas is only required when the caller passes a DataFrame — keep the
+    # import lazy so Arrow-only callers don't need pandas installed.
+    try:
+        import pandas as pd_mod
+    except ImportError:
+        pd_mod = None  # type: ignore[assignment]
 
     # Convert pandas to Arrow if needed
-    if isinstance(data, pd_mod.DataFrame):
+    if pd_mod is not None and isinstance(data, pd_mod.DataFrame):
         arrow_table = pa_mod.Table.from_pandas(data, preserve_index=False)
-    else:
+    elif isinstance(data, pa_mod.Table):
         arrow_table = data
+    else:
+        raise TypeError(
+            f"data must be a pyarrow.Table or pandas.DataFrame, got {type(data).__name__}"
+        )
 
     table_path = f"Tables/{schema}/{table_name}"
     target = abfss_url(ws_id, lh_id, table_path)
@@ -141,8 +150,15 @@ def write_table(
             table_name,
             mode,
         )
-        preview = arrow_table.slice(0, min(5, row_count)).to_pandas()
-        log.info("[DRY RUN] Preview:\n%s", preview.to_string(index=False))
+        preview_slice = arrow_table.slice(0, min(5, row_count))
+        if pd_mod is not None:
+            log.info(
+                "[DRY RUN] Preview:\n%s",
+                preview_slice.to_pandas().to_string(index=False),
+            )
+        else:
+            # Fall back to Arrow's own repr when pandas isn't installed.
+            log.info("[DRY RUN] Preview:\n%s", preview_slice)
         return WriteResult(
             table_path=table_path,
             row_count=row_count,

--- a/tests/data/test_lakehouse.py
+++ b/tests/data/test_lakehouse.py
@@ -96,3 +96,66 @@ class TestWriteTableTimestampNtzWarning:
         )
         events = self._run_write(tbl, fake_credential)
         assert not self._has_ntz_warning(events)
+
+
+class TestWriteTableWithoutPandas:
+    """Regression coverage for CI divergence: dev venvs typically have pandas
+    installed (transitively, via notebook tooling); the CI test env does not.
+    A test that passes locally but fails on CI because pandas is missing is
+    exactly the bug this locks in — so pre-checkin catches it before push.
+    """
+
+    def test_arrow_only_write_table_works_without_pandas(self, monkeypatch):
+        import builtins
+        import importlib
+        import sys
+
+        real_import = builtins.__import__
+
+        def blocked_import(name, *args, **kwargs):
+            if name == "pandas" or name.startswith("pandas."):
+                raise ImportError("simulated: pandas not installed")
+            return real_import(name, *args, **kwargs)
+
+        # Uncache pandas so the next import goes through blocked_import.
+        for mod in [
+            k for k in list(sys.modules) if k == "pandas" or k.startswith("pandas.")
+        ]:
+            monkeypatch.delitem(sys.modules, mod, raising=False)
+        monkeypatch.setattr(builtins, "__import__", blocked_import)
+
+        # Reload the module so its try/except import block re-runs without pandas.
+        from pyfabric.data import lakehouse as lh_mod
+
+        importlib.reload(lh_mod)
+
+        class _FakeCred:
+            storage_token = "fake-token"
+
+        tbl = pa.table(
+            {
+                "id": pa.array([1], type=pa.int64()),
+                "ts": pa.array(
+                    [datetime(2026, 4, 17, 10, 0, 0)], type=pa.timestamp("us")
+                ),
+            }
+        )
+
+        with structlog.testing.capture_logs() as events:
+            result = lh_mod.write_table(
+                _FakeCred(),
+                ws_id="00000000-0000-0000-0000-000000000000",
+                lh_id="00000000-0000-0000-0000-000000000000",
+                table_name="t",
+                data=tbl,
+                schema="dbo",
+                dry_run=True,
+            )
+
+        assert result.row_count == 1
+        assert result.dry_run is True
+        # Warning must still fire without pandas — it uses only pyarrow reflection.
+        assert any(
+            e.get("log_level") == "warning" and "TIMESTAMP_NTZ" in e.get("event", "")
+            for e in events
+        )

--- a/tests/data/test_lakehouse.py
+++ b/tests/data/test_lakehouse.py
@@ -1,0 +1,98 @@
+"""Tests for pyfabric.data.lakehouse.write_table."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import pyarrow as pa
+import pytest
+import structlog
+
+from pyfabric.data.lakehouse import write_table
+
+
+@pytest.fixture
+def fake_credential(monkeypatch):
+    """A FabricCredential whose storage_token property returns a fixed value."""
+
+    class _FakeCred:
+        storage_token = "fake-token"
+
+    return _FakeCred()
+
+
+class TestWriteTableTimestampNtzWarning:
+    """Fabric's SQL analytics endpoint rejects Delta TIMESTAMP_NTZ columns.
+    PyArrow timestamps without a tz map to TIMESTAMP_NTZ in Delta, so write_table
+    should warn when it sees one — giving callers a chance to add tz='UTC' or
+    cast to string before the write hits a downstream consumer that can't read it.
+    """
+
+    def _run_write(self, arrow_table: pa.Table, cred) -> list[dict]:
+        """Call write_table in dry_run mode and return the structlog events."""
+        with structlog.testing.capture_logs() as events:
+            write_table(
+                cred,
+                ws_id="00000000-0000-0000-0000-000000000000",
+                lh_id="00000000-0000-0000-0000-000000000000",
+                table_name="t",
+                data=arrow_table,
+                schema="dbo",
+                dry_run=True,
+            )
+        return events
+
+    def _has_ntz_warning(self, events: list[dict]) -> bool:
+        return any(
+            e.get("log_level") == "warning" and "TIMESTAMP_NTZ" in e.get("event", "")
+            for e in events
+        )
+
+    def test_naive_timestamp_emits_warning(self, fake_credential):
+        naive = [datetime(2026, 4, 17, 10, 0, 0), datetime(2026, 4, 17, 11, 0, 0)]
+        tbl = pa.table(
+            {
+                "id": pa.array([1, 2], type=pa.int64()),
+                "extracted_at": pa.array(naive, type=pa.timestamp("us")),
+            }
+        )
+        events = self._run_write(tbl, fake_credential)
+        assert self._has_ntz_warning(events)
+
+    def test_tz_aware_timestamp_does_not_warn(self, fake_credential):
+        utc = [
+            datetime(2026, 4, 17, 10, 0, 0, tzinfo=UTC),
+            datetime(2026, 4, 17, 11, 0, 0, tzinfo=UTC),
+        ]
+        tbl = pa.table(
+            {
+                "id": pa.array([1, 2], type=pa.int64()),
+                "extracted_at": pa.array(utc, type=pa.timestamp("us", tz="UTC")),
+            }
+        )
+        events = self._run_write(tbl, fake_credential)
+        assert not self._has_ntz_warning(events)
+
+    def test_no_timestamp_columns_does_not_warn(self, fake_credential):
+        tbl = pa.table(
+            {
+                "id": pa.array([1, 2], type=pa.int64()),
+                "name": pa.array(["a", "b"], type=pa.string()),
+            }
+        )
+        events = self._run_write(tbl, fake_credential)
+        assert not self._has_ntz_warning(events)
+
+    def test_string_column_named_extracted_at_does_not_warn(self, fake_credential):
+        # A column named 'extracted_at' but typed as string is fine — the warning
+        # must be type-driven, not name-driven.
+        tbl = pa.table(
+            {
+                "id": pa.array([1], type=pa.int64()),
+                "extracted_at": pa.array(
+                    ["2026-04-17T10:00:00+00:00"], type=pa.string()
+                ),
+            }
+        )
+        events = self._run_write(tbl, fake_credential)
+        assert not self._has_ntz_warning(events)

--- a/tests/test_claude_install.py
+++ b/tests/test_claude_install.py
@@ -123,16 +123,30 @@ class TestInstall:
 
 
 class TestPathSlug:
-    def test_slug_replaces_separators_and_colon(self, tmp_path: Path):
+    def test_slug_replaces_all_non_alnum_with_dash(self, tmp_path: Path):
         p = tmp_path / "repo"
         p.mkdir()
         slug = _slugify_path(p)
-        # Slug is the fully-resolved absolute path with : \ / -> -
+        # Slug is the fully-resolved absolute path with any non-alphanumeric
+        # character (except `-`) replaced by `-`.
         assert ":" not in slug
         assert "\\" not in slug
         assert "/" not in slug
         # Trailing component survives
         assert slug.endswith("-repo")
+        # Every char in the result is in the allowed set
+        assert all(c.isalnum() or c == "-" for c in slug)
+
+    def test_slug_replaces_dots_and_underscores(self, tmp_path: Path):
+        # Regression for v0.1.0b4: dotted usernames and underscored repo
+        # names were left un-slugified, so the install landed in a dir
+        # Claude never reads.
+        p = tmp_path / "my_repo.dir"
+        p.mkdir()
+        slug = _slugify_path(p)
+        assert "." not in slug
+        assert "_" not in slug
+        assert slug.endswith("-my-repo-dir")
 
     def test_find_project_root_walks_to_git(self, tmp_path: Path):
         root = tmp_path / "myrepo"


### PR DESCRIPTION
## Summary

Two unrelated `claude-install` / `write_table` fixes landing in the same PR:

---

### 1. `claude-install`: slug non-alphanumeric chars (dots, underscores)

v0.1.0b4's `_slugify_path` only replaced `:`, `\`, `/` with `-`. Claude Code's actual rule is broader — **every** non-alphanumeric character (except `-`) becomes `-`. So usernames with dots (`dave.catlett`) and repo names with underscores (`my_repo`) were slugified differently than Claude does.

Result: `pyfabric install-claude-memory --project PATH` wrote to a directory Claude never reads — same class of silent-ignore bug #26 addressed for the missing `projects/<slug>/memory` layer.

Empirically verified against existing project slugs under `<claude>/projects/`. E.g. `C:\Users\dave.catlett\source\repos\mgc\ws_creative_planning\` is stored as `C--Users-dave-catlett-source-repos-mgc-ws-creative-planning` (dots/underscores as dashes), not `C--Users-dave.catlett-source-repos-mgc-ws_creative_planning`.

**Fix:** one-regex replacement
```python
re.sub(r"[^A-Za-z0-9-]", "-", str(p.resolve()))
```

**Tests:**
- New test: `test_slug_replaces_all_non_alnum_with_dash` — invariant that every slug char is `[A-Za-z0-9-]`.
- New test: `test_slug_replaces_dots_and_underscores` — explicit regression: `my_repo.dir` → `-my-repo-dir`.

---

### 2. `write_table`: warn on naive timestamps (Delta `TIMESTAMP_NTZ`)

PyArrow timestamp columns without a timezone map to Delta `TIMESTAMP_NTZ`, which the Fabric SQL analytics endpoint rejects with `"Columns of the specified data types are not supported"`. Power BI DirectLake through the SQL endpoint hits the same error. Silent failure mode — the Delta write succeeds, the downstream query then can't read the column.

**Fix:** `write_table` now scans the Arrow schema once and logs a single warning listing the naive-timestamp column names, pointing at the two remedies (add `tz='UTC'` to the Arrow type, or cast to string ISO-8601). Write still proceeds — informational, not a hard failure, because callers targeting only Spark/pandas may legitimately use naive timestamps.

**Also:** made the `pandas` import in `write_table` lazy. It's only needed when the caller passes a DataFrame; Arrow-only callers no longer need pandas installed. Also gated the dry-run `.to_pandas()` preview behind the same check with an Arrow-repr fallback. This is what fixed the CI failures on the first push of this change (tests hit `ModuleNotFoundError: No module named 'pandas'` because pyfabric CI's test env doesn't install pandas).

**Tests:** new `tests/data/test_lakehouse.py` — first coverage of `write_table`. 4 cases:
- Naive `pa.timestamp('us')` → warning fires
- Tz-aware `pa.timestamp('us', tz='UTC')` → no warning
- No timestamp columns → no warning
- String column named `extracted_at` → no warning (type-driven, not name-driven)

---

## Test plan

- [x] Full local pre-checkin suite (ruff, ruff format, mypy, pytest, pip-audit) green on Python 3.14 venv.
- [x] Empirically confirmed slug behavior against real `<claude>/projects/` dirs.
- [x] Empirically confirmed TIMESTAMP_NTZ warning surfaces on an MCG projection PDF extraction pipeline; migration guide landed in project memory.
- [ ] CI green on Python 3.12 / 3.13 (currently re-running).
- [ ] Merge, cut `v0.1.0b5`, verify `install-claude-memory --project` + Arrow-only `write_table` callers both work from a clean install.

🤖 Generated with [Claude Code](https://claude.com/claude-code)