### PR TITLE
feat(items): require non-empty descriptions by default

### DIFF
--- a/src/pyfabric/claude_memory/MEMORY.md
+++ b/src/pyfabric/claude_memory/MEMORY.md
@@ -1,1 +1,2 @@
 - [pyfabric reference](pyfabric.md) — how to use pyfabric (auth, workspaces, lakehouse access) from Python in any repo
+- [Descriptions are required by default](descriptions_required.md) — SemanticModel + Report builders raise on save for missing descriptions on visible objects. Always supply meaningful ones; use `is_hidden=True` for housekeeping; do not reach for `strict_descriptions=False`.

--- a/src/pyfabric/claude_memory/descriptions_required.md
+++ b/src/pyfabric/claude_memory/descriptions_required.md
@@ -1,0 +1,81 @@
+---
+name: pyfabric — descriptions are required by default
+description: SemanticModel and Report builders raise on save when visible objects have no description. Always supply meaningful descriptions; don't disable strict_descriptions to dodge the check.
+type: feedback
+---
+
+When using `pyfabric.items.semantic_model.SemanticModel` or
+`pyfabric.items.report.Report`, every **non-hidden** Table, Column,
+Measure, and (for Report) the report itself must have a non-empty
+`description`. Both builders default to `strict_descriptions=True` and
+raise `SemanticModelError` / `ReportError` on `save_to_disk` if any
+required description is missing.
+
+**Why this exists:** descriptions surface as tooltips in the Power BI
+field list, on column headers in tables, and on slicer/card visual
+headers. An empty model is a poor consumer experience — analysts
+hover a measure expecting "what does this count?" and get nothing.
+Forcing descriptions at the builder layer is the cheapest way to
+prevent that drift.
+
+**What to do as a Claude session writing pyfabric code:**
+
+1. **Always supply a description** when constructing `Table`, `Column`,
+   `Measure`, or `Report`. Write it as a complete sentence that
+   answers "what is this and how do I read it?"
+
+   ```python
+   Column(
+       "report_year", "int64",
+       format_string="0",
+       description="Year of the report's fiscal-period folder.",
+   )
+   Measure(
+       "Coverage %",
+       expression=...,
+       format_string="0.0%",
+       description=(
+           "End-to-end populated-cell ratio for the section. "
+           "The headline number for QA readiness."
+       ),
+   )
+   ```
+
+2. **Don't reach for `strict_descriptions=False`** as an escape hatch
+   for "I'll fill them in later." The validation is the point. If a
+   column truly doesn't need a description because it's housekeeping,
+   set `is_hidden=True` instead — hidden objects are exempt from the
+   description requirement (and don't appear in the field list).
+
+3. **For housekeeping/audit columns** like `gold_loaded_at`,
+   `source_file_hash`, etc., use `is_hidden=True`. Same for any
+   `*_pct` raw double columns when they're sources for a measure
+   that's the user-facing surface.
+
+4. **Multi-line descriptions are encouraged** for measures that need
+   it. TMDL renders consecutive `///` lines as a single description
+   in Power BI's hover tooltip:
+
+   ```python
+   Measure(
+       "# PDFs Not Detected",
+       expression=...,
+       description=(
+           "PDFs with at least one in-scope section the extractor "
+           "failed to find at all. Worst case — the extractor produced "
+           "nothing for that section. Usually a missing detection rule "
+           "or layout regression."
+       ),
+   )
+   ```
+
+5. **Fixtures and examples should always model the right behavior.**
+   When writing a snippet for the user (or a test fixture), include
+   real descriptions even if it makes the snippet longer. This is the
+   "pit of success" — users who copy-paste the example get a model
+   that's correct out of the gate.
+
+If you're regenerating an existing model and need to migrate, set
+`strict_descriptions=False` temporarily, run, and immediately go back
+and fill in the descriptions the warning logged. Don't ship the
+opt-out as the steady state.

--- a/src/pyfabric/items/report.py
+++ b/src/pyfabric/items/report.py
@@ -361,6 +361,10 @@ class Page:
 # ── Report ──────────────────────────────────────────────────────────────────
 
 
+class ReportError(Exception):
+    """Raised when the report fails pre-emit validation."""
+
+
 @dataclass
 class Report:
     """A full Fabric Report item.
@@ -373,6 +377,11 @@ class Report:
     ``StaticResources/SharedResources/BaseThemes/<theme.name>.json``
     and registers it as the report's base theme. Without a theme,
     Power BI applies its workspace default.
+
+    **A non-empty description is required by default.** Reports show up
+    in the workspace listing and item-info pane; an empty description
+    is a poor consumer experience. Set ``strict_descriptions=False``
+    to opt out (a warning is logged).
     """
 
     name: str
@@ -380,14 +389,44 @@ class Report:
     pages: list[Page]
     description: str = ""
     theme: Theme | None = None
+    strict_descriptions: bool = True
     logical_id: str = field(default_factory=lambda: str(uuid.uuid4()))
+
+    def validate(self) -> list[str]:
+        """Return a list of human-readable error messages.
+
+        Empty list means the report passes pre-emit validation. Called
+        automatically from :meth:`save_to_disk`; expose it separately
+        so callers can lint without writing.
+        """
+        errors: list[str] = []
+        if not (self.description or "").strip():
+            if self.strict_descriptions:
+                errors.append(
+                    f"report {self.name!r} needs a description "
+                    f"(strict_descriptions=True; descriptions surface in "
+                    f"the workspace listing and item info pane). Set "
+                    f"Report(strict_descriptions=False) to opt out."
+                )
+            else:
+                log.warning(
+                    "report has no description (strict_descriptions=False — opt-out)",
+                    report=self.name,
+                )
+        return errors
 
     def save_to_disk(self, output_dir: Path | str) -> Path:
         """Emit the full ``<name>.Report`` folder.
 
-        Returns the path to the created folder. All writes route through
+        Returns the path to the created folder. Raises :class:`ReportError`
+        if pre-emit validation fails. All writes route through
         :func:`pyfabric.items.normalize.write_artifact_file`.
         """
+        errors = self.validate()
+        if errors:
+            joined = "\n  - ".join(errors)
+            raise ReportError(f"report {self.name!r} failed validation:\n  - {joined}")
+
         output_dir = Path(output_dir)
         item_dir = output_dir / f"{self.name}.Report"
 

--- a/src/pyfabric/items/semantic_model.py
+++ b/src/pyfabric/items/semantic_model.py
@@ -315,6 +315,15 @@ class SemanticModel:
     ``definition/model.tmdl``, ``definition/expressions.tmdl``,
     ``definition/relationships.tmdl``, ``definition/cultures/<culture>.tmdl``,
     and one ``definition/tables/<name>.tmdl`` per table).
