### PR TITLE
feat(items): byte normalization helpers + TMDL collision validator

### DIFF
--- a/src/pyfabric/items/normalize.py
+++ b/src/pyfabric/items/normalize.py
@@ -1,0 +1,282 @@
+"""Normalize Fabric artifact files to the byte format Fabric writes itself.
+
+Fabric's git-sync rewrites artifact files (`.platform`, `notebook-content.py`,
+every `*.tmdl`, `*.json`, `*.yml`, etc.) in its own canonical form every
+time a user opens or refreshes the item in the portal. The canonical
+form is **file-type specific** — discovered by inspecting Fabric-authored
+commits directly:
+
+| Path pattern                                  | Line endings | Trailing NL |
+|-----------------------------------------------|--------------|-------------|
+| ``*.Lakehouse/alm.settings.json``             | CRLF         | No          |
+| ``*.Environment/Setting/Sparkcompute.yml``    | CRLF         | Yes (CRLF)  |
+| ``*.Notebook/notebook-content.py``            | LF           | Yes (LF)    |
+| ``*.Notebook/notebook-content.sql``           | LF           | Yes (LF)    |
+| everything else in Fabric artifact folders    | LF           | No          |
+
+If committed bytes don't match this convention, every Fabric sync cycle
+flags the file as "changed by Fabric" and pushes a no-op edit back into
+git — a permanent flap. This module routes every artifact-folder write
+through ``write_artifact_file`` so callers can't accidentally produce
+the wrong bytes, and ``normalize_tree`` provides a one-shot fixer for
+existing repos.
+
+Usage::
+
+    from pyfabric.items.normalize import (
+        canonical_bytes,
+        is_canonical,
+        normalize_tree,
+        write_artifact_file,
+    )
+
+    # Write a single file the right way for its path:
+    write_artifact_file(
+        Path("ws/sm_x.SemanticModel/definition/model.tmdl"),
+        "model Model\\n\\tculture: en-US",
+    )
+
+    # Walk a tree and fix any drifted files:
+    result = normalize_tree(Path("ws/"))
+    print(f"Normalized {len(result.changed)} files")
+
+    # Or check-only (returns False without writing):
+    ok = is_canonical(Path("ws/sm_x.SemanticModel/definition/model.tmdl"))
+"""
+
+import fnmatch
+from collections.abc import Iterable
+from dataclasses import dataclass, field
+from pathlib import Path
+
+import structlog
+
+log = structlog.get_logger()
+
+
+# ── Public constants ────────────────────────────────────────────────────────
+
+#: UTF-8 byte-order mark — stripped from artifact files because Fabric never emits one.
+BOM = b"\xef\xbb\xbf"
+
+#: Path globs covering every Fabric artifact file type git-sync handles.
+#: Used by ``normalize_tree`` and ``lint_tree`` to enumerate files.
+#: Patterns are relative to a workspace root (the directory containing
+#: the ``*.{ItemType}`` folders).
+ARTIFACT_GLOBS: tuple[str, ...] = (
+    "*.Lakehouse/.platform",
+    "*.Lakehouse/*.json",
+    "*.Notebook/.platform",
+    "*.Notebook/notebook-content.py",
+    "*.Notebook/notebook-content.sql",
+    "*.Dataflow/.platform",
+    "*.Dataflow/*.json",
+    "*.Dataflow/*.pq",
+    "*.Environment/**/*",
+    "*.VariableLibrary/**/*",
+    "*.SemanticModel/.platform",
+    "*.SemanticModel/definition.pbism",
+    "*.SemanticModel/definition/**/*.tmdl",
+    "*.SemanticModel/definition/**/*.json",
+    "*.Report/.platform",
+    "*.Report/definition.pbir",
+    "*.Report/definition/**/*.json",
+    "*.Report/definition/**/*.pbir",
+)
+
+# File-type-specific rules. First match wins. Order matters.
+# Tuple shape: (path-glob, line-ending, trailing-newline-bool).
+_RULES: tuple[tuple[str, str, bool], ...] = (
+    # CRLF + no trailing newline
+    ("*.Lakehouse/alm.settings.json", "\r\n", False),
+    # CRLF + trailing CRLF
+    ("*.Environment/Setting/Sparkcompute.yml", "\r\n", True),
+    ("*.Environment/Setting/*.yml", "\r\n", True),  # future-proofing
+    # LF + trailing LF
+    ("*.Notebook/notebook-content.py", "\n", True),
+    ("*.Notebook/notebook-content.sql", "\n", True),
+    # LF + no trailing — default for everything else
+    ("*", "\n", False),
+)
+
+
+# ── Public types ────────────────────────────────────────────────────────────
+
+
+@dataclass(frozen=True)
+class FileRule:
+    """The byte convention applied to a single artifact file."""
+
+    line_ending: str  # "\n" or "\r\n"
+    trailing_newline: bool
+
+
+@dataclass
+class NormalizeResult:
+    """Summary of a ``normalize_tree`` (or ``lint_tree``) walk."""
+
+    root: Path
+    checked: list[Path] = field(default_factory=list)
+    changed: list[Path] = field(default_factory=list)
+    dry_run: bool = False
+
+    @property
+    def is_canonical(self) -> bool:
+        """True if every checked file already matched the canonical bytes."""
+        return len(self.changed) == 0
+
+
+# ── Public functions ────────────────────────────────────────────────────────
+
+
+def rule_for(rel_path: str) -> FileRule:
+    """Return the byte-convention rule that applies to ``rel_path``.
+
+    ``rel_path`` is the path relative to the workspace root, with forward
+    slashes. The first matching glob in ``_RULES`` wins; the catch-all
+    ``"*"`` ensures every artifact path resolves to a rule.
+    """
+    for pattern, eol, trailing in _RULES:
+        if fnmatch.fnmatch(rel_path, pattern):
+            return FileRule(line_ending=eol, trailing_newline=trailing)
+    # Defensive fallback — the catch-all in _RULES means we never reach here.
+    return FileRule(line_ending="\n", trailing_newline=False)
+
+
+def canonical_bytes(rel_path: str, raw: bytes) -> bytes:
+    """Return the canonical bytes Fabric would produce for this path.
+
+    Strips a UTF-8 BOM if present, normalizes line endings to the rule
+    for ``rel_path``, and adds or removes the trailing newline to match.
+    Binary files (those that fail UTF-8 decode) pass through unchanged.
+    """
+    if raw.startswith(BOM):
+        raw = raw[3:]
+    try:
+        text = raw.decode("utf-8")
+    except UnicodeDecodeError:
+        return raw
+    rule = rule_for(rel_path)
+    joined = rule.line_ending.join(text.splitlines())
+    if rule.trailing_newline:
+        joined += rule.line_ending
+    return joined.encode("utf-8")
+
+
+def write_artifact_file(
+    path: Path,
+    content: str | bytes,
+    *,
+    workspace_root: Path | None = None,
+) -> None:
+    """Write content to a Fabric artifact file in the canonical byte format.
+
+    Use this in place of ``Path.write_text`` / ``Path.write_bytes``
+    anywhere inside a Fabric artifact folder. The rule applied is
+    inferred from ``path``'s position relative to ``workspace_root``
+    (or its filename pattern alone if ``workspace_root`` is ``None``).
+
+    Args:
+        path: Destination path. Parent directories are created if missing.
+        content: File content. Strings are encoded as UTF-8 first; bytes
+            are processed as-is.
+        workspace_root: Root directory used to compute the relative path
+            for rule matching. If ``None``, ``path.name`` is used, which
+            is enough for most cases (the rules key off filename + nearest
+            ``*.{ItemType}`` ancestor).
+    """
+    raw = content.encode("utf-8") if isinstance(content, str) else content
+    rel = _relative_for_rule(path, workspace_root)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(canonical_bytes(rel, raw))
+
+
+def is_canonical(path: Path, *, workspace_root: Path | None = None) -> bool:
+    """Return True if ``path``'s bytes already match the canonical form."""
+    raw = path.read_bytes()
+    rel = _relative_for_rule(path, workspace_root)
+    return canonical_bytes(rel, raw) == raw
+
+
+def normalize_tree(
+    root: Path,
+    *,
+    dry_run: bool = False,
+    extra_globs: Iterable[str] | None = None,
+) -> NormalizeResult:
+    """Walk ``root`` and rewrite every artifact file to canonical bytes.
+
+    Idempotent. ``dry_run=True`` performs the same comparison without
+    writing — use it for a "would this commit be a no-op?" check (e.g. in
+    a pre-push hook). ``extra_globs`` lets callers register additional
+    artifact-path patterns beyond ``ARTIFACT_GLOBS``.
+
+    Returns a ``NormalizeResult`` listing every file that was checked
+    and every file that did (or would) change.
+    """
+    result = NormalizeResult(root=root, dry_run=dry_run)
+    globs = tuple(ARTIFACT_GLOBS) + tuple(extra_globs or ())
+    seen: set[Path] = set()
+    for pattern in globs:
+        for f in root.glob(pattern):
+            if not f.is_file() or f in seen:
+                continue
+            seen.add(f)
+            result.checked.append(f)
+            raw = f.read_bytes()
+            rel = _relative_with_fwdslash(f, root)
+            new = canonical_bytes(rel, raw)
+            if new != raw:
+                result.changed.append(f)
+                if not dry_run:
+                    f.write_bytes(new)
+    log.info(
+        "normalize_tree complete",
+        root=str(root),
+        checked=len(result.checked),
+        changed=len(result.changed),
+        dry_run=dry_run,
+    )
+    return result
+
+
+# ── Internals ───────────────────────────────────────────────────────────────
+
+
+def _relative_with_fwdslash(p: Path, root: Path) -> str:
+    """Return ``p`` relative to ``root`` with forward slashes (cross-platform)."""
+    return str(p.relative_to(root)).replace("\\", "/")
+
+
+def _relative_for_rule(path: Path, workspace_root: Path | None) -> str:
+    """Compute the path string used to look up a rule.
+
+    With a workspace root, returns the full relative path (forward slashes)
+    so globs anchored at ``*.{ItemType}/`` match. Without it, walks up
+    looking for the nearest ``*.{ItemType}`` ancestor and reconstructs a
+    relative path from there. Falls back to the bare filename if no such
+    ancestor exists — adequate for the catch-all ``"*"`` rule but means
+    file-type-specific rules (e.g. CRLF for ``alm.settings.json``) only
+    fire when an item folder is present in the path.
+    """
+    if workspace_root is not None:
+        return _relative_with_fwdslash(path, workspace_root)
+    for ancestor in path.parents:
+        if "." in ancestor.name and ancestor.name.split(".")[-1] in _ITEM_TYPES:
+            return _relative_with_fwdslash(path, ancestor.parent)
+    return path.name
+
+
+# Item-type suffixes recognized when walking up to find the workspace root.
+# Keep in sync with ``pyfabric.items.types.ITEM_TYPES`` keys.
+_ITEM_TYPES: frozenset[str] = frozenset(
+    {
+        "Lakehouse",
+        "Notebook",
+        "Dataflow",
+        "Environment",
+        "VariableLibrary",
+        "SemanticModel",
+        "Report",
+    }
+)

