### PR TITLE
release: 0.1.0b7 — fix #47, docs #40 + #41

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,7 @@ azure = [
 data = [
     "pyodbc>=5.1",
     "azure-storage-file-datalake>=12.17",
+    "pandas>=2.0",
 ]
 # Runtime deps for pyfabric.data.lakehouse.write_table (Delta write path
 # to OneLake). These are genuine runtime requirements of the write_table

--- a/src/pyfabric/claude_memory/MEMORY.md
+++ b/src/pyfabric/claude_memory/MEMORY.md
@@ -1,2 +1,4 @@
 - [pyfabric reference](pyfabric.md) — how to use pyfabric (auth, workspaces, lakehouse access) from Python in any repo
 - [Descriptions are required by default](descriptions_required.md) — SemanticModel + Report builders raise on save for missing descriptions on visible objects. Always supply meaningful ones; use `is_hidden=True` for housekeeping; do not reach for `strict_descriptions=False`.
+- [OneLake direct vs SQL analytics endpoint](onelake_vs_sql_endpoint.md) — prefer OneLake for discovery/scans; FabricSql only for joins or endpoint validation. MirroredDatabase SQL endpoint lags during refresh.
+- [Wheel + SqlConn transform pattern](wheel_sqlconn_pattern.md) — canonical pattern for Fabric Spark notebooks: transforms in a pip wheel, DuckDB for local tests, SparkSqlConn in Fabric. Closes the loop with LocalLakehouse.push_table().

--- a/src/pyfabric/claude_memory/onelake_vs_sql_endpoint.md
+++ b/src/pyfabric/claude_memory/onelake_vs_sql_endpoint.md
@@ -1,0 +1,46 @@
+---
+name: OneLake direct vs SQL analytics endpoint
+description: When to use pyfabric.data.onelake / LocalLakehouse vs FabricSql. Critical for MirroredDatabase — SQL endpoint lags behind delta files during mirror refresh.
+type: reference
+---
+
+Prefer **OneLake direct** (`pyfabric.data.onelake.walk()` + `deltalake.DeltaTable`
+or `LocalLakehouse`) over **`FabricSql`** (SQL analytics endpoint) for
+discovery-style work: listing tables, inspecting columns, row counts, delta
+history, quick scans.
+
+**Why OneLake direct is better for discovery:**
+
+- SQL analytics endpoint has sync latency for `MirroredDatabase` — can lag
+  seconds-to-minutes behind the delta files during mirror refresh. OneLake
+  reads are up-to-the-second current.
+- SQL endpoint requires ODBC handshake + AAD token on first query; OneLake
+  needs a single ABFS `list` call for discovery.
+- Columnar projection/pushdown on parquet is strictly faster than serverless
+  SQL for single-table scans.
+
+**When to reach for `FabricSql` instead:**
+
+- Cross-table joins that would be awkward with DuckDB ATTACH.
+- WHERE-clause pushdown where server-side filtering matters for performance.
+- Testing the published SQL endpoint path itself (e.g., validating a
+  downstream semantic model's query behavior).
+
+**Quick reference:**
+
+```python
+# Discovery — prefer this
+from pyfabric.data import LocalLakehouse
+lh = LocalLakehouse(cred, workspace_id=WS, lakehouse_id=LH)
+df = lh.query("SELECT COUNT(*) FROM {table}", table="customers")
+
+# Schema inspection without downloading data
+from deltalake import DeltaTable
+from pyfabric.data.onelake import abfs_path
+schema = DeltaTable(abfs_path(WS, LH, "Tables/customers"), storage_options=...).schema()
+
+# SQL endpoint — for joins or endpoint validation
+from pyfabric.data.sql import FabricSql
+sql = FabricSql(server=..., database=..., credential=cred)
+df = sql.query_df("SELECT a.id, b.name FROM a JOIN b ON a.id = b.id")
+```

--- a/src/pyfabric/claude_memory/wheel_sqlconn_pattern.md
+++ b/src/pyfabric/claude_memory/wheel_sqlconn_pattern.md
@@ -1,0 +1,86 @@
+---
+name: Wheel + SqlConn transform pattern
+description: Canonical pattern for Fabric Spark notebooks — transforms live in a pip wheel, tested against DuckDB locally, deployed to Fabric via SparkSqlConn. Use for any bronze→silver/gold materialization.
+type: reference
+---
+
+When authoring a Fabric Spark notebook that materializes derived tables
+(bronze→silver, silver→gold, etc.), use the **wheel + SqlConn pattern** so the
+same transform code runs locally (DuckDB) and in Fabric (Spark) without
+modification.
+
+## Structure
+
+1. **Transforms in a pip wheel** — pure Python functions typed against `SqlConn`:
+
+   ```python
+   # my_pkg/build.py
+   from pyfabric.data.sqlconn import SqlConn
+
+   def build_silver(con: SqlConn, *, bronze_schema: str, silver_schema: str) -> None:
+       con.execute(f"""
+           CREATE OR REPLACE TABLE {silver_schema}.dim_customer AS
+           SELECT id, name FROM {bronze_schema}.customer
+       """)
+   ```
+
+2. **Local tests against DuckDB** — `duckdb.connect()` satisfies `SqlConn` natively:
+
+   ```python
+   import duckdb
+   from my_pkg.build import build_silver
+
+   def test_build_silver():
+       con = duckdb.connect(":memory:")
+       con.execute("CREATE SCHEMA bronze; CREATE TABLE bronze.customer (id INT, name TEXT)")
+       con.execute("INSERT INTO bronze.customer VALUES (1, 'Alice')")
+       build_silver(con, bronze_schema="bronze", silver_schema="silver")
+       result = con.execute("SELECT name FROM silver.dim_customer").fetchone()
+       assert result[0] == "Alice"
+   ```
+
+3. **Fabric notebook cells**:
+
+   ```python
+   # Cell 1 — install wheel from Resources/builtin/
+   # MAGIC %pip install "builtin/my_pkg-1.0.0-py3-none-any.whl" --quiet
+
+   # Cell 2 — wrap Spark as SqlConn
+   from pyfabric.data.sqlconn import SparkSqlConn
+   con = SparkSqlConn(spark)
+
+   # Cell 3 — run same build functions
+   from my_pkg.build import build_silver
+   build_silver(con, bronze_schema="lh_bronze.dbo", silver_schema="lh_silver.dbo")
+   ```
+
+## Deployment
+
+- Wheel goes to `<Notebook>/Resources/builtin/` in the git repo.
+- Guard with `notebook-settings.json: {"includeResourcesInGit": "on"}` and
+  `fs-settings.json: {"gitExclusions": []}`.
+- **Do NOT delete old wheel versions** — Fabric git-sync flaps on Resources
+  deletes. Pin the version in the `%pip install` cell instead.
+
+## Closing the local development loop
+
+`LocalLakehouse.push_table()` lets you run the full pipeline locally and push
+results directly to OneLake as Delta — no Fabric notebook needed during
+development:
+
+```python
+from pyfabric.data import LocalLakehouse
+import duckdb
+
+con = duckdb.connect(":memory:")
+# ... seed bronze data ...
+build_silver(con, bronze_schema="bronze", silver_schema="silver")
+
+lh = LocalLakehouse(cred, workspace_id=WS, lakehouse_id=LH)
+lh.push_table("dim_customer", con.execute("SELECT * FROM silver.dim_customer").arrow())
+```
+
+## In the wild
+
+- `mgc/ws_creative_planning` — projection PDF extraction pipeline
+- `bc2fab_sales` — sales SemanticModel DirectLake migration

--- a/src/pyfabric/data/sql.py
+++ b/src/pyfabric/data/sql.py
@@ -110,7 +110,11 @@ class FabricSql:
         log.debug("SQL query: %s", sql[:200])
         conn = self._get_connection()
         try:
-            df = pd_mod.read_sql(sql, conn, params=params)
+            cursor = conn.cursor()
+            cursor.execute(sql, params or ())
+            cols = [desc[0] for desc in cursor.description]
+            rows = cursor.fetchall()
+            df = pd_mod.DataFrame.from_records(rows, columns=cols)
             log.debug("  -> %d rows, %d columns", len(df), len(df.columns))
             return df
         except Exception as e:

--- a/tests/data/test_sql_errors.py
+++ b/tests/data/test_sql_errors.py
@@ -137,22 +137,16 @@ class TestQueryDfCursorPath:
         sql._conn = mock_conn
         return sql
 
-    def _mock_pd(self) -> MagicMock:
-        mock_pd = MagicMock()
-        mock_pd.DataFrame.from_records.return_value = MagicMock()
-        return mock_pd
-
-    def test_from_records_called_with_correct_rows_and_columns(self):
-        mock_pd = self._mock_pd()
+    def test_returns_dataframe_with_correct_columns_and_rows(self):
         sql = self._make_sql()
-        with patch.dict("sys.modules", {"pandas": mock_pd}):
-            sql.query_df("SELECT id, name FROM dbo.t")
-        mock_pd.DataFrame.from_records.assert_called_with(
-            [(1, "alpha"), (2, "beta")], columns=["id", "name"]
-        )
+        df = sql.query_df("SELECT id, name FROM dbo.t")
+        assert list(df.columns) == ["id", "name"]
+        assert len(df) == 2
+        assert df["name"].tolist() == ["alpha", "beta"]
 
     def test_does_not_call_read_sql(self):
-        mock_pd = self._mock_pd()
+        mock_pd = MagicMock()
+        mock_pd.DataFrame.from_records.return_value = MagicMock()
         sql = self._make_sql()
         with patch.dict("sys.modules", {"pandas": mock_pd}):
             sql.query_df("SELECT 1")
@@ -161,18 +155,14 @@ class TestQueryDfCursorPath:
     def test_params_forwarded_to_cursor_execute(self):
         sql = self._make_sql()
         cursor = sql._conn.cursor.return_value
-
-        with patch.dict("sys.modules", {"pandas": self._mock_pd()}):
-            sql.query_df("SELECT * FROM t WHERE id = ?", params=[42])
+        sql.query_df("SELECT * FROM t WHERE id = ?", params=[42])
         # _get_connection calls execute("SELECT 1") first; check the query call.
         cursor.execute.assert_called_with("SELECT * FROM t WHERE id = ?", [42])
 
     def test_empty_params_uses_empty_tuple(self):
         sql = self._make_sql()
         cursor = sql._conn.cursor.return_value
-
-        with patch.dict("sys.modules", {"pandas": self._mock_pd()}):
-            sql.query_df("SELECT 1")
+        sql.query_df("SELECT 1")
         # _get_connection calls execute("SELECT 1") first; check the query call.
         cursor.execute.assert_called_with("SELECT 1", ())
 

--- a/tests/data/test_sql_errors.py
+++ b/tests/data/test_sql_errors.py
@@ -66,10 +66,14 @@ class TestQueryErrors:
         cred = MagicMock()
         sql = FabricSql("server", "db", cred)
         mock_conn = MagicMock()
+        # First execute is the SELECT 1 health check (succeeds); second is the query.
+        mock_conn.cursor.return_value.execute.side_effect = [
+            None,
+            Exception("Invalid column name 'nonexistent'"),
+        ]
         sql._conn = mock_conn
 
         mock_pd = MagicMock()
-        mock_pd.read_sql.side_effect = Exception("Invalid column name 'nonexistent'")
         with patch.dict("sys.modules", {"pandas": mock_pd}):
             with pytest.raises(SqlError, match="SQL query failed") as exc_info:
                 sql.query_df("SELECT nonexistent FROM dbo.products")
@@ -106,13 +110,64 @@ class TestQueryErrors:
         cred = MagicMock()
         sql = FabricSql("server", "db", cred)
         mock_conn = MagicMock()
+        # First execute is the SELECT 1 health check; second is the INFORMATION_SCHEMA query.
+        mock_conn.cursor.return_value.execute.side_effect = [
+            None,
+            Exception("connection lost"),
+        ]
         sql._conn = mock_conn
 
         mock_pd = MagicMock()
-        mock_pd.read_sql.side_effect = Exception("connection lost")
         with patch.dict("sys.modules", {"pandas": mock_pd}):
             result = sql.table_exists("nonexistent_table")
             assert result is False
+
+
+class TestQueryDfCursorPath:
+    """query_df uses cursor.execute + DataFrame.from_records — no pd.read_sql."""
+
+    def _make_sql(self) -> FabricSql:
+        cred = MagicMock()
+        sql = FabricSql("server", "db", cred)
+        cursor = MagicMock()
+        cursor.description = [("id",), ("name",)]
+        cursor.fetchall.return_value = [(1, "alpha"), (2, "beta")]
+        mock_conn = MagicMock()
+        mock_conn.cursor.return_value = cursor
+        sql._conn = mock_conn
+        return sql
+
+    def test_returns_dataframe_with_correct_columns_and_rows(self):
+
+        sql = self._make_sql()
+        df = sql.query_df("SELECT id, name FROM dbo.t")
+        assert list(df.columns) == ["id", "name"]
+        assert len(df) == 2
+        assert df["name"].tolist() == ["alpha", "beta"]
+
+    def test_does_not_call_read_sql(self):
+        mock_pd = MagicMock()
+        mock_pd.DataFrame.from_records.return_value = mock_pd.DataFrame.from_records()
+        sql = self._make_sql()
+        with patch.dict("sys.modules", {"pandas": mock_pd}):
+            sql.query_df("SELECT 1")
+        mock_pd.read_sql.assert_not_called()
+
+    def test_params_forwarded_to_cursor_execute(self):
+        sql = self._make_sql()
+        cursor = sql._conn.cursor.return_value
+
+        sql.query_df("SELECT * FROM t WHERE id = ?", params=[42])
+        # _get_connection calls execute("SELECT 1") first; check the query call.
+        cursor.execute.assert_called_with("SELECT * FROM t WHERE id = ?", [42])
+
+    def test_empty_params_uses_empty_tuple(self):
+        sql = self._make_sql()
+        cursor = sql._conn.cursor.return_value
+
+        sql.query_df("SELECT 1")
+        # _get_connection calls execute("SELECT 1") first; check the query call.
+        cursor.execute.assert_called_with("SELECT 1", ())
 
 
 class TestConnectLakehouseErrors:

--- a/tests/data/test_sql_errors.py
+++ b/tests/data/test_sql_errors.py
@@ -137,17 +137,22 @@ class TestQueryDfCursorPath:
         sql._conn = mock_conn
         return sql
 
-    def test_returns_dataframe_with_correct_columns_and_rows(self):
+    def _mock_pd(self) -> MagicMock:
+        mock_pd = MagicMock()
+        mock_pd.DataFrame.from_records.return_value = MagicMock()
+        return mock_pd
 
+    def test_from_records_called_with_correct_rows_and_columns(self):
+        mock_pd = self._mock_pd()
         sql = self._make_sql()
-        df = sql.query_df("SELECT id, name FROM dbo.t")
-        assert list(df.columns) == ["id", "name"]
-        assert len(df) == 2
-        assert df["name"].tolist() == ["alpha", "beta"]
+        with patch.dict("sys.modules", {"pandas": mock_pd}):
+            sql.query_df("SELECT id, name FROM dbo.t")
+        mock_pd.DataFrame.from_records.assert_called_with(
+            [(1, "alpha"), (2, "beta")], columns=["id", "name"]
+        )
 
     def test_does_not_call_read_sql(self):
-        mock_pd = MagicMock()
-        mock_pd.DataFrame.from_records.return_value = mock_pd.DataFrame.from_records()
+        mock_pd = self._mock_pd()
         sql = self._make_sql()
         with patch.dict("sys.modules", {"pandas": mock_pd}):
             sql.query_df("SELECT 1")
@@ -157,7 +162,8 @@ class TestQueryDfCursorPath:
         sql = self._make_sql()
         cursor = sql._conn.cursor.return_value
 
-        sql.query_df("SELECT * FROM t WHERE id = ?", params=[42])
+        with patch.dict("sys.modules", {"pandas": self._mock_pd()}):
+            sql.query_df("SELECT * FROM t WHERE id = ?", params=[42])
         # _get_connection calls execute("SELECT 1") first; check the query call.
         cursor.execute.assert_called_with("SELECT * FROM t WHERE id = ?", [42])
 
@@ -165,7 +171,8 @@ class TestQueryDfCursorPath:
         sql = self._make_sql()
         cursor = sql._conn.cursor.return_value
 
-        sql.query_df("SELECT 1")
+        with patch.dict("sys.modules", {"pandas": self._mock_pd()}):
+            sql.query_df("SELECT 1")
         # _get_connection calls execute("SELECT 1") first; check the query call.
         cursor.execute.assert_called_with("SELECT 1", ())
 


### PR DESCRIPTION
## Summary

- **fix(sql #47):** Replace `pd.read_sql` with cursor-based fetch in `FabricSql.query_df`. Eliminates the pandas `UserWarning` about DBAPI2 connections on pandas ≥ 2.x. No SQLAlchemy dependency needed; consistent with how `execute()` already uses the cursor directly.
- **docs(claude_memory #40):** New `onelake_vs_sql_endpoint.md` — when to reach for OneLake direct reads vs the SQL analytics endpoint. Critical for `MirroredDatabase` where the SQL endpoint lags during mirror refresh.
- **docs(claude_memory #41):** New `wheel_sqlconn_pattern.md` — canonical wheel + `SqlConn` pattern for Fabric Spark notebooks: transforms typed against `SqlConn`, DuckDB for local tests, `SparkSqlConn` in Fabric, inner loop closed with `LocalLakehouse.push_table()`.

## Closes

Fixes #47 · Closes #40 · Closes #41

## Test plan

- [x] `ruff check`, `ruff format --check`, `mypy` — all pass
- [x] 536 tests pass, 1 skipped (e2e, expected)
- [x] `TestQueryDfCursorPath` — 4 new cases covering correct columns/rows, no `read_sql`, params forwarding, empty-params tuple
- [x] Existing mock-based error tests updated for cursor path

🤖 Generated with [Claude Code](https://claude.com/claude-code)