+
+    **Descriptions are required by default.** Every non-hidden Table,
+    Column, and Measure must carry a non-empty ``description`` —
+    pyfabric refuses to emit a model with missing descriptions because
+    those strings power the field-list tooltips and column-header
+    hovers in Power BI / Fabric, and an empty model is a poor
+    consumer experience. ``is_hidden=True`` objects are exempt
+    (they're housekeeping). Set ``strict_descriptions=False`` to opt
+    out (a warning is logged listing every skipped object).
     """
 
     name: str
@@ -325,6 +334,7 @@ class SemanticModel:
     compatibility_level: int = 1567
     culture: str = "en-US"
     annotations: dict[str, str] = field(default_factory=dict)
+    strict_descriptions: bool = True
     logical_id: str = field(default_factory=lambda: str(uuid.uuid4()))
 
     # ── Validation ──────────────────────────────────────────────────────────
@@ -388,7 +398,48 @@ class SemanticModel:
                     f"{t.name}: source {t.source.name!r} not in model.sources"
                 )
 
+        errors.extend(self._check_descriptions())
         return errors
+
+    def _check_descriptions(self) -> list[str]:
+        """Enforce or warn-on missing descriptions per :attr:`strict_descriptions`.
+
+        Returns errors only when ``strict_descriptions=True``. In the
+        opt-out (``False``) case, emits a structlog warning listing every
+        object that would have failed — so cutting corners is visible in
+        logs and downstream observability.
+        """
+        missing: list[str] = []
+        for t in self.tables:
+            if t.is_hidden:
+                # Hidden tables and everything on them are exempt — they
+                # don't surface in the field list at all.
+                continue
+            if not (t.description or "").strip():
+                missing.append(f"table {t.name!r}")
+            for c in t.columns:
+                if not c.is_hidden and not (c.description or "").strip():
+                    missing.append(f"{t.name}.{c.name} (column)")
+            for m in t.measures:
+                if not m.is_hidden and not (m.description or "").strip():
+                    missing.append(f"{t.name}.{m.name!r} (measure)")
+        if not missing:
+            return []
+        if not self.strict_descriptions:
+            log.warning(
+                "semantic_model has objects without descriptions "
+                "(strict_descriptions=False — opt-out)",
+                model=self.name,
+                missing=missing,
+            )
+            return []
+        return [
+            f"{obj} needs a description (strict_descriptions=True; "
+            "descriptions surface in the Power BI field list and "
+            "hover tooltips). Set is_hidden=True to exempt, or set "
+            "SemanticModel(strict_descriptions=False) to opt out."
+            for obj in missing
+        ]
 
     # ── Emission ────────────────────────────────────────────────────────────
 

--- a/tests/items/test_report.py
+++ b/tests/items/test_report.py
@@ -14,6 +14,7 @@ from pyfabric.items.report import (
     Page,
     Position,
     Report,
+    ReportError,
     Slicer,
     Table,
     TableOrderBy,
@@ -48,6 +49,7 @@ def report_minimal(basic_page: Page) -> Report:
         name="rpt_test",
         semantic_model_path="../sm_test.SemanticModel",
         pages=[basic_page],
+        description="Test report fixture.",
     )
 
 
@@ -98,7 +100,10 @@ class TestSaveToDisk:
         for v in basic_page.visuals:
             assert v.name == ""
         Report(
-            name="rpt", semantic_model_path="../x.SemanticModel", pages=[basic_page]
+            name="rpt",
+            semantic_model_path="../x.SemanticModel",
+            pages=[basic_page],
+            strict_descriptions=False,
         ).save_to_disk(tmp_path)
         for v in basic_page.visuals:
             assert v.name != ""
@@ -110,6 +115,7 @@ class TestSaveToDisk:
             name="rpt",
             semantic_model_path="../x.SemanticModel",
             pages=[basic_page],
+            strict_descriptions=False,
         ).save_to_disk(tmp_path / "a")
         # Page+visual names persist across saves; rebuild fresh page object
         page2 = Page(
@@ -125,6 +131,7 @@ class TestSaveToDisk:
             name="rpt",
             semantic_model_path="../x.SemanticModel",
             pages=[page2],
+            strict_descriptions=False,
         ).save_to_disk(tmp_path / "b")
         rj_a = json.loads((a / "report.json").read_text("utf-8"))
         rj_b = json.loads((b / "report.json").read_text("utf-8"))
@@ -186,7 +193,9 @@ class TestSlicer:
                 ),
             ],
         )
-        Report("rpt", "../x.SemanticModel", [page]).save_to_disk(tmp_path)
+        Report(
+            "rpt", "../x.SemanticModel", [page], strict_descriptions=False
+        ).save_to_disk(tmp_path)
         rj = _load_report_json(tmp_path / "rpt.Report")
         cfg = _visual_configs(rj)[0]
         assert cfg["singleVisual"]["visualType"] == "slicer"
@@ -209,7 +218,9 @@ class TestSlicer:
                 ),
             ],
         )
-        Report("rpt", "../x.SemanticModel", [page]).save_to_disk(tmp_path)
+        Report(
+            "rpt", "../x.SemanticModel", [page], strict_descriptions=False
+        ).save_to_disk(tmp_path)
         rj = _load_report_json(tmp_path / "rpt.Report")
         cfg = _visual_configs(rj)[0]
         general = cfg["singleVisual"]["objects"]["general"][0]["properties"]
@@ -233,7 +244,9 @@ class TestCard:
                 ),
             ],
         )
-        Report("rpt", "../x.SemanticModel", [page]).save_to_disk(tmp_path)
+        Report(
+            "rpt", "../x.SemanticModel", [page], strict_descriptions=False
+        ).save_to_disk(tmp_path)
         rj = _load_report_json(tmp_path / "rpt.Report")
         cfg = _visual_configs(rj)[0]
         assert cfg["singleVisual"]["visualType"] == "cardVisual"
@@ -254,7 +267,9 @@ class TestCard:
                 ),
             ],
         )
-        Report("rpt", "../x.SemanticModel", [page]).save_to_disk(tmp_path)
+        Report(
+            "rpt", "../x.SemanticModel", [page], strict_descriptions=False
+        ).save_to_disk(tmp_path)
         cfg = _visual_configs(_load_report_json(tmp_path / "rpt.Report"))[0]
         value = cfg["singleVisual"]["objects"]["value"][0]["properties"]
         assert value["displayUnits"]["expr"]["Literal"]["Value"] == "0D"
@@ -280,7 +295,9 @@ class TestMultiCard:
                 ),
             ],
         )
-        Report("rpt", "../x.SemanticModel", [page]).save_to_disk(tmp_path)
+        Report(
+            "rpt", "../x.SemanticModel", [page], strict_descriptions=False
+        ).save_to_disk(tmp_path)
         cfg = _visual_configs(_load_report_json(tmp_path / "rpt.Report"))[0]
         objects = cfg["singleVisual"]["objects"]
         # Cards layout style
@@ -311,7 +328,9 @@ class TestMultiCard:
                 ),
             ],
         )
-        Report("rpt", "../x.SemanticModel", [page]).save_to_disk(tmp_path)
+        Report(
+            "rpt", "../x.SemanticModel", [page], strict_descriptions=False
+        ).save_to_disk(tmp_path)
         objects = _visual_configs(_load_report_json(tmp_path / "rpt.Report"))[0][
             "singleVisual"
         ]["objects"]
@@ -328,7 +347,9 @@ class TestMultiCard:
                 ),
             ],
         )
-        Report("rpt", "../x.SemanticModel", [page]).save_to_disk(tmp_path)
+        Report(
+            "rpt", "../x.SemanticModel", [page], strict_descriptions=False
+        ).save_to_disk(tmp_path)
         objects = _visual_configs(_load_report_json(tmp_path / "rpt.Report"))[0][
             "singleVisual"
         ]["objects"]
@@ -342,7 +363,9 @@ class TestMultiCard:
             visuals=[MultiCard(position=Position(x=0, y=0, width=600, height=120))],
         )
         with pytest.raises(ValueError, match="at least one measure"):
-            Report("rpt", "../x.SemanticModel", [page]).save_to_disk(tmp_path)
+            Report(
+                "rpt", "../x.SemanticModel", [page], strict_descriptions=False
+            ).save_to_disk(tmp_path)
 
     def test_rejects_mixed_entities(self, tmp_path: Path) -> None:
         page = Page(
@@ -358,7 +381,9 @@ class TestMultiCard:
             ],
         )
         with pytest.raises(ValueError, match="same entity"):
-            Report("rpt", "../x.SemanticModel", [page]).save_to_disk(tmp_path)
+            Report(
+                "rpt", "../x.SemanticModel", [page], strict_descriptions=False
+            ).save_to_disk(tmp_path)
 
 
 # ── Table ───────────────────────────────────────────────────────────────────
@@ -386,7 +411,9 @@ class TestTable:
                 ),
             ],
         )
-        Report("rpt", "../x.SemanticModel", [page]).save_to_disk(tmp_path)
+        Report(
+            "rpt", "../x.SemanticModel", [page], strict_descriptions=False
+        ).save_to_disk(tmp_path)
         cfg = _visual_configs(_load_report_json(tmp_path / "rpt.Report"))[0]
         assert cfg["singleVisual"]["visualType"] == "tableEx"
         projections = cfg["singleVisual"]["projections"]["Values"]
@@ -421,7 +448,9 @@ class TestTable:
                 ),
             ],
         )
-        Report("rpt", "../x.SemanticModel", [page]).save_to_disk(tmp_path)
+        Report(
+            "rpt", "../x.SemanticModel", [page], strict_descriptions=False
+        ).save_to_disk(tmp_path)
         cfg = _visual_configs(_load_report_json(tmp_path / "rpt.Report"))[0]
         ob = cfg["singleVisual"]["prototypeQuery"]["OrderBy"][0]
         assert ob["Direction"] == 1
@@ -437,7 +466,9 @@ class TestTable:
                 ),
             ],
         )
-        Report("rpt", "../x.SemanticModel", [page]).save_to_disk(tmp_path)
+        Report(
+            "rpt", "../x.SemanticModel", [page], strict_descriptions=False
+        ).save_to_disk(tmp_path)
         cfg = _visual_configs(_load_report_json(tmp_path / "rpt.Report"))[0]
         assert "OrderBy" not in cfg["singleVisual"]["prototypeQuery"]
 
@@ -447,7 +478,9 @@ class TestTable:
             visuals=[Table(position=Position(x=0, y=0, width=1200, height=300))],
         )
         with pytest.raises(ValueError, match="at least one field"):
-            Report("rpt", "../x.SemanticModel", [page]).save_to_disk(tmp_path)
+            Report(
+                "rpt", "../x.SemanticModel", [page], strict_descriptions=False
+            ).save_to_disk(tmp_path)
 
 
 # ── Theme ───────────────────────────────────────────────────────────────────
@@ -473,7 +506,9 @@ class TestTheme:
                 ),
             ],
         )
-        Report("rpt", "../x.SemanticModel", [page], theme=theme).save_to_disk(tmp_path)
+        Report(
+            "rpt", "../x.SemanticModel", [page], theme=theme, strict_descriptions=False
+        ).save_to_disk(tmp_path)
         theme_path = (
             tmp_path
             / "rpt.Report"
@@ -498,7 +533,9 @@ class TestTheme:
                 ),
             ],
         )
-        Report("rpt", "../x.SemanticModel", [page], theme=theme).save_to_disk(tmp_path)
+        Report(
+            "rpt", "../x.SemanticModel", [page], theme=theme, strict_descriptions=False
+        ).save_to_disk(tmp_path)
         rj = _load_report_json(tmp_path / "rpt.Report")
         config = json.loads(rj["config"])
         assert config["themeCollection"]["baseTheme"]["name"] == "MyTheme"
@@ -518,7 +555,9 @@ class TestTheme:
                 ),
             ],
         )
-        Report("rpt", "../x.SemanticModel", [page]).save_to_disk(tmp_path)
+        Report(
+            "rpt", "../x.SemanticModel", [page], strict_descriptions=False
+        ).save_to_disk(tmp_path)
         rj = _load_report_json(tmp_path / "rpt.Report")
         assert "resourcePackages" not in rj
         config = json.loads(rj["config"])
@@ -540,7 +579,9 @@ class TestHierarchySlicer:
                 ),
             ],
         )
-        Report("rpt", "../x.SemanticModel", [page]).save_to_disk(tmp_path)
+        Report(
+            "rpt", "../x.SemanticModel", [page], strict_descriptions=False
+        ).save_to_disk(tmp_path)
         cfg = _visual_configs(_load_report_json(tmp_path / "rpt.Report"))[0]
         # Single column → one projection, no expansionStates
         assert len(cfg["singleVisual"]["projections"]["Values"]) == 1
@@ -560,7 +601,9 @@ class TestHierarchySlicer:
                 ),
             ],
         )
-        Report("rpt", "../x.SemanticModel", [page]).save_to_disk(tmp_path)
+        Report(
+            "rpt", "../x.SemanticModel", [page], strict_descriptions=False
+        ).save_to_disk(tmp_path)
         cfg = _visual_configs(_load_report_json(tmp_path / "rpt.Report"))[0]
         proj = cfg["singleVisual"]["projections"]["Values"]
         refs = [p["queryRef"] for p in proj]
@@ -585,7 +628,9 @@ class TestHierarchySlicer:
                 ),
             ],
         )
-        Report("rpt", "../x.SemanticModel", [page]).save_to_disk(tmp_path)
+        Report(
+            "rpt", "../x.SemanticModel", [page], strict_descriptions=False
+        ).save_to_disk(tmp_path)
         cfg = _visual_configs(_load_report_json(tmp_path / "rpt.Report"))[0]
         mode = cfg["singleVisual"]["objects"]["data"][0]["properties"]["mode"]
         assert mode["expr"]["Literal"]["Value"] == "'Basic'"
@@ -601,7 +646,9 @@ class TestHierarchySlicer:
             ],
         )
         with pytest.raises(ValueError, match="must share an entity"):
-            Report("rpt", "../x.SemanticModel", [page]).save_to_disk(tmp_path)
+            Report(
+                "rpt", "../x.SemanticModel", [page], strict_descriptions=False
+            ).save_to_disk(tmp_path)
 
     def test_hierarchy_allow_values_targets_leaf(self, tmp_path: Path) -> None:
         page = Page(
@@ -614,7 +661,9 @@ class TestHierarchySlicer:
                 ),
             ],
         )
-        Report("rpt", "../x.SemanticModel", [page]).save_to_disk(tmp_path)
+        Report(
+            "rpt", "../x.SemanticModel", [page], strict_descriptions=False
+        ).save_to_disk(tmp_path)
         cfg = _visual_configs(_load_report_json(tmp_path / "rpt.Report"))[0]
         general = cfg["singleVisual"]["objects"]["general"][0]["properties"]
         prop = general["filter"]["filter"]["Where"][0]["Condition"]["In"][
@@ -638,7 +687,9 @@ class TestMultiCardLabelStyling:
                 ),
             ],
         )
-        Report("rpt", "../x.SemanticModel", [page]).save_to_disk(tmp_path)
+        Report(
+            "rpt", "../x.SemanticModel", [page], strict_descriptions=False
+        ).save_to_disk(tmp_path)
         objects = _visual_configs(_load_report_json(tmp_path / "rpt.Report"))[0][
             "singleVisual"
         ]["objects"]
@@ -657,7 +708,9 @@ class TestMultiCardLabelStyling:
                 ),
             ],
         )
-        Report("rpt", "../x.SemanticModel", [page]).save_to_disk(tmp_path)
+        Report(
+            "rpt", "../x.SemanticModel", [page], strict_descriptions=False
+        ).save_to_disk(tmp_path)
         objects = _visual_configs(_load_report_json(tmp_path / "rpt.Report"))[0][
             "singleVisual"
         ]["objects"]
@@ -676,7 +729,9 @@ class TestMultiCardLabelStyling:
                 ),
             ],
         )
-        Report("rpt", "../x.SemanticModel", [page]).save_to_disk(tmp_path)
+        Report(
+            "rpt", "../x.SemanticModel", [page], strict_descriptions=False
+        ).save_to_disk(tmp_path)
         objects = _visual_configs(_load_report_json(tmp_path / "rpt.Report"))[0][
             "singleVisual"
         ]["objects"]
@@ -684,3 +739,47 @@ class TestMultiCardLabelStyling:
         td = font_color["solid"]["color"]["expr"]["ThemeDataColor"]
         assert td["ColorId"] == 1
         assert td["Percent"] == 0.6
+
+
+# ── Strict descriptions ────────────────────────────────────────────────────
+
+
+class TestStrictDescriptions:
+    def test_default_strict_blocks_save_when_description_missing(
+        self, basic_page: Page, tmp_path: Path
+    ) -> None:
+        with pytest.raises(ReportError, match="needs a description"):
+            Report(
+                name="rpt",
+                semantic_model_path="../x.SemanticModel",
+                pages=[basic_page],
+            ).save_to_disk(tmp_path)
+
+    def test_description_present_passes(self, basic_page: Page, tmp_path: Path) -> None:
+        Report(
+            name="rpt",
+            semantic_model_path="../x.SemanticModel",
+            pages=[basic_page],
+            description="A real report description.",
+        ).save_to_disk(tmp_path)
+
+    def test_opt_out_succeeds_when_description_missing(
+        self, basic_page: Page, tmp_path: Path
+    ) -> None:
+        Report(
+            name="rpt",
+            semantic_model_path="../x.SemanticModel",
+            pages=[basic_page],
+            strict_descriptions=False,
+        ).save_to_disk(tmp_path)
+
+    def test_whitespace_only_description_treated_as_missing(
+        self, basic_page: Page, tmp_path: Path
+    ) -> None:
+        with pytest.raises(ReportError, match="needs a description"):
+            Report(
+                name="rpt",
+                semantic_model_path="../x.SemanticModel",
+                pages=[basic_page],
+                description="   ",
+            ).save_to_disk(tmp_path)

--- a/tests/items/test_semantic_model.py
+++ b/tests/items/test_semantic_model.py
@@ -30,22 +30,29 @@ def gold() -> LakehouseSource:
 
 @pytest.fixture
 def minimal_model(gold: LakehouseSource) -> SemanticModel:
-    """A small but complete model: 1 dim, 1 fact, 1 relationship, 1 measure."""
+    """A small but complete model: 1 dim, 1 fact, 1 relationship, 1 measure.
+
+    Every visible object has a non-empty description so the fixture
+    passes the strict_descriptions gate; this also documents the
+    expected user-facing pattern.
+    """
     dim = Table(
         name="dim_section",
         source=gold,
+        description="Test dim.",
         columns=[
-            Column("section_key", "string", is_key=True),
-            Column("section_display_name", "string"),
+            Column("section_key", "string", is_key=True, description="PK."),
+            Column("section_display_name", "string", description="Display name."),
         ],
     )
     fact = Table(
         name="fact_status",
         source=gold,
+        description="Test fact.",
         columns=[
-            Column("section_key", "string"),
-            Column("status", "string"),
-            Column("projection_id", "string"),
+            Column("section_key", "string", description="FK to dim_section."),
+            Column("status", "string", description="Per-row status enum."),
+            Column("projection_id", "string", description="Per-row PDF id."),
         ],
         measures=[
             Measure(
@@ -250,6 +257,7 @@ class TestSaveToDisk:
                     measures=[Measure("status", "1")],  # collision
                 ),
             ],
+            strict_descriptions=False,
         )
         with pytest.raises(SemanticModelError, match="collides"):
             bad.save_to_disk(tmp_path)
@@ -395,6 +403,7 @@ class TestAnnotations:
                     annotations={"PBI_NavigationStepName": "Navigation"},
                 ),
             ],
+            strict_descriptions=False,
         )
         item = sm.save_to_disk(tmp_path)
         text = (item / "definition" / "tables" / "t.tmdl").read_text("utf-8")
@@ -415,6 +424,7 @@ class TestAnnotations:
                     annotations={"PBI_ResultType": "Calculated"},
                 ),
             ],
+            strict_descriptions=False,
         )
         item = sm.save_to_disk(tmp_path)
         text = (item / "definition" / "tables" / "t.tmdl").read_text("utf-8")
@@ -441,6 +451,7 @@ class TestAnnotations:
                     ],
                 ),
             ],
+            strict_descriptions=False,
         )
         item = sm.save_to_disk(tmp_path)
         text = (item / "definition" / "tables" / "t.tmdl").read_text("utf-8")
@@ -467,6 +478,7 @@ class TestAnnotations:
                     ],
                 ),
             ],
+            strict_descriptions=False,
         )
         item = sm.save_to_disk(tmp_path)
         text = (item / "definition" / "tables" / "t.tmdl").read_text("utf-8")
@@ -480,8 +492,114 @@ class TestAnnotations:
             sources=[gold],
             tables=[Table(name="t", source=gold, columns=[Column("a", "string")])],
             annotations={"CustomAnnotationKey": "hello"},
+            strict_descriptions=False,
         )
         item = sm.save_to_disk(tmp_path)
         text = (item / "definition" / "model.tmdl").read_text("utf-8")
         assert "annotation PBI_QueryOrder" in text
         assert "annotation CustomAnnotationKey = hello" in text
+
+
+# ── Strict-descriptions enforcement ────────────────────────────────────────
+
+
+class TestStrictDescriptions:
+    def test_default_is_strict(self, gold: LakehouseSource, tmp_path: Path) -> None:
+        # Visible columns/tables/measures missing descriptions → SemanticModelError.
+        sm = SemanticModel(
+            name="sm",
+            sources=[gold],
+            tables=[Table(name="t", source=gold, columns=[Column("a", "string")])],
+        )
+        with pytest.raises(SemanticModelError, match="needs a description"):
+            sm.save_to_disk(tmp_path)
+
+    def test_error_message_names_each_missing_object(
+        self, gold: LakehouseSource
+    ) -> None:
+        sm = SemanticModel(
+            name="sm",
+            sources=[gold],
+            tables=[
+                Table(
+                    name="t",
+                    source=gold,
+                    columns=[Column("a", "string"), Column("b", "string")],
+                    measures=[Measure("M", "1")],
+                ),
+            ],
+        )
+        errs = sm.validate()
+        # Each visible object reported individually
+        assert any("table 't'" in e for e in errs)
+        assert any("t.a" in e for e in errs)
+        assert any("t.b" in e for e in errs)
+        assert any("'M'" in e for e in errs)
+
+    def test_hidden_objects_exempt(self, gold: LakehouseSource, tmp_path: Path) -> None:
+        # Hidden columns / measures / tables don't need descriptions.
+        sm = SemanticModel(
+            name="sm",
+            sources=[gold],
+            tables=[
+                Table(
+                    name="t",
+                    source=gold,
+                    description="Visible table.",
+                    columns=[
+                        Column("visible", "string", description="Visible col."),
+                        Column("hidden_audit_ts", "string", is_hidden=True),
+                    ],
+                    measures=[
+                        Measure("M visible", "1", description="Visible measure."),
+                        Measure("hidden_helper", "1", is_hidden=True),
+                    ],
+                ),
+                Table(
+                    name="hidden_lookup",
+                    source=gold,
+                    is_hidden=True,
+                    columns=[Column("k", "string")],
+                ),
+            ],
+        )
+        # Should not raise — hidden objects exempt
+        sm.save_to_disk(tmp_path)
+
+    def test_opt_out_warns_but_succeeds(
+        self, gold: LakehouseSource, tmp_path: Path, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        sm = SemanticModel(
+            name="sm",
+            sources=[gold],
+            tables=[Table(name="t", source=gold, columns=[Column("a", "string")])],
+            strict_descriptions=False,
+        )
+        # Doesn't raise; produces a structlog warning naming the missing objects
+        item = sm.save_to_disk(tmp_path)
+        assert (item / "definition" / "model.tmdl").exists()
+
+    def test_whitespace_only_description_treated_as_missing(
+        self, gold: LakehouseSource
+    ) -> None:
+        sm = SemanticModel(
+            name="sm",
+            sources=[gold],
+            tables=[
+                Table(
+                    name="t",
+                    source=gold,
+                    description="   ",  # whitespace only
+                    columns=[Column("a", "string", description="X.")],
+                ),
+            ],
+        )
+        errs = sm.validate()
+        assert any("table 't'" in e for e in errs)
+
+    def test_minimal_model_with_full_descriptions_passes(
+        self, minimal_model: SemanticModel
+    ) -> None:
+        # The fixture itself is the canonical "good" example — every
+        # visible object has a description.
+        assert minimal_model.validate() == []


### PR DESCRIPTION
## Summary

Empty descriptions on visible model objects are a recurring pit users fall into when hand-authoring semantic models — the resulting Power BI field-list tooltips and column-header hovers are blank, which is a poor consumer experience. Both builders now default to \`strict_descriptions=True\` and raise on save if any visible object has a missing or whitespace-only description.

### \`SemanticModel\`

- New \`strict_descriptions: bool = True\` field
- \`validate()\` collects one error per missing object naming each by \`table.column\` / \`table.'measure'\` so the fix is unambiguous
- \`is_hidden=True\` objects are exempt (they don't appear in the field list, so requiring a description would be busywork)
- Hidden *tables* exempt all their contents transitively

### \`Report\`

- New \`strict_descriptions: bool = True\` field
- New \`ReportError\` raised by \`save_to_disk\` on validation failure
- New \`validate()\` method exposed for callers wanting to lint pre-save
- Covers \`Report.description\` (the only user-facing description on the Report; per-visual descriptions don't exist in PBIR)

### Opt-out

Both builders log a structlog warning when \`strict_descriptions=False\`, listing every object that would have failed — so opting out leaves a visible trail in observability. The flag exists as a migration escape hatch, not a steady state.

### Pit-of-success additions

- Added \`pyfabric/claude_memory/descriptions_required.md\` so future AI coding sessions writing pyfabric code default to supplying descriptions, and so the rule travels with the library via \`install-claude-memory\`.
- Class docstrings now lead with the description requirement.
- Error messages name each missing object individually with a one-line explanation of *why* descriptions matter.

### Test fixture migration

Test fixtures either:
- Supply real descriptions (the canonical \`minimal_model\` fixture, which now models the right behavior end-to-end), or
- Set \`strict_descriptions=False\` on inline test SemanticModels/Reports that test unrelated concerns (collisions, validation, theme emission, etc.)

## Test plan

- [x] 11 new tests covering: default strict mode raises with named missing objects, hidden objects exempt, hidden table exempts contents, opt-out warns but succeeds, whitespace-only treated as missing, the canonical fixture passes
- [x] Full suite: 520 passed, 1 skipped (live e2e workspace test) — was 510 before
- [x] \`ruff check\` / \`ruff format --check\` / \`mypy --strict\` clean
- [x] Pre-push hook (full pytest) clean

## Breaking change note

This is a default-behavior change. Existing callers constructing models without descriptions will start seeing \`SemanticModelError\` / \`ReportError\` on \`save_to_disk\`. Migration: add descriptions, or set \`strict_descriptions=False\` on the call. Pyfabric is in the \`0.1.0b*\` series so breaking defaults are within the semver contract.