### PR TITLE
onelake.walk: manual recursion — DFS recursive flag is shallow on deep paths

### DIFF
--- a/src/pyfabric/data/onelake.py
+++ b/src/pyfabric/data/onelake.py
@@ -152,20 +152,39 @@ def walk(
         Dicts with at least ``name`` (DFS-native path), ``rel_path``
         (path relative to item_id), ``size`` (int bytes), plus any other
         fields returned by the DFS API.
+
+    Implementation note: iterates with ``recursive=False`` and descends
+    manually rather than passing ``recursive=True`` to :func:`list_paths`.
+    DFS's recursive flag on OneLake returns the filesystem root fully
+    recursively but goes shallow when the request path is a deep
+    subdirectory (observed: a request for
+    ``Files/.../2026/04 - April 2026`` returns only the 4 region
+    folders, never descending further, even though the same DFS call
+    with ``path="Files"`` returns 70k+ entries). Manual recursion
+    works uniformly at any depth.
     """
     prefix = f"{item_id}/"
-    for entry in list_paths(token, ws_id, item_id, path, recursive=True):
-        if entry.get("isDirectory", "false") == "true":
-            continue
-        name = entry.get("name", "")
-        if suffix and not name.endswith(suffix):
-            continue
-        rel_path = name[len(prefix) :] if name.startswith(prefix) else name
-        yield {
-            **entry,
-            "rel_path": rel_path,
-            "size": int(entry.get("contentLength", 0)),
-        }
+    stack: list[str] = [path]
+    while stack:
+        current = stack.pop()
+        for entry in list_paths(token, ws_id, item_id, current, recursive=False):
+            name = entry.get("name", "")
+            is_dir = entry.get("isDirectory", "false") == "true"
+            # Directory names from DFS come back prefixed with the
+            # lakehouse item_id; strip for the next request.
+            next_path = (
+                name[len(prefix) :] if name.startswith(prefix) else name.lstrip("/")
+            )
+            if is_dir:
+                stack.append(next_path)
+                continue
+            if suffix and not name.endswith(suffix):
+                continue
+            yield {
+                **entry,
+                "rel_path": next_path,
+                "size": int(entry.get("contentLength", 0)),
+            }
 
 
 # ── Hash utility ─────────────────────────────────────────────────────────────

--- a/src/pyfabric/items/semantic_model.py
+++ b/src/pyfabric/items/semantic_model.py
@@ -268,7 +268,11 @@ class Table:
                 "Table.from_parquet requires pyarrow; install with `pip install pyfabric[data]`"
             ) from e
 
-        schema_obj = pq.read_schema(str(parquet_path))
+        # pq.read_schema is untyped in pyarrow's stubs on older versions
+        # (mypy's no-untyped-call fires on CI's 3.12/pyarrow combo but
+        # not on newer toolchains). Suppress both the untyped-call
+        # warning and the unused-ignore warning that newer mypy emits.
+        schema_obj = pq.read_schema(str(parquet_path))  # type: ignore[no-untyped-call, unused-ignore]
         columns = [
             Column(name=field.name, data_type=arrow_to_tmdl(str(field.type)))
             for field in schema_obj

--- a/tests/data/test_onelake_walk_cache.py
+++ b/tests/data/test_onelake_walk_cache.py
@@ -43,30 +43,69 @@ def _mock_session_with_pages(*pages: list[dict]) -> MagicMock:
 # ── walk() ──────────────────────────────────────────────────────────────────
 
 
+def _mock_session_per_directory(tree: dict[str, list[dict]]) -> MagicMock:
+    """Build a mock session that returns different entries per directory.
+
+    `tree` maps a request URL suffix (the directory path) to the list of
+    entries that should be returned when that directory is listed.
+    Missing entries (directories not in `tree`) yield an empty list.
+
+    Mirrors real DFS semantics: calling with a directory path returns
+    only its direct children. Manual-recursion in :func:`walk` drives
+    a sequence of calls, one per subdirectory.
+    """
+
+    def handle_get(url, **kwargs):
+        resp = MagicMock()
+        resp.status_code = 200
+        # URL shape: {base}/{ws}/{item}/{path}. Extract the path tail.
+        suffix = url.rstrip("/").rsplit("/lh/", 1)[-1] if "/lh/" in url else url
+        # Normalize: suffix == "lh" when path == "" (root)
+        page = tree.get(suffix, [])
+        resp.json.return_value = {"paths": page}
+        resp.headers = {}
+        return resp
+
+    session = MagicMock()
+    session.get.side_effect = handle_get
+    return session
+
+
 class TestWalk:
     def test_yields_files_not_directories(self):
-        entries = [
-            {"name": "lh/Files/a.pdf", "contentLength": "100"},
-            {"name": "lh/Files/sub", "isDirectory": "true"},
-            {"name": "lh/Files/sub/b.pdf", "contentLength": "200"},
-        ]
+        # Real DFS semantics: list_paths("Files") returns direct children
+        # only. walk() descends manually into "Files/sub".
+        tree = {
+            "Files": [
+                {"name": "lh/Files/a.pdf", "contentLength": "100"},
+                {"name": "lh/Files/sub", "isDirectory": "true"},
+            ],
+            "Files/sub": [
+                {"name": "lh/Files/sub/b.pdf", "contentLength": "200"},
+            ],
+        }
         with patch(
             "pyfabric.data.onelake._get_session",
-            return_value=_mock_session_with_pages(entries),
+            return_value=_mock_session_per_directory(tree),
         ):
             results = list(walk("tok", "ws", "lh", "Files"))
-        assert [r["rel_path"] for r in results] == ["Files/a.pdf", "Files/sub/b.pdf"]
-        assert [r["size"] for r in results] == [100, 200]
+        assert sorted(r["rel_path"] for r in results) == [
+            "Files/a.pdf",
+            "Files/sub/b.pdf",
+        ]
+        assert sorted(r["size"] for r in results) == [100, 200]
 
     def test_suffix_filter(self):
-        entries = [
-            {"name": "lh/Files/a.pdf", "contentLength": "1"},
-            {"name": "lh/Files/b.txt", "contentLength": "2"},
-            {"name": "lh/Files/c.PDF", "contentLength": "3"},  # case-sensitive
-        ]
+        tree = {
+            "Files": [
+                {"name": "lh/Files/a.pdf", "contentLength": "1"},
+                {"name": "lh/Files/b.txt", "contentLength": "2"},
+                {"name": "lh/Files/c.PDF", "contentLength": "3"},  # case-sensitive
+            ],
+        }
         with patch(
             "pyfabric.data.onelake._get_session",
-            return_value=_mock_session_with_pages(entries),
+            return_value=_mock_session_per_directory(tree),
         ):
             results = list(walk("tok", "ws", "lh", "Files", suffix=".pdf"))
         assert [r["rel_path"] for r in results] == ["Files/a.pdf"]
@@ -74,7 +113,7 @@ class TestWalk:
     def test_empty_dir_yields_nothing(self):
         with patch(
             "pyfabric.data.onelake._get_session",
-            return_value=_mock_session_with_pages([]),
+            return_value=_mock_session_per_directory({"Files": []}),
         ):
             results = list(walk("tok", "ws", "lh", "Files"))
         assert results == []
@@ -91,13 +130,40 @@ class TestWalk:
         assert results == []
 
     def test_names_without_item_prefix_pass_through(self):
-        entries = [{"name": "Files/a.pdf", "contentLength": "1"}]
+        tree = {"Files": [{"name": "Files/a.pdf", "contentLength": "1"}]}
         with patch(
             "pyfabric.data.onelake._get_session",
-            return_value=_mock_session_with_pages(entries),
+            return_value=_mock_session_per_directory(tree),
         ):
             results = list(walk("tok", "ws", "lh", "Files"))
         assert results[0]["rel_path"] == "Files/a.pdf"
+
+    def test_deep_tree_recurses_all_the_way_down(self):
+        """Regression test for OneLake DFS quirk (2026-04-21): calling
+        list_paths with recursive=true on a deep subdirectory returns
+        only its direct children — not the full subtree. walk() must
+        descend manually so any depth traversal returns all files.
+        """
+        tree = {
+            "root": [
+                {"name": "lh/root/year", "isDirectory": "true"},
+            ],
+            "root/year": [
+                {"name": "lh/root/year/month", "isDirectory": "true"},
+            ],
+            "root/year/month": [
+                {"name": "lh/root/year/month/region", "isDirectory": "true"},
+            ],
+            "root/year/month/region": [
+                {"name": "lh/root/year/month/region/a.pdf", "contentLength": "10"},
+            ],
+        }
+        with patch(
+            "pyfabric.data.onelake._get_session",
+            return_value=_mock_session_per_directory(tree),
+        ):
+            results = list(walk("tok", "ws", "lh", "root"))
+        assert [r["rel_path"] for r in results] == ["root/year/month/region/a.pdf"]
 
 
 # ── list_paths passes continuation tokens through ───────────────────────────


### PR DESCRIPTION
## Summary
- `DFS filesystem list_paths?recursive=true` on OneLake returns the filesystem root fully recursively but goes shallow when the request path is a deep subdirectory — it returns only the direct children of the requested path, not the full subtree.
- Fixes `walk()` to descend manually via `recursive=false` at each level, so it works uniformly at any depth.

## Reproduction

Against a workspace with a year/month/region/file hierarchy under `Files/`:

| Request path | `recursive=true` returned |
|---|---:|
| `Files` | 74,484 entries (all files + dirs, as expected) |
| `Files/X` | 6 entries (2 files + 4 dirs at that level) |
| `Files/X/2026` | 12 entries (only the 12 month directories) |
| `Files/X/2026/04 - April 2026` | 4 entries (only the 4 region directories) |
| `Files/X/2026/04 - April 2026/ABC` | 5 entries (the 5 files, because leaf) |

Existing callers that hand-rolled manual recursion via `recursive=false` worked around this without knowing. This fix moves the workaround into the library so the documented "recursively yield file entries" contract of `walk()` actually holds at any depth.

## Changes
- `walk()` uses a stack-based depth traversal calling `list_paths(recursive=False)` per directory rather than relying on the DFS flag.
- Added regression test `test_deep_tree_recurses_all_the_way_down` that exercises a 4-level directory tree via a per-directory mock session.
- Existing `walk` unit tests rewritten to use a per-directory mock (the prior tests fed a flat entry list as if `recursive=true` worked).
- No changes to `walk()`'s public contract: same yielded shape, same `suffix` filter, same 404-as-empty semantics.

## Test plan
- [x] Full suite: `pytest -q` — 521 passed, 1 skipped
- [x] `ruff check`, `ruff format --check`, `mypy src/` — all clean
- [x] New test fails against the old implementation (verified locally)
- [x] All existing `walk` tests pass with the new implementation