--- a/src/pyfabric/items/validate_tmdl.py
+++ b/src/pyfabric/items/validate_tmdl.py
@@ -1,0 +1,116 @@
+"""Lightweight TMDL checks for SemanticModel items.
+
+These catch the most common Fabric sync rejections that a folder-shape
+validator (``pyfabric.items.validate``) misses, without depending on a
+full TMDL parser. Today: measure-vs-column name collisions on the same
+table.
+
+Background: DAX identifiers within a table live in one flat namespace
+that is **case-insensitive** in the Analysis Services engine behind
+Fabric. TMDL parsers don't enforce the rule at save time, so a model
+with both ``measure 'Status'`` and ``column status`` on the same table
+saves cleanly locally — and then Fabric rejects the import with::
+
+    Dataset_Import_FailedToImportDataset: The 'Status' measure cannot
+    be created because a column with the same name already exists.
+
+The check here surfaces those collisions before push.
+
+Usage::
+
+    from pyfabric.items.validate_tmdl import check_name_collisions
+
+    issues = check_name_collisions(Path("ws/sm_x.SemanticModel"))
+    for issue in issues:
+        print(f"{issue.path.name}: {issue.message}")
+"""
+
+import re
+from dataclasses import dataclass
+from pathlib import Path
+
+# Match ``measure 'Foo Bar' = ...`` or ``measure FooBar = ...``.
+# TMDL allows quoted (single quote) or bare identifiers; bare ones must
+# match the standard identifier grammar (letter/underscore + word chars).
+_MEASURE_RE = re.compile(
+    r"""^\s*measure\s+
+        (?: '([^']+)'                       # 'quoted name' (group 1)
+          | ([A-Za-z_][A-Za-z0-9_]*)        # or bareIdentifier (group 2)
+        )
+        \s*=
+    """,
+    re.VERBOSE | re.MULTILINE,
+)
+
+# Match ``column 'Foo Bar'`` or ``column foo_bar``. Same identifier rules.
+_COLUMN_RE = re.compile(
+    r"""^\s*column\s+
+        (?: '([^']+)'
+          | ([A-Za-z_][A-Za-z0-9_]*)
+        )
+        \s*$
+    """,
+    re.VERBOSE | re.MULTILINE,
+)
+
+
+@dataclass(frozen=True)
+class TmdlIssue:
+    """A single collision (or other check failure) found in a TMDL file."""
+
+    path: Path
+    message: str
+
+
+def parse_table_identifiers(tmdl_text: str) -> tuple[set[str], set[str]]:
+    """Extract measure names and column names from one table's TMDL.
+
+    Returns ``(measure_names, column_names)``, both **case-insensitive**
+    (lower-cased). Strips surrounding quotes if present. Tolerates
+    indentation, leading whitespace, and quoted-or-bare identifiers as
+    TMDL allows.
+    """
+    measures: set[str] = set()
+    for m in _MEASURE_RE.finditer(tmdl_text):
+        name = (m.group(1) or m.group(2) or "").strip()
+        if name:
+            measures.add(name.lower())
+
+    columns: set[str] = set()
+    for m in _COLUMN_RE.finditer(tmdl_text):
+        name = (m.group(1) or m.group(2) or "").strip()
+        if name:
+            columns.add(name.lower())
+
+    return measures, columns
+
+
+def check_name_collisions(item_dir: Path) -> list[TmdlIssue]:
+    """Find measure-vs-column name collisions in every table TMDL under ``item_dir``.
+
+    ``item_dir`` should be the root of a ``*.SemanticModel`` folder; the
+    function looks for table TMDLs under ``definition/tables/*.tmdl``.
+    Returns one ``TmdlIssue`` per file that has at least one collision.
+    """
+    issues: list[TmdlIssue] = []
+    tables_dir = item_dir / "definition" / "tables"
+    if not tables_dir.is_dir():
+        return issues
+    for tmdl_path in sorted(tables_dir.glob("*.tmdl")):
+        text = tmdl_path.read_text(encoding="utf-8")
+        measures, columns = parse_table_identifiers(text)
+        clash = sorted(measures & columns)
+        if clash:
+            quoted = ", ".join(f"'{c}'" for c in clash)
+            issues.append(
+                TmdlIssue(
+                    path=tmdl_path,
+                    message=(
+                        f"measure/column name collision (case-insensitive): {quoted}. "
+                        "Fabric AS engine will reject the import. "
+                        "Rename the measure (e.g. add a '%' or '#' prefix/suffix) "
+                        "so it cannot collide with a column name."
+                    ),
+                )
+            )
+    return issues

