### PR TITLE
docs(claude_memory): warn about pinning logicalId on rebuilds

### DIFF
--- a/src/pyfabric/claude_memory/pyfabric.md
+++ b/src/pyfabric/claude_memory/pyfabric.md
@@ -51,6 +51,17 @@ for the current shell is the tenant pyfabric talks to. Pass `tenant=` to
   `testing` extra.
 - Lakehouse GUIDs are easiest to grab from the Fabric UI (Settings →
   Identifier). Workspace GUIDs come from listing workspaces via pyfabric.
+- **Pin the `logical_id=` on every `SemanticModel(...)` / `Report(...)` you
+  regenerate from a build script.** The builders mint a fresh logicalId
+  via `<factory>` on each run; Fabric git-sync keys deployed items by
+  `.platform/logicalId`, so a rebuild lands as a **new** artifact that
+  collides with the already-deployed one (same displayName, different
+  logicalId). The sync fails, listing both the deployed item (real
+  ObjectId) and the new one (ObjectId `00000000-…`). Fix: declare
+  module-level UUID constants once, pass them via `logical_id=` on every
+  rebuild, and never let a `<factory>`-generated logicalId reach main.
+  If one slips through, restore from the first successful deploy with
+  `git show <sha>:path/to/.platform`.
 
 **Common operations:**
 


### PR DESCRIPTION
## Summary
- Add a pitfalls entry to `src/pyfabric/claude_memory/pyfabric.md` explaining that `SemanticModel(...)` and `Report(...)` mint a fresh `<factory>`-generated `logicalId` on every run.
- Rebuilding without pinning `logical_id=` causes the next Fabric git-sync to treat the rebuild as a new artifact colliding with the already-deployed one (same displayName, different logicalId), producing a sync failure that lists both the deployed item and the new one with ObjectId `00000000-…`.
- The fix (declare module-level UUID constants once and reuse them on every `logical_id=` pass) is now surfaced in the consumer-facing guidance that ships with the wheel and lands via `pyfabric install-claude-memory`.

This is a consumer-facing docs change only — no code paths touched. The library already accepts `logical_id=` on both builders; this PR just makes the expectation loud in the shipped memory so future AI sessions don't repeat the footgun.

## Test plan
- [x] `ruff check .` passes
- [x] `ruff format --check .` passes
- [x] `mypy src/` passes
- [x] `pytest` passes (pre-push hook)
- [ ] Consumer projects running `pyfabric install-claude-memory` on the next beta release see the updated pitfall in their project `pyfabric.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)