--- a/tests/items/test_normalize.py
+++ b/tests/items/test_normalize.py
@@ -1,0 +1,191 @@
+"""Tests for byte normalization of Fabric artifact files."""
+
+from pathlib import Path
+
+import pytest
+
+from pyfabric.items.normalize import (
+    BOM,
+    canonical_bytes,
+    is_canonical,
+    normalize_tree,
+    rule_for,
+    write_artifact_file,
+)
+
+# ── rule_for ────────────────────────────────────────────────────────────────
+
+
+class TestRuleFor:
+    @pytest.mark.parametrize(
+        "rel_path, expected_eol, expected_trailing",
+        [
+            # CRLF + no trailing newline
+            ("lh.Lakehouse/alm.settings.json", "\r\n", False),
+            # CRLF + trailing CRLF
+            ("env.Environment/Setting/Sparkcompute.yml", "\r\n", True),
+            ("env.Environment/Setting/something.yml", "\r\n", True),
+            # LF + trailing LF
+            ("nb.Notebook/notebook-content.py", "\n", True),
+            ("nb.Notebook/notebook-content.sql", "\n", True),
+            # LF + no trailing — defaults
+            ("sm.SemanticModel/.platform", "\n", False),
+            ("sm.SemanticModel/definition.pbism", "\n", False),
+            ("sm.SemanticModel/definition/model.tmdl", "\n", False),
+            ("sm.SemanticModel/definition/tables/dim_x.tmdl", "\n", False),
+            ("rpt.Report/report.json", "\n", False),
+            ("any/random/file.txt", "\n", False),
+        ],
+    )
+    def test_rule_match(self, rel_path, expected_eol, expected_trailing):
+        rule = rule_for(rel_path)
+        assert rule.line_ending == expected_eol
+        assert rule.trailing_newline is expected_trailing
+
+
+# ── canonical_bytes ─────────────────────────────────────────────────────────
+
+
+class TestCanonicalBytes:
+    def test_lf_no_trailing_default(self):
+        # A SemanticModel TMDL with CRLF + trailing LF should drop both.
+        raw = b"model Model\r\n\tculture: en-US\r\n"
+        out = canonical_bytes("sm.SemanticModel/definition/model.tmdl", raw)
+        assert out == b"model Model\n\tculture: en-US"
+
+    def test_notebook_lf_with_trailing(self):
+        raw = b"# cell 1\r\nprint('hi')"  # missing trailing newline + CRLF
+        out = canonical_bytes("nb.Notebook/notebook-content.py", raw)
+        assert out == b"# cell 1\nprint('hi')\n"
+
+    def test_yml_crlf_with_trailing(self):
+        raw = b"key: value\nother: thing"  # LF + no trailing
+        out = canonical_bytes("env.Environment/Setting/Sparkcompute.yml", raw)
+        assert out == b"key: value\r\nother: thing\r\n"
+
+    def test_alm_settings_crlf_no_trailing(self):
+        raw = b'{"k": "v"}\r\n'
+        out = canonical_bytes("lh.Lakehouse/alm.settings.json", raw)
+        # CRLF preserved, trailing CRLF stripped
+        assert out == b'{"k": "v"}'
+
+    def test_strips_bom(self):
+        raw = BOM + b'{"a": 1}'
+        out = canonical_bytes("sm.SemanticModel/.platform", raw)
+        assert out == b'{"a": 1}'
+        assert not out.startswith(BOM)
+
+    def test_idempotent(self):
+        raw = b"line one\nline two"
+        once = canonical_bytes("sm.SemanticModel/definition/model.tmdl", raw)
+        twice = canonical_bytes("sm.SemanticModel/definition/model.tmdl", once)
+        assert once == twice
+
+    def test_binary_passthrough(self):
+        # PNG-ish bytes that aren't valid UTF-8
+        raw = b"\x89PNG\r\n\x1a\n\x00\x00\x00\rIHDR" + bytes(range(255))
+        out = canonical_bytes("rpt.Report/StaticResources/img.png", raw)
+        assert out == raw
+
+    def test_handles_mixed_line_endings(self):
+        # \r\n and \n in the same file
+        raw = b"a\r\nb\nc\r\n"
+        out = canonical_bytes("sm.SemanticModel/definition/model.tmdl", raw)
+        assert out == b"a\nb\nc"
+
+
+# ── write_artifact_file ────────────────────────────────────────────────────
+
+
+class TestWriteArtifactFile:
+    def test_writes_with_workspace_root(self, tmp_path: Path):
+        ws = tmp_path / "ws"
+        nb = ws / "x.Notebook" / "notebook-content.py"
+        write_artifact_file(nb, "# header\nprint('x')", workspace_root=ws)
+        # Expect LF line endings + trailing LF
+        assert nb.read_bytes() == b"# header\nprint('x')\n"
+
+    def test_writes_without_workspace_root_uses_ancestor(self, tmp_path: Path):
+        sm = tmp_path / "sm.SemanticModel" / "definition" / "model.tmdl"
+        write_artifact_file(sm, "model M\r\n\tculture: en-US\r\n")
+        # LF, no trailing newline
+        assert sm.read_bytes() == b"model M\n\tculture: en-US"
+
+    def test_creates_parent_dirs(self, tmp_path: Path):
+        deep = tmp_path / "sm.SemanticModel" / "definition" / "tables" / "x.tmdl"
+        assert not deep.parent.exists()
+        write_artifact_file(deep, "table x")
+        assert deep.exists()
+
+    def test_accepts_bytes(self, tmp_path: Path):
+        f = tmp_path / "sm.SemanticModel" / "definition" / "model.tmdl"
+        write_artifact_file(f, b"model M\r\n")
+        assert f.read_bytes() == b"model M"
+
+
+# ── is_canonical ────────────────────────────────────────────────────────────
+
+
+class TestIsCanonical:
+    def test_canonical_file_returns_true(self, tmp_path: Path):
+        f = tmp_path / "sm.SemanticModel" / "definition" / "model.tmdl"
+        write_artifact_file(f, "model M")
+        assert is_canonical(f) is True
+
+    def test_drifted_file_returns_false(self, tmp_path: Path):
+        sm_dir = tmp_path / "sm.SemanticModel" / "definition"
+        sm_dir.mkdir(parents=True)
+        f = sm_dir / "model.tmdl"
+        # CRLF + trailing newline — wrong for TMDL
+        f.write_bytes(b"model M\r\nculture: en-US\r\n")
+        assert is_canonical(f) is False
+
+
+# ── normalize_tree ──────────────────────────────────────────────────────────
+
+
+class TestNormalizeTree:
+    def test_fixes_drifted_files(self, tmp_path: Path):
+        sm = tmp_path / "sm.SemanticModel"
+        (sm / "definition").mkdir(parents=True)
+        (sm / ".platform").write_bytes(b'{"k": "v"}\r\n')
+        (sm / "definition" / "model.tmdl").write_bytes(b"model M\r\n")
+        result = normalize_tree(tmp_path)
+        assert len(result.changed) == 2
+        assert (sm / ".platform").read_bytes() == b'{"k": "v"}'
+        assert (sm / "definition" / "model.tmdl").read_bytes() == b"model M"
+
+    def test_dry_run_does_not_write(self, tmp_path: Path):
+        sm = tmp_path / "sm.SemanticModel" / "definition"
+        sm.mkdir(parents=True)
+        (sm / "model.tmdl").write_bytes(b"model M\r\n")
+        result = normalize_tree(tmp_path, dry_run=True)
+        assert len(result.changed) == 1
+        # File still drifted because dry_run skipped the write
+        assert (sm / "model.tmdl").read_bytes() == b"model M\r\n"
+        assert result.dry_run is True
+
+    def test_idempotent(self, tmp_path: Path):
+        sm = tmp_path / "sm.SemanticModel" / "definition"
+        sm.mkdir(parents=True)
+        (sm / "model.tmdl").write_bytes(b"model M\r\n")
+        normalize_tree(tmp_path)  # first pass — fixes
+        result = normalize_tree(tmp_path)  # second pass — no changes
+        assert result.is_canonical
+        assert len(result.changed) == 0
+
+    def test_skips_non_artifact_files(self, tmp_path: Path):
+        # A README in the workspace root shouldn't be touched
+        (tmp_path / "README.md").write_bytes(b"# title\r\n")
+        result = normalize_tree(tmp_path)
+        assert (tmp_path / "README.md").read_bytes() == b"# title\r\n"
+        assert len(result.changed) == 0
+
+    def test_extra_globs(self, tmp_path: Path):
+        # Caller can register extra path patterns
+        custom = tmp_path / "custom.dir" / "file.txt"
+        custom.parent.mkdir()
+        custom.write_bytes(b"hello\r\n")
+        result = normalize_tree(tmp_path, extra_globs=["custom.dir/*.txt"])
+        assert custom in result.changed
+        assert custom.read_bytes() == b"hello"

--- a/tests/items/test_validate_tmdl.py
+++ b/tests/items/test_validate_tmdl.py
@@ -1,0 +1,129 @@
+"""Tests for TMDL-specific validation (name collisions etc.)."""
+
+from pathlib import Path
+
+from pyfabric.items.validate_tmdl import (
+    check_name_collisions,
+    parse_table_identifiers,
+)
+
+
+def _write_table(item_dir: Path, name: str, body: str) -> Path:
+    tables = item_dir / "definition" / "tables"
+    tables.mkdir(parents=True, exist_ok=True)
+    p = tables / f"{name}.tmdl"
+    p.write_text(body, encoding="utf-8")
+    return p
+
+
+# ── parse_table_identifiers ─────────────────────────────────────────────────
+
+
+class TestParseTableIdentifiers:
+    def test_quoted_measure_and_bare_column(self):
+        body = (
+            "table fact_x\n"
+            "\tmeasure 'Coverage Status' = SELECTEDVALUE(...)\n"
+            "\tcolumn status\n"
+        )
+        measures, columns = parse_table_identifiers(body)
+        assert measures == {"coverage status"}
+        assert columns == {"status"}
+
+    def test_special_chars_in_measure_names(self):
+        body = (
+            "table f\n"
+            "\tmeasure '# PDFs OK' =\n"
+            "\t\tCALCULATE(...)\n"
+            "\tmeasure 'Detection %' = SELECTEDVALUE(...)\n"
+        )
+        measures, _ = parse_table_identifiers(body)
+        assert measures == {"# pdfs ok", "detection %"}
+
+    def test_bare_measure_identifier(self):
+        body = "table x\n\tmeasure CountFoo = COUNTROWS(x)\n"
+        measures, _ = parse_table_identifiers(body)
+        assert measures == {"countfoo"}
+
+    def test_quoted_column(self):
+        body = "table x\n\tcolumn 'Display Name'\n"
+        _, columns = parse_table_identifiers(body)
+        assert columns == {"display name"}
+
+    def test_case_insensitive(self):
+        body = "table x\n\tmeasure 'Status' = ...\n\tcolumn STATUS\n"
+        measures, columns = parse_table_identifiers(body)
+        assert measures == {"status"}
+        assert columns == {"status"}
+        assert measures & columns == {"status"}
+
+    def test_empty_table(self):
+        measures, columns = parse_table_identifiers("table empty\n")
+        assert measures == set()
+        assert columns == set()
+
+
+# ── check_name_collisions ──────────────────────────────────────────────────
+
+
+class TestCheckNameCollisions:
+    def test_no_collisions_returns_empty(self, tmp_path: Path):
+        item = tmp_path / "sm.SemanticModel"
+        _write_table(
+            item,
+            "fact_x",
+            "table fact_x\n\tmeasure 'Coverage Status' = ...\n\tcolumn status\n",
+        )
+        assert check_name_collisions(item) == []
+
+    def test_detects_case_insensitive_clash(self, tmp_path: Path):
+        item = tmp_path / "sm.SemanticModel"
+        path = _write_table(
+            item,
+            "fact_x",
+            "table fact_x\n\tmeasure 'Status' = SELECTEDVALUE(...)\n\tcolumn status\n",
+        )
+        issues = check_name_collisions(item)
+        assert len(issues) == 1
+        assert issues[0].path == path
+        assert "'status'" in issues[0].message
+        assert "case-insensitive" in issues[0].message
+
+    def test_multiple_collisions_in_one_file(self, tmp_path: Path):
+        item = tmp_path / "sm.SemanticModel"
+        _write_table(
+            item,
+            "fact_x",
+            "table f\n"
+            "\tmeasure 'Status' = ...\n"
+            "\tmeasure 'Region' = ...\n"
+            "\tcolumn status\n"
+            "\tcolumn region\n",
+        )
+        issues = check_name_collisions(item)
+        assert len(issues) == 1
+        # Both names present in the message
+        assert "'status'" in issues[0].message
+        assert "'region'" in issues[0].message
+
+    def test_separate_files_reported_separately(self, tmp_path: Path):
+        item = tmp_path / "sm.SemanticModel"
+        _write_table(item, "f1", "table f1\n\tmeasure 'A' = 1\n\tcolumn a\n")
+        _write_table(item, "f2", "table f2\n\tmeasure 'B' = 1\n\tcolumn b\n")
+        issues = check_name_collisions(item)
+        assert len(issues) == 2
+        names = {i.path.name for i in issues}
+        assert names == {"f1.tmdl", "f2.tmdl"}
+
+    def test_no_tables_dir_returns_empty(self, tmp_path: Path):
+        item = tmp_path / "sm.SemanticModel"
+        item.mkdir()
+        # No definition/tables/ subdir
+        assert check_name_collisions(item) == []
+
+    def test_collision_between_tables_does_not_fire(self, tmp_path: Path):
+        # Same name on different tables is allowed; only same-table collisions reject.
+        item = tmp_path / "sm.SemanticModel"
+        _write_table(item, "f1", "table f1\n\tmeasure 'Status' = 1\n")
+        _write_table(item, "f2", "table f2\n\tcolumn status\n")
+        assert check_name_collisions(item) == []


### PR DESCRIPTION
## Summary

Two related additions for callers building Fabric SemanticModel and Report items by hand. Foundation for upcoming SemanticModel and Report builders — every future writer will route through ``write_artifact_file``.

### \`pyfabric.items.normalize\`

Fabric writes artifact files in a per-file-type byte convention. Anything else triggers permanent sync flap because Fabric "fixes" the file on every refresh.

| Path                                       | Line endings | Trailing NL |
|--------------------------------------------|--------------|-------------|
| \`*.Lakehouse/alm.settings.json\`            | CRLF         | No          |
| \`*.Environment/Setting/Sparkcompute.yml\`   | CRLF         | Yes (CRLF)  |
| \`*.Notebook/notebook-content.py\` / \`.sql\` | LF           | Yes (LF)    |
| everything else                            | LF           | No          |

API:
- \`canonical_bytes(rel_path, raw)\` — return what Fabric would write
- \`write_artifact_file(path, content)\` — atomic correct-by-construction write
- \`is_canonical(path)\` — single-file check
- \`normalize_tree(root, dry_run=...)\` — repo-wide fixer / lint mode
- \`rule_for(rel_path) -> FileRule\` — public access to the rule table
- \`ARTIFACT_GLOBS\` — extensible path patterns

### \`pyfabric.items.validate_tmdl\`

Adds case-insensitive measure-vs-column name collision check — the most common Fabric AS-engine import rejection that the existing structural validator can't catch (it surfaces as \`Dataset_Import_FailedToImportDataset: The 'X' measure cannot be created because a column with the same name already exists\`).

API:
- \`parse_table_identifiers(tmdl_text) -> (measures, columns)\`
- \`check_name_collisions(item_dir) -> list[TmdlIssue]\`

## Test plan

- [x] 42 new tests passing (rule matching, BOM stripping, idempotence, binary passthrough, dry-run, special-char identifiers, between-table vs same-table collisions)
- [x] Full suite: 439 passed, 1 skipped (the e2e workspace test that needs a live Fabric env)
- [x] \`ruff check\` / \`ruff format --check\` / \`mypy --strict\` clean
- [x] Pre-push hook (full pytest) clean

## Discovery context

Both checks come from real downstream incidents observed while hand-authoring SemanticModel and Notebook items:
- A multi-hour debug session over byte normalization: a hand-written notebook write produced LF when Fabric wanted CRLF on \`Sparkcompute.yml\`, and a follow-up "fix" went the wrong direction (CRLF for everything), causing 10 items to flap. Final correct rule table is the per-file-type one above.
- A SemanticModel \`Status\` measure collided with a \`status\` column on the same table; the import rejected at sync time. A pure regex check would have caught it pre-push.