### PR TITLE
Lakehouse DDL helpers + schema drift detection + push target_schema override

### DIFF
--- a/src/pyfabric/data/__init__.py
+++ b/src/pyfabric/data/__init__.py
@@ -1,5 +1,17 @@
 """Data access for OneLake, SQL endpoints, and lakehouse tables."""
 
-from pyfabric.data.local_lakehouse import LocalLakehouse  # noqa: F401
+from pyfabric.data.lakehouse import (  # noqa: F401
+    LakehouseRenameSchemaError,
+    delete_table,
+    drop_schema,
+    list_schemas,
+    list_tables,
+    rename_schema,
+    rename_table,
+)
+from pyfabric.data.local_lakehouse import (  # noqa: F401
+    LocalLakehouse,
+    LocalLakehouseSchemaDrift,
+)
 from pyfabric.data.processing_log import ProcessingLog  # noqa: F401
 from pyfabric.data.schema import Col, TableDef  # noqa: F401

--- a/src/pyfabric/data/lakehouse.py
+++ b/src/pyfabric/data/lakehouse.py
@@ -29,9 +29,33 @@ if TYPE_CHECKING:
     import pyarrow as pa
 
 from pyfabric.client.auth import FabricCredential
+from pyfabric.data import onelake
 from pyfabric.data.onelake import abfss_url
 
 log = structlog.get_logger()
+
+
+class LakehouseRenameSchemaError(Exception):
+    """Raised by :func:`rename_schema` when at least one table move failed.
+
+    Attempts every table in the source schema before raising — callers
+    can retry the listed ``failed`` tables without re-moving the ones
+    already in ``moved``.
+
+    Attributes:
+        moved:  Table names successfully moved to the destination schema.
+        failed: Mapping of table name → error message for tables that
+                could not be moved. The source copies of these tables
+                remain in place.
+    """
+
+    def __init__(self, moved: list[str], failed: dict[str, str]):
+        self.moved = moved
+        self.failed = failed
+        super().__init__(
+            f"rename_schema partial failure — moved {len(moved)}, "
+            f"failed {len(failed)}: {sorted(failed)}"
+        )
 
 
 @dataclass
@@ -324,3 +348,202 @@ def _read_delta(
         "Delta file-level read: %d rows from %d files", len(result), len(file_uris)
     )
     return result
+
+
+# ── DDL helpers (schema/table management) ────────────────────────────────────
+
+
+def delete_table(
+    credential: FabricCredential,
+    ws_id: str,
+    lh_id: str,
+    table: str,
+    *,
+    schema: str = "dbo",
+) -> bool:
+    """Delete a Delta table from a Fabric lakehouse.
+
+    Removes the ``Tables/{schema}/{table}/`` directory and everything
+    under it (delta log + parquet files). Returns True when the
+    directory existed and was deleted, False when it was already
+    missing.
+    """
+    path = f"Tables/{schema}/{table}"
+    log.info("delete_table", schema=schema, table=table, path=path)
+    return onelake.delete_path(
+        credential.storage_token, ws_id, lh_id, path, recursive=True
+    )
+
+
+def rename_table(
+    credential: FabricCredential,
+    ws_id: str,
+    lh_id: str,
+    src: str,
+    dst: str,
+    *,
+    schema: str = "dbo",
+) -> None:
+    """Rename a Delta table within a schema.
+
+    Metadata-only move on ``Tables/{schema}/{src}/`` → ``Tables/{schema}/{dst}/``.
+    No data is rewritten.
+    """
+    if src == dst:
+        raise ValueError(
+            f"rename_table src and dst are identical ({src!r}); nothing to do"
+        )
+    src_path = f"Tables/{schema}/{src}"
+    dst_path = f"Tables/{schema}/{dst}"
+    log.info(
+        "rename_table",
+        schema=schema,
+        src=src,
+        dst=dst,
+        src_path=src_path,
+        dst_path=dst_path,
+    )
+    onelake.rename_path(credential.storage_token, ws_id, lh_id, src_path, dst_path)
+
+
+def rename_schema(
+    credential: FabricCredential,
+    ws_id: str,
+    lh_id: str,
+    src_schema: str,
+    dst_schema: str,
+) -> list[str]:
+    """Move every table in ``src_schema`` into ``dst_schema``.
+
+    Iterates all table directories under ``Tables/{src_schema}/`` and
+    renames each one to ``Tables/{dst_schema}/{table}/``. Continues
+    past individual failures — any table that couldn't be moved is
+    reported via :class:`LakehouseRenameSchemaError` after every other
+    table has been attempted, so callers can retry the failures without
+    re-moving the successes.
+
+    Returns the list of table names that moved successfully. Raises
+    :class:`LakehouseRenameSchemaError` if any move failed.
+    """
+    if src_schema == dst_schema:
+        raise ValueError(
+            f"rename_schema src and dst are identical ({src_schema!r}); nothing to do"
+        )
+
+    tables = list_tables(credential, ws_id, lh_id, schema=src_schema)
+    log.info(
+        "rename_schema_starting",
+        src_schema=src_schema,
+        dst_schema=dst_schema,
+        table_count=len(tables),
+    )
+
+    moved: list[str] = []
+    failed: dict[str, str] = {}
+    for t in tables:
+        try:
+            onelake.rename_path(
+                credential.storage_token,
+                ws_id,
+                lh_id,
+                f"Tables/{src_schema}/{t}",
+                f"Tables/{dst_schema}/{t}",
+            )
+            moved.append(t)
+        except Exception as e:
+            failed[t] = str(e)
+            log.error(
+                "rename_schema_table_failed",
+                src_schema=src_schema,
+                dst_schema=dst_schema,
+                table=t,
+                error=str(e),
+            )
+
+    if failed:
+        raise LakehouseRenameSchemaError(moved, failed)
+
+    log.info(
+        "rename_schema_complete",
+        src_schema=src_schema,
+        dst_schema=dst_schema,
+        moved_count=len(moved),
+    )
+    return moved
+
+
+def drop_schema(
+    credential: FabricCredential,
+    ws_id: str,
+    lh_id: str,
+    schema: str,
+) -> bool:
+    """Drop a schema from a schema-enabled lakehouse.
+
+    Removes the ``Tables/{schema}/`` directory and everything under it.
+    Returns True when the directory existed and was deleted, False when
+    it was already missing.
+
+    This deletes any tables still present under the schema — pair with
+    :func:`rename_schema` when you want to preserve the data.
+    """
+    path = f"Tables/{schema}"
+    log.info("drop_schema", schema=schema, path=path)
+    return onelake.delete_path(
+        credential.storage_token, ws_id, lh_id, path, recursive=True
+    )
+
+
+def list_schemas(
+    credential: FabricCredential,
+    ws_id: str,
+    lh_id: str,
+) -> list[str]:
+    """List schema names (directories directly under ``Tables/``)."""
+    entries = onelake.list_paths(
+        credential.storage_token, ws_id, lh_id, "Tables", recursive=False
+    )
+    return [
+        _basename(e["name"]) for e in entries if e.get("isDirectory", "false") == "true"
+    ]
+
+
+def list_tables(
+    credential: FabricCredential,
+    ws_id: str,
+    lh_id: str,
+    *,
+    schema: str | None = None,
+) -> list[str]:
+    """List table names in a lakehouse.
+
+    With ``schema``, returns unqualified table names in that schema
+    (e.g. ``["widgets", "gizmos"]``). Without, returns qualified names
+    across every schema (e.g. ``["dbo.widgets", "silver.foo"]``).
+    """
+    if schema is not None:
+        entries = onelake.list_paths(
+            credential.storage_token,
+            ws_id,
+            lh_id,
+            f"Tables/{schema}",
+            recursive=False,
+        )
+        return [
+            _basename(e["name"])
+            for e in entries
+            if e.get("isDirectory", "false") == "true"
+        ]
+
+    qualified: list[str] = []
+    for sch in list_schemas(credential, ws_id, lh_id):
+        qualified.extend(
+            f"{sch}.{name}"
+            for name in list_tables(credential, ws_id, lh_id, schema=sch)
+        )
+    return qualified
+
+
+def _basename(dfs_name: str) -> str:
+    """Return the final path segment of a DFS ``name`` field."""
+    return dfs_name.rstrip("/").rsplit("/", 1)[-1]

--- a/src/pyfabric/data/local_lakehouse.py
+++ b/src/pyfabric/data/local_lakehouse.py
@@ -41,7 +41,7 @@ Usage:
 from __future__ import annotations
 
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Literal
 
 import structlog
 
@@ -55,6 +55,32 @@ if TYPE_CHECKING:
     from pyfabric.client.auth import FabricCredential
 
 log = structlog.get_logger()
+
+
+OnDrift = Literal["ignore", "raise", "evolve"]
+
+
+class LocalLakehouseSchemaDrift(Exception):
+    """Raised when ``register()`` detects that an existing DuckDB table
+    has fewer columns than its current ``TableDef``.
+
+    Callers can react by picking a different ``on_drift`` policy
+    (``"evolve"`` to add the missing columns in place, or ``"ignore"``
+    to preserve the pre-drift-detection behaviour) or by re-creating
+    the database from scratch. The exception's ``drift`` attribute maps
+    each affected table name to the list of missing column names.
+    """
+
+    def __init__(self, drift: dict[str, list[str]]):
+        self.drift = drift
+        parts = [f"{name}: missing {cols}" for name, cols in drift.items()]
+        super().__init__(
+            "LocalLakehouse schema drift detected — "
+            + "; ".join(parts)
+            + ". Pass on_drift='evolve' to add the missing columns, "
+            "on_drift='ignore' to keep the existing schema, "
+            "or re-create the database."
+        )
 
 
 class LocalLakehouse:
@@ -105,22 +131,140 @@ class LocalLakehouse:
             self._conn.execute(stmt)
         return len(statements)
 
-    def register(self, tables: TableDef | tuple[TableDef, ...] | list[TableDef]) -> int:
+    def register(
+        self,
+        tables: TableDef | tuple[TableDef, ...] | list[TableDef],
+        *,
+        on_drift: OnDrift = "raise",
+    ) -> int:
         """Register one or more TableDefs and create the DuckDB tables.
 
         Registered tables are used by ``insert_typed`` to validate rows
-        before insert. Existing tables are not dropped — DDL uses
-        ``CREATE TABLE IF NOT EXISTS``.
+        before insert. Tables that already exist with the same columns
+        are left alone.
+
+        When an existing table has **fewer** columns than its current
+        ``TableDef`` (additive drift — e.g. new extractor fields added
+        mid-sprint) the behaviour is controlled by ``on_drift``:
+
+        - ``"raise"`` (default) — raise :class:`LocalLakehouseSchemaDrift`
+          listing every affected table and missing column. Forces the
+          caller to make an explicit choice.
+        - ``"evolve"`` — issue ``ALTER TABLE ... ADD COLUMN`` for each
+          missing column, preserving existing rows.
+        - ``"ignore"`` — keep the existing table shape. Matches the
+          pre-0.1.0b8 silent behaviour.
+
+        Type changes and column removals are **not** detected here;
+        only additive drift is. Use a fresh database if the column
+        types change.
 
         Returns the number of tables registered.
         """
+        if on_drift not in ("raise", "evolve", "ignore"):
+            raise ValueError(
+                f"on_drift must be 'raise', 'evolve', or 'ignore'; got {on_drift!r}"
+            )
+
         if isinstance(tables, TableDef):
             tables = (tables,)
+
+        drift = self._detect_drift(tables)
+        if drift:
+            if on_drift == "raise":
+                raise LocalLakehouseSchemaDrift(drift)
+            if on_drift == "evolve":
+                self._apply_drift(drift, tables)
+            # on_drift == "ignore" — intentionally fall through without ALTER.
 
         for table in tables:
             self._tables[table.name] = table
             self._conn.execute(table.to_duckdb_ddl(self.schema))
         return len(tables)
+
+    def evolve_schema(
+        self, tables: TableDef | tuple[TableDef, ...] | list[TableDef]
+    ) -> int:
+        """Evolve the DuckDB schema to match the given ``TableDef``(s).
+
+        Creates any tables that don't exist yet and issues
+        ``ALTER TABLE ... ADD COLUMN`` for every column present in the
+        ``TableDef`` but missing from the existing table. Existing rows
+        are preserved; new columns are added as nullable regardless of
+        the ``Col.nullable`` flag, because DuckDB cannot add a NOT NULL
+        column to a populated table without a default.
+
+        No-ops when the live schema already matches the definitions.
+
+        Returns the number of tables processed.
+        """
+        if isinstance(tables, TableDef):
+            tables = (tables,)
+
+        drift = self._detect_drift(tables)
+        if drift:
+            self._apply_drift(drift, tables)
+
+        for table in tables:
+            self._tables[table.name] = table
+            # CREATE IF NOT EXISTS covers the "table is new" case; ALTERs
+            # above have already handled additive drift on existing tables.
+            self._conn.execute(table.to_duckdb_ddl(self.schema))
+        return len(tables)
+
+    def _existing_columns(self, table_name: str) -> list[str]:
+        rows = self._conn.execute(
+            "SELECT column_name FROM information_schema.columns "
+            "WHERE table_schema = ? AND table_name = ? "
+            "ORDER BY ordinal_position",
+            [self.schema, table_name],
+        ).fetchall()
+        return [r[0] for r in rows]
+
+    def _detect_drift(
+        self, tables: tuple[TableDef, ...] | list[TableDef]
+    ) -> dict[str, list[str]]:
+        """Return {table_name: [missing_column, ...]} for tables that
+        already exist but are missing columns from their TableDef.
+
+        Non-existent tables are skipped — they will be CREATE'd on the
+        normal path. Only additive drift (TableDef columns missing from
+        the live table) is reported.
+        """
+        drift: dict[str, list[str]] = {}
+        for table in tables:
+            existing = self._existing_columns(table.name)
+            if not existing:
+                continue
+            existing_set = set(existing)
+            missing = [c.name for c in table.columns if c.name not in existing_set]
+            if missing:
+                drift[table.name] = missing
+        return drift
+
+    def _apply_drift(
+        self,
+        drift: dict[str, list[str]],
+        tables: tuple[TableDef, ...] | list[TableDef],
+    ) -> None:
+        from pyfabric.data.schema import DUCKDB_TYPES
+
+        by_name = {t.name: t for t in tables}
+        for table_name, missing in drift.items():
+            table = by_name[table_name]
+            for col_name in missing:
+                col = table.column(col_name)
+                duck_type = DUCKDB_TYPES[col.type_key]
+                self._conn.execute(
+                    f"ALTER TABLE {self.schema}.{table_name} "
+                    f"ADD COLUMN {col_name} {duck_type}"
+                )
+                log.info(
+                    "evolved_schema_added_column",
+                    table=table_name,
+                    column=col_name,
+                    duckdb_type=duck_type,
+                )
 
     def registered_tables(self) -> dict[str, TableDef]:
         """Return a copy of the registered TableDef map."""
@@ -279,10 +423,14 @@ class LocalLakehouse:
         *,
         mode: str = "overwrite",
         skip_empty: bool = False,
+        target_schema: str | None = None,
     ) -> int:
         """Push a single DuckDB table to OneLake as a Delta table.
 
-        Writes to ``Tables/{schema}/{table_name}/`` in the lakehouse.
+        Writes to ``Tables/{target_schema or self.schema}/{table_name}/``
+        in the lakehouse. The source SELECT always reads from
+        ``self.schema`` — ``target_schema`` only affects the destination
+        OneLake path.
 
         Args:
             credential: FabricCredential for storage token.
@@ -295,19 +443,42 @@ class LocalLakehouse:
                 or access was denied" when the delta log is missing —
                 zero-row deltas are valid and DirectLake-compatible, so
                 writing them is the safer default.
+            target_schema: Override the destination lakehouse schema.
+                Defaults to ``self.schema``. Useful when one local
+                DuckDB file holds multiple medallion layers
+                (``dbo`` / ``silver`` / ``gold``) and each pushes to a
+                separate Fabric lakehouse that uses ``dbo`` as its
+                canonical target schema.
 
         Returns:
             Number of rows written.
         """
         from pyfabric.data.lakehouse import write_table
 
+        if target_schema is not None and not target_schema.strip():
+            raise ValueError(
+                "target_schema must be a non-empty string or None; "
+                f"got {target_schema!r}"
+            )
+
+        effective_target = target_schema or self.schema
+
         # .arrow() returns RecordBatchReader; .read_all() materializes to Table
         reader = self._conn.execute(f"SELECT * FROM {self.schema}.{table_name}").arrow()
         arrow_table = reader.read_all() if hasattr(reader, "read_all") else reader
 
         if arrow_table.num_rows == 0 and skip_empty:
-            log.info("Skipping empty table: %s", table_name)
+            log.info("skipping_empty_table", table=table_name)
             return 0
+
+        if effective_target != self.schema:
+            log.info(
+                "pushing_table_cross_schema",
+                table=table_name,
+                source_schema=self.schema,
+                target_schema=effective_target,
+                rows=arrow_table.num_rows,
+            )
 
         result = write_table(
             credential,
@@ -315,7 +486,7 @@ class LocalLakehouse:
             self.lh_id,
             table_name,
             arrow_table,
-            schema=self.schema,
+            schema=effective_target,
             mode=mode,
             source="LocalLakehouse.push_table",
         )
@@ -328,6 +499,7 @@ class LocalLakehouse:
         mode: str = "overwrite",
         tables: list[str] | None = None,
         skip_empty: bool = False,
+        target_schema: str | None = None,
     ) -> dict[str, int]:
         """Push tables to OneLake, including zero-row ones by default.
 
@@ -343,6 +515,8 @@ class LocalLakehouse:
                         or access was denied" when the delta log is
                         missing — writing zero-row deltas keeps the log
                         valid and DirectLake-compatible.
+            target_schema: Override the destination lakehouse schema for
+                        every pushed table. See :meth:`push_table`.
 
         Returns:
             Dict of {table_name: rows_written}. Skipped-empty tables
@@ -355,24 +529,25 @@ class LocalLakehouse:
             count = self.row_count(name)
             if count == 0 and skip_empty:
                 continue
-            log.info("Pushing %s (%d rows)", name, count)
+            log.info("pushing_table", table=name, rows=count)
             try:
                 written = self.push_table(
                     credential,
                     name,
                     mode=mode,
                     skip_empty=skip_empty,
+                    target_schema=target_schema,
                 )
                 results[name] = written
             except Exception as e:
-                log.error("Failed to push %s: %s", name, e)
+                log.error("push_table_failed", table=name, error=str(e))
                 results[name] = -1  # signal failure
 
         total = sum(v for v in results.values() if v >= 0)
         log.info(
-            "Push complete: %d rows across %d tables",
-            total,
-            sum(1 for v in results.values() if v >= 0),
+            "push_complete",
+            total_rows=total,
+            table_count=sum(1 for v in results.values() if v >= 0),
         )
         return results
 
@@ -413,6 +588,64 @@ class LocalLakehouse:
             )
 
         return len(df)
+
+    # ── Schema rename ────────────────────────────────────────────────────────
+
+    def rename_schema(self, src_schema: str, dst_schema: str) -> list[str]:
+        """Rename a DuckDB schema by moving every table into a new schema.
+
+        DuckDB 1.5.x has no ``ALTER SCHEMA ... RENAME``, so this uses the
+        portable ``CREATE TABLE dst.x AS SELECT * FROM src.x`` pattern
+        followed by ``DROP TABLE src.x`` and ``DROP SCHEMA src``. Rows
+        are preserved; column types follow whatever DuckDB infers from
+        ``SELECT *`` (matches the source exactly).
+
+        If ``src_schema`` is the current ``self.schema`` the attribute
+        is updated to ``dst_schema`` so subsequent calls on this handle
+        target the renamed location without a reopen.
+
+        Returns the list of table names that moved.
+        """
+        if src_schema == dst_schema:
+            raise ValueError(
+                f"rename_schema src and dst are identical ({src_schema!r}); "
+                "nothing to do"
+            )
+
+        schemas = {
+            r[0]
+            for r in self._conn.execute(
+                "SELECT schema_name FROM information_schema.schemata"
+            ).fetchall()
+        }
+        if src_schema not in schemas:
+            raise ValueError(f"source schema {src_schema!r} does not exist")
+
+        table_rows = self._conn.execute(
+            "SELECT table_name FROM information_schema.tables "
+            "WHERE table_schema = ? ORDER BY table_name",
+            [src_schema],
+        ).fetchall()
+        tables = [r[0] for r in table_rows]
+
+        self._conn.execute(f"CREATE SCHEMA IF NOT EXISTS {dst_schema}")
+        for name in tables:
+            self._conn.execute(
+                f"CREATE TABLE {dst_schema}.{name} AS SELECT * FROM {src_schema}.{name}"
+            )
+            self._conn.execute(f"DROP TABLE {src_schema}.{name}")
+        self._conn.execute(f"DROP SCHEMA {src_schema}")
+
+        if self.schema == src_schema:
+            self.schema = dst_schema
+
+        log.info(
+            "local_rename_schema_complete",
+            src_schema=src_schema,
+            dst_schema=dst_schema,
+            moved_count=len(tables),
+        )
+        return tables
 
     # ── Lifecycle ────────────────────────────────────────────────────────────
 

--- a/src/pyfabric/data/onelake.py
+++ b/src/pyfabric/data/onelake.py
@@ -424,6 +424,50 @@ def delete_file(token: str, ws_id: str, item_id: str, path: str) -> bool:
     return r.status_code in (200, 202)
 
 
+def delete_path(
+    token: str,
+    ws_id: str,
+    item_id: str,
+    path: str,
+    *,
+    recursive: bool = False,
+) -> bool:
+    """Delete a file or directory at ``{item_id}/{path}``.
+
+    Returns True if deleted, False if the path did not exist (404).
+
+    Use ``recursive=True`` to delete a directory and all of its contents
+    (required by the ADLS Gen2 DFS API for non-empty directories).
+    """
+    url = _dfs_url(ws_id, item_id, path)
+    params = {"recursive": "true"} if recursive else None
+    r = _get_session().delete(url, headers=_hdrs(token), params=params)
+    if r.status_code == 404:
+        return False
+    r.raise_for_status()
+    return True
+
+
+def rename_path(
+    token: str,
+    ws_id: str,
+    item_id: str,
+    src_path: str,
+    dst_path: str,
+) -> None:
+    """Rename a file or directory at ``{item_id}/{src_path}`` to ``dst_path``.
+
+    Metadata-only move — no data rewrite. The destination is addressed by
+    PUT on its URL with the ``x-ms-rename-source`` header pointing at the
+    source, per the ADLS Gen2 DFS protocol.
+    """
+    url = _dfs_url(ws_id, item_id, dst_path)
+    rename_source = f"/{ws_id}/{item_id}/{src_path}"
+    headers = {**_hdrs(token), "x-ms-rename-source": rename_source}
+    r = _get_session().put(url, headers=headers)
+    r.raise_for_status()
+
+
 def upload_parquet(
     token: str,
     ws_id: str,

--- a/tests/data/test_lakehouse_ddl.py
+++ b/tests/data/test_lakehouse_ddl.py
@@ -1,0 +1,308 @@
+"""Tests for the lakehouse DDL-management helpers (issue #39).
+
+Every schema migration today leaves orphaned tables behind because the
+portal UI is the only way to drop/rename Delta tables in a Fabric
+lakehouse. These helpers provide a programmatic path.
+
+All tests mock the OneLake DFS layer at the ``pyfabric.data.onelake``
+seam (``list_paths``, ``delete_path``, ``rename_path``). None of them
+talk to the network.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# Attribute access on the module object rather than a ``from ... import``
+# so that a sibling test's ``importlib.reload`` (see
+# ``TestWriteTableWithoutPandas``) doesn't leave this module holding a
+# stale class reference that no longer matches ``pytest.raises`` against
+# what ``rename_schema`` actually raises at call time.
+from pyfabric.data import lakehouse as _lh
+
+delete_table = _lh.delete_table
+drop_schema = _lh.drop_schema
+list_schemas = _lh.list_schemas
+list_tables = _lh.list_tables
+rename_schema = _lh.rename_schema
+rename_table = _lh.rename_table
+
+
+WS = "00000000-0000-0000-0000-000000000000"
+LH = "11111111-1111-1111-1111-111111111111"
+
+
+@pytest.fixture
+def fake_credential():
+    class _FakeCred:
+        storage_token = "fake-token"
+
+    return _FakeCred()
+
+
+def _path_entry(name: str, *, is_dir: bool) -> dict:
+    """Shape matches the DFS filesystem API response."""
+    return {"name": name, "isDirectory": "true" if is_dir else "false"}
+
+
+# ── delete_table ────────────────────────────────────────────────────────────
+
+
+class TestDeleteTable:
+    def test_deletes_table_directory_recursively(self, fake_credential):
+        with patch("pyfabric.data.lakehouse.onelake.delete_path") as mock_del:
+            mock_del.return_value = True
+            result = delete_table(fake_credential, WS, LH, "widgets", schema="dbo")
+        assert result is True
+        mock_del.assert_called_once()
+        args, kwargs = mock_del.call_args
+        assert args[0] == "fake-token"
+        assert args[1] == WS
+        assert args[2] == LH
+        assert args[3] == "Tables/dbo/widgets"
+        assert kwargs.get("recursive") is True
+
+    def test_returns_false_when_table_missing(self, fake_credential):
+        with patch("pyfabric.data.lakehouse.onelake.delete_path") as mock_del:
+            mock_del.return_value = False
+            result = delete_table(fake_credential, WS, LH, "missing")
+        assert result is False
+
+
+# ── rename_table ────────────────────────────────────────────────────────────
+
+
+class TestRenameTable:
+    def test_renames_within_same_schema(self, fake_credential):
+        with patch("pyfabric.data.lakehouse.onelake.rename_path") as mock_ren:
+            rename_table(fake_credential, WS, LH, "src", "dst", schema="dbo")
+        mock_ren.assert_called_once_with(
+            "fake-token",
+            WS,
+            LH,
+            "Tables/dbo/src",
+            "Tables/dbo/dst",
+        )
+
+    def test_refuses_when_src_equals_dst(self, fake_credential):
+        with (
+            patch("pyfabric.data.lakehouse.onelake.rename_path") as mock_ren,
+            pytest.raises(ValueError, match="identical"),
+        ):
+            rename_table(fake_credential, WS, LH, "same", "same")
+        mock_ren.assert_not_called()
+
+
+# ── rename_schema ───────────────────────────────────────────────────────────
+
+
+class TestRenameSchema:
+    def test_moves_every_table_to_new_schema(self, fake_credential):
+        with (
+            patch("pyfabric.data.lakehouse.onelake.list_paths") as mock_ls,
+            patch("pyfabric.data.lakehouse.onelake.rename_path") as mock_ren,
+        ):
+            mock_ls.return_value = [
+                _path_entry(f"{LH}/Tables/old/a", is_dir=True),
+                _path_entry(f"{LH}/Tables/old/b", is_dir=True),
+                _path_entry(f"{LH}/Tables/old/c", is_dir=True),
+            ]
+            moved = rename_schema(fake_credential, WS, LH, "old", "new")
+        assert sorted(moved) == ["a", "b", "c"]
+        assert mock_ren.call_count == 3
+        # Each rename sends src=Tables/old/<t>, dst=Tables/new/<t>
+        src_dst_pairs = {
+            (call.args[3], call.args[4]) for call in mock_ren.call_args_list
+        }
+        assert src_dst_pairs == {
+            ("Tables/old/a", "Tables/new/a"),
+            ("Tables/old/b", "Tables/new/b"),
+            ("Tables/old/c", "Tables/new/c"),
+        }
+
+    def test_partial_failure_raises_structured_exception(self, fake_credential):
+        with (
+            patch("pyfabric.data.lakehouse.onelake.list_paths") as mock_ls,
+            patch("pyfabric.data.lakehouse.onelake.rename_path") as mock_ren,
+        ):
+            mock_ls.return_value = [
+                _path_entry(f"{LH}/Tables/old/a", is_dir=True),
+                _path_entry(f"{LH}/Tables/old/b", is_dir=True),
+                _path_entry(f"{LH}/Tables/old/c", is_dir=True),
+            ]
+            mock_ren.side_effect = [None, RuntimeError("409 conflict"), None]
+            # Attribute lookup on the live module so the class identity
+            # matches even if another test has reloaded the module since
+            # import time.
+            with pytest.raises(_lh.LakehouseRenameSchemaError) as exc:
+                rename_schema(fake_credential, WS, LH, "old", "new")
+        err = exc.value
+        assert set(err.moved) == {"a", "c"}
+        assert "b" in err.failed
+        assert "409 conflict" in err.failed["b"]
+        # Every table was attempted (no early abort).
+        assert mock_ren.call_count == 3
+
+    def test_no_tables_in_source_schema_returns_empty(self, fake_credential):
+        with (
+            patch("pyfabric.data.lakehouse.onelake.list_paths") as mock_ls,
+            patch("pyfabric.data.lakehouse.onelake.rename_path") as mock_ren,
+        ):
+            mock_ls.return_value = []
+            moved = rename_schema(fake_credential, WS, LH, "empty", "new")
+        assert moved == []
+        mock_ren.assert_not_called()
+
+    def test_refuses_when_src_equals_dst(self, fake_credential):
+        with (
+            patch("pyfabric.data.lakehouse.onelake.rename_path") as mock_ren,
+            pytest.raises(ValueError, match="identical"),
+        ):
+            rename_schema(fake_credential, WS, LH, "x", "x")
+        mock_ren.assert_not_called()
+
+
+# ── drop_schema ─────────────────────────────────────────────────────────────
+
+
+class TestDropSchema:
+    def test_deletes_schema_directory_recursively(self, fake_credential):
+        with patch("pyfabric.data.lakehouse.onelake.delete_path") as mock_del:
+            mock_del.return_value = True
+            result = drop_schema(fake_credential, WS, LH, "old")
+        assert result is True
+        args, kwargs = mock_del.call_args
+        assert args[3] == "Tables/old"
+        assert kwargs.get("recursive") is True
+
+    def test_returns_false_when_schema_missing(self, fake_credential):
+        with patch("pyfabric.data.lakehouse.onelake.delete_path") as mock_del:
+            mock_del.return_value = False
+            result = drop_schema(fake_credential, WS, LH, "gone")
+        assert result is False
+
+
+# ── list_schemas ────────────────────────────────────────────────────────────
+
+
+class TestListSchemas:
+    def test_returns_schema_directory_basenames(self, fake_credential):
+        with patch("pyfabric.data.lakehouse.onelake.list_paths") as mock_ls:
+            mock_ls.return_value = [
+                _path_entry(f"{LH}/Tables/dbo", is_dir=True),
+                _path_entry(f"{LH}/Tables/silver", is_dir=True),
+                _path_entry(f"{LH}/Tables/gold", is_dir=True),
+            ]
+            schemas = list_schemas(fake_credential, WS, LH)
+        assert sorted(schemas) == ["dbo", "gold", "silver"]
+        mock_ls.assert_called_once()
+        assert mock_ls.call_args.args[3] == "Tables"
+
+    def test_filters_out_non_directory_entries(self, fake_credential):
+        with patch("pyfabric.data.lakehouse.onelake.list_paths") as mock_ls:
+            mock_ls.return_value = [
+                _path_entry(f"{LH}/Tables/dbo", is_dir=True),
+                _path_entry(f"{LH}/Tables/readme.md", is_dir=False),
+            ]
+            schemas = list_schemas(fake_credential, WS, LH)
+        assert schemas == ["dbo"]
+
+    def test_empty_when_no_schemas(self, fake_credential):
+        with patch("pyfabric.data.lakehouse.onelake.list_paths") as mock_ls:
+            mock_ls.return_value = []
+            schemas = list_schemas(fake_credential, WS, LH)
+        assert schemas == []
+
+
+# ── list_tables ─────────────────────────────────────────────────────────────
+
+
+class TestListTables:
+    def test_lists_tables_in_single_schema(self, fake_credential):
+        with patch("pyfabric.data.lakehouse.onelake.list_paths") as mock_ls:
+            mock_ls.return_value = [
+                _path_entry(f"{LH}/Tables/dbo/widgets", is_dir=True),
+                _path_entry(f"{LH}/Tables/dbo/gizmos", is_dir=True),
+            ]
+            tables = list_tables(fake_credential, WS, LH, schema="dbo")
+        assert sorted(tables) == ["gizmos", "widgets"]
+        assert mock_ls.call_args.args[3] == "Tables/dbo"
+
+    def test_lists_all_tables_flattened_as_qualified_names(self, fake_credential):
+        def side_effect(token, ws, lh, path, recursive=False):
+            if path == "Tables":
+                return [
+                    _path_entry(f"{LH}/Tables/dbo", is_dir=True),
+                    _path_entry(f"{LH}/Tables/silver", is_dir=True),
+                ]
+            if path == "Tables/dbo":
+                return [_path_entry(f"{LH}/Tables/dbo/a", is_dir=True)]
+            if path == "Tables/silver":
+                return [_path_entry(f"{LH}/Tables/silver/b", is_dir=True)]
+            return []
+
+        with patch(
+            "pyfabric.data.lakehouse.onelake.list_paths", side_effect=side_effect
+        ):
+            tables = list_tables(fake_credential, WS, LH)
+        assert sorted(tables) == ["dbo.a", "silver.b"]
+
+    def test_empty_schema_returns_empty(self, fake_credential):
+        with patch("pyfabric.data.lakehouse.onelake.list_paths") as mock_ls:
+            mock_ls.return_value = []
+            assert list_tables(fake_credential, WS, LH, schema="dbo") == []
+
+
+# ── onelake.delete_path / rename_path (unit-level) ──────────────────────────
+
+
+class TestOnelakeDeletePath:
+    def test_delete_path_issues_recursive_delete(self):
+        from pyfabric.data import onelake
+
+        session = MagicMock()
+        resp = MagicMock()
+        resp.status_code = 200
+        session.delete.return_value = resp
+
+        with patch("pyfabric.data.onelake._get_session", return_value=session):
+            result = onelake.delete_path(
+                "tok", WS, LH, "Tables/dbo/widgets", recursive=True
+            )
+        assert result is True
+        # URL and ?recursive=true assembled correctly.
+        url = session.delete.call_args.args[0]
+        assert url.endswith(f"/{WS}/{LH}/Tables/dbo/widgets")
+        assert session.delete.call_args.kwargs.get("params") == {"recursive": "true"}
+
+    def test_delete_path_returns_false_on_404(self):
+        from pyfabric.data import onelake
+
+        session = MagicMock()
+        resp = MagicMock()
+        resp.status_code = 404
+        session.delete.return_value = resp
+        with patch("pyfabric.data.onelake._get_session", return_value=session):
+            result = onelake.delete_path("tok", WS, LH, "Tables/missing")
+        assert result is False
+
+
+class TestOnelakeRenamePath:
+    def test_rename_path_issues_put_with_rename_source_header(self):
+        from pyfabric.data import onelake
+
+        session = MagicMock()
+        resp = MagicMock()
+        resp.status_code = 201
+        session.put.return_value = resp
+
+        with patch("pyfabric.data.onelake._get_session", return_value=session):
+            onelake.rename_path("tok", WS, LH, "Tables/old/a", "Tables/new/a")
+        url = session.put.call_args.args[0]
+        headers = session.put.call_args.kwargs["headers"]
+        assert url.endswith(f"/{WS}/{LH}/Tables/new/a")
+        # x-ms-rename-source points at /{filesystem}/{src_full_path}; the
+        # filesystem is the workspace id and the path is item_id/src.
+        assert headers["x-ms-rename-source"] == f"/{WS}/{LH}/Tables/old/a"

--- a/tests/data/test_local_lakehouse_push.py
+++ b/tests/data/test_local_lakehouse_push.py
@@ -94,3 +94,55 @@ class TestPushAllEmptyDefault:
             results = lh.push_all(fake_credential, tables=["empty_tbl"])
         assert set(results.keys()) == {"empty_tbl"}
         assert mock_write.call_count == 1
+
+
+class TestPushTableTargetSchema:
+    def test_default_target_schema_matches_source(self, lh, fake_credential):
+        """Back-compat: without target_schema, push uses self.schema."""
+        with patch("pyfabric.data.lakehouse.write_table") as mock_write:
+            mock_write.return_value = MagicMock(row_count=2)
+            lh.push_table(fake_credential, "full_tbl")
+        assert mock_write.call_args.kwargs["schema"] == "dbo"
+
+    def test_target_schema_override_routes_write_to_target(self, lh, fake_credential):
+        """SELECT reads source schema; write_table gets the override."""
+        with patch("pyfabric.data.lakehouse.write_table") as mock_write:
+            mock_write.return_value = MagicMock(row_count=2)
+            lh.push_table(fake_credential, "full_tbl", target_schema="silver_dbo")
+        assert mock_write.call_args.kwargs["schema"] == "silver_dbo"
+        # Arrow payload came from the source schema, so row count matches.
+        arrow_arg = mock_write.call_args.args[4]
+        assert arrow_arg.num_rows == 2
+
+    def test_target_schema_empty_string_rejected(self, lh, fake_credential):
+        with (
+            patch("pyfabric.data.lakehouse.write_table") as mock_write,
+            pytest.raises(ValueError, match="target_schema"),
+        ):
+            lh.push_table(fake_credential, "full_tbl", target_schema="")
+        mock_write.assert_not_called()
+
+    def test_target_schema_whitespace_rejected(self, lh, fake_credential):
+        with (
+            patch("pyfabric.data.lakehouse.write_table") as mock_write,
+            pytest.raises(ValueError, match="target_schema"),
+        ):
+            lh.push_table(fake_credential, "full_tbl", target_schema="   ")
+        mock_write.assert_not_called()
+
+
+class TestPushAllTargetSchema:
+    def test_push_all_passes_target_schema_to_every_table(self, lh, fake_credential):
+        with patch("pyfabric.data.lakehouse.write_table") as mock_write:
+            mock_write.return_value = MagicMock(row_count=0)
+            lh.push_all(fake_credential, target_schema="gold_dbo")
+        assert mock_write.call_count == 2
+        for call in mock_write.call_args_list:
+            assert call.kwargs["schema"] == "gold_dbo"
+
+    def test_push_all_default_target_matches_source(self, lh, fake_credential):
+        with patch("pyfabric.data.lakehouse.write_table") as mock_write:
+            mock_write.return_value = MagicMock(row_count=0)
+            lh.push_all(fake_credential)
+        for call in mock_write.call_args_list:
+            assert call.kwargs["schema"] == "dbo"

--- a/tests/data/test_local_lakehouse_rename_schema.py
+++ b/tests/data/test_local_lakehouse_rename_schema.py
@@ -1,0 +1,91 @@
+"""Tests for ``LocalLakehouse.rename_schema``.
+
+DuckDB 1.5.x doesn't support ``ALTER SCHEMA ... RENAME``. The helper
+implements the standard workaround (CREATE TABLE dst.x AS SELECT * FROM
+src.x; DROP TABLE src.x; DROP SCHEMA src) so caller code is portable
+local↔remote with the matching OneLake helper.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from pyfabric.data import Col, LocalLakehouse, TableDef
+
+
+def _lh(tmp_path, schema="old"):
+    return LocalLakehouse(
+        db_path=tmp_path / "lh.duckdb", ws_id="w", lh_id="l", schema=schema
+    )
+
+
+class TestLocalRenameSchema:
+    def test_renames_schema_with_rows_preserved(self, tmp_path):
+        lh = _lh(tmp_path)
+        lh.register(
+            TableDef(
+                name="widgets",
+                columns=(
+                    Col("id", "int", nullable=False, pk=True),
+                    Col("name", "string"),
+                ),
+            )
+        )
+        lh.conn.execute("INSERT INTO old.widgets VALUES (1, 'alpha'), (2, 'beta')")
+
+        lh.rename_schema("old", "new")
+
+        schemas = {
+            r[0]
+            for r in lh.conn.execute(
+                "SELECT schema_name FROM information_schema.schemata"
+            ).fetchall()
+        }
+        assert "new" in schemas
+        assert "old" not in schemas
+
+        row_count = lh.conn.execute("SELECT COUNT(*) FROM new.widgets").fetchone()
+        assert row_count is not None and row_count[0] == 2
+
+    def test_moves_self_schema_attribute(self, tmp_path):
+        lh = _lh(tmp_path)
+        lh.register(
+            TableDef(
+                name="widgets",
+                columns=(Col("id", "int", nullable=False, pk=True),),
+            )
+        )
+        lh.rename_schema("old", "new")
+        # After renaming the current schema, subsequent operations should
+        # target 'new' without the caller having to reopen the handle.
+        assert lh.schema == "new"
+        assert "widgets" in lh.table_names()
+
+    def test_self_schema_unchanged_when_renaming_a_different_schema(self, tmp_path):
+        lh = _lh(tmp_path, schema="dbo")
+        lh.conn.execute("CREATE SCHEMA staging")
+        lh.conn.execute("CREATE TABLE staging.t (id INT)")
+        lh.rename_schema("staging", "stage2")
+        assert lh.schema == "dbo"
+        assert {
+            r[0]
+            for r in lh.conn.execute(
+                "SELECT schema_name FROM information_schema.schemata"
+            ).fetchall()
+        } >= {"dbo", "stage2"}
+
+    def test_src_equals_dst_rejected(self, tmp_path):
+        lh = _lh(tmp_path)
+        lh.register(
+            TableDef(
+                name="widgets",
+                columns=(Col("id", "int", nullable=False, pk=True),),
+            )
+        )
+        with pytest.raises(ValueError, match="identical"):
+            lh.rename_schema("old", "old")
+
+    def test_missing_source_schema_raises(self, tmp_path):
+        lh = _lh(tmp_path, schema="dbo")
+        with pytest.raises(ValueError, match="does not exist"):
+            lh.rename_schema("never_created", "new")

--- a/tests/data/test_local_lakehouse_schema_drift.py
+++ b/tests/data/test_local_lakehouse_schema_drift.py
@@ -1,0 +1,269 @@
+"""Tests for ``LocalLakehouse.register`` schema-drift detection and
+``evolve_schema`` additive-migration support.
+
+The underlying bug: ``register()`` uses ``CREATE TABLE IF NOT EXISTS``, so
+when a caller reopens a pre-existing DuckDB file with a newer ``TableDef``
+(extra columns added), the table silently keeps the old shape. Subsequent
+inserts drop the new columns without warning. The fix surfaces the drift
+explicitly (raise by default) and offers an opt-in evolve path.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from pyfabric.data import Col, LocalLakehouse, TableDef
+from pyfabric.data.local_lakehouse import LocalLakehouseSchemaDrift
+
+
+def _reopen(db_path, schema="dbo"):
+    return LocalLakehouse(db_path=db_path, ws_id="w", lh_id="l", schema=schema)
+
+
+class TestRegisterDriftRaisesByDefault:
+    def test_register_raises_on_column_drift(self, tmp_path):
+        db = tmp_path / "drift.duckdb"
+        with _reopen(db) as lh:
+            v1 = TableDef(
+                name="widgets",
+                columns=(
+                    Col("id", "int", nullable=False, pk=True),
+                    Col("name", "string"),
+                ),
+            )
+            lh.register(v1)
+
+        with _reopen(db) as lh:
+            v2 = TableDef(
+                name="widgets",
+                columns=(
+                    Col("id", "int", nullable=False, pk=True),
+                    Col("name", "string"),
+                    Col("color", "string"),
+                ),
+            )
+            with pytest.raises(LocalLakehouseSchemaDrift) as exc:
+                lh.register(v2)
+        msg = str(exc.value)
+        assert "widgets" in msg
+        assert "color" in msg
+
+    def test_drift_exception_lists_all_missing_columns(self, tmp_path):
+        db = tmp_path / "drift_multi.duckdb"
+        with _reopen(db) as lh:
+            lh.register(
+                TableDef(
+                    name="widgets",
+                    columns=(Col("id", "int", nullable=False, pk=True),),
+                )
+            )
+
+        v2 = TableDef(
+            name="widgets",
+            columns=(
+                Col("id", "int", nullable=False, pk=True),
+                Col("name", "string"),
+                Col("color", "string"),
+                Col("qty", "int"),
+            ),
+        )
+        with _reopen(db) as lh, pytest.raises(LocalLakehouseSchemaDrift) as exc:
+            lh.register(v2)
+        msg = str(exc.value)
+        for added in ("name", "color", "qty"):
+            assert added in msg
+
+    def test_register_no_raise_when_schema_matches(self, tmp_path):
+        db = tmp_path / "aligned.duckdb"
+        t = TableDef(
+            name="widgets",
+            columns=(
+                Col("id", "int", nullable=False, pk=True),
+                Col("name", "string"),
+            ),
+        )
+        with _reopen(db) as lh:
+            lh.register(t)
+        # Re-registering the same TableDef must be a no-op, not a raise.
+        with _reopen(db) as lh:
+            assert lh.register(t) == 1
+
+
+class TestRegisterOnDriftIgnore:
+    def test_ignore_preserves_old_silent_behaviour(self, tmp_path):
+        db = tmp_path / "ignore.duckdb"
+        with _reopen(db) as lh:
+            lh.register(
+                TableDef(
+                    name="widgets",
+                    columns=(
+                        Col("id", "int", nullable=False, pk=True),
+                        Col("name", "string"),
+                    ),
+                )
+            )
+
+        v2 = TableDef(
+            name="widgets",
+            columns=(
+                Col("id", "int", nullable=False, pk=True),
+                Col("name", "string"),
+                Col("color", "string"),
+            ),
+        )
+        with _reopen(db) as lh:
+            # No raise — caller has explicitly opted out of drift detection.
+            assert lh.register(v2, on_drift="ignore") == 1
+            # Table still has only the original two columns.
+            cols = [
+                r[0]
+                for r in lh.conn.execute(
+                    "SELECT column_name FROM information_schema.columns "
+                    "WHERE table_schema = 'dbo' AND table_name = 'widgets' "
+                    "ORDER BY ordinal_position"
+                ).fetchall()
+            ]
+            assert cols == ["id", "name"]
+
+
+class TestRegisterOnDriftEvolve:
+    def test_evolve_adds_missing_columns(self, tmp_path):
+        db = tmp_path / "evolve_flag.duckdb"
+        with _reopen(db) as lh:
+            lh.register(
+                TableDef(
+                    name="widgets",
+                    columns=(
+                        Col("id", "int", nullable=False, pk=True),
+                        Col("name", "string"),
+                    ),
+                )
+            )
+            lh.conn.execute("INSERT INTO dbo.widgets VALUES (1, 'alpha')")
+
+        v2 = TableDef(
+            name="widgets",
+            columns=(
+                Col("id", "int", nullable=False, pk=True),
+                Col("name", "string"),
+                Col("color", "string"),
+            ),
+        )
+        with _reopen(db) as lh:
+            assert lh.register(v2, on_drift="evolve") == 1
+            cols = [
+                r[0]
+                for r in lh.conn.execute(
+                    "SELECT column_name FROM information_schema.columns "
+                    "WHERE table_schema = 'dbo' AND table_name = 'widgets' "
+                    "ORDER BY ordinal_position"
+                ).fetchall()
+            ]
+            assert cols == ["id", "name", "color"]
+            row = lh.conn.execute("SELECT id, name, color FROM dbo.widgets").fetchone()
+            assert row == (1, "alpha", None)
+
+
+class TestEvolveSchemaMethod:
+    def test_adds_missing_columns_preserving_existing_rows(self, tmp_path):
+        db = tmp_path / "evolve.duckdb"
+        with _reopen(db) as lh:
+            lh.register(
+                TableDef(
+                    name="widgets",
+                    columns=(
+                        Col("id", "int", nullable=False, pk=True),
+                        Col("name", "string"),
+                    ),
+                )
+            )
+            lh.conn.execute("INSERT INTO dbo.widgets VALUES (1, 'alpha')")
+
+        v2 = TableDef(
+            name="widgets",
+            columns=(
+                Col("id", "int", nullable=False, pk=True),
+                Col("name", "string"),
+                Col("color", "string"),
+            ),
+        )
+        with _reopen(db) as lh:
+            lh.evolve_schema(v2)
+            cols = [
+                r[0]
+                for r in lh.conn.execute(
+                    "SELECT column_name FROM information_schema.columns "
+                    "WHERE table_schema = 'dbo' AND table_name = 'widgets' "
+                    "ORDER BY ordinal_position"
+                ).fetchall()
+            ]
+            assert cols == ["id", "name", "color"]
+            row = lh.conn.execute("SELECT id, name, color FROM dbo.widgets").fetchone()
+            assert row == (1, "alpha", None)
+
+    def test_creates_missing_tables(self, tmp_path):
+        db = tmp_path / "create_missing.duckdb"
+        with _reopen(db) as lh:
+            # No prior registration — evolve should create the table.
+            lh.evolve_schema(
+                TableDef(
+                    name="gizmos",
+                    columns=(
+                        Col("id", "int", nullable=False, pk=True),
+                        Col("label", "string"),
+                    ),
+                )
+            )
+            assert "gizmos" in lh.table_names()
+
+    def test_no_op_when_aligned(self, tmp_path):
+        db = tmp_path / "noop.duckdb"
+        t = TableDef(
+            name="widgets",
+            columns=(
+                Col("id", "int", nullable=False, pk=True),
+                Col("name", "string"),
+            ),
+        )
+        with _reopen(db) as lh:
+            lh.register(t)
+            lh.conn.execute("INSERT INTO dbo.widgets VALUES (1, 'alpha')")
+
+        with _reopen(db) as lh:
+            lh.evolve_schema(t)  # no drift — must not error
+            cols = [
+                r[0]
+                for r in lh.conn.execute(
+                    "SELECT column_name FROM information_schema.columns "
+                    "WHERE table_schema = 'dbo' AND table_name = 'widgets' "
+                    "ORDER BY ordinal_position"
+                ).fetchall()
+            ]
+            assert cols == ["id", "name"]
+
+    def test_accepts_sequence_of_tables(self, tmp_path):
+        db = tmp_path / "evolve_many.duckdb"
+        a = TableDef(
+            name="a",
+            columns=(Col("id", "int", nullable=False, pk=True),),
+        )
+        b = TableDef(
+            name="b",
+            columns=(Col("id", "int", nullable=False, pk=True),),
+        )
+        with _reopen(db) as lh:
+            lh.evolve_schema([a, b])
+            assert set(lh.table_names()) >= {"a", "b"}
+
+
+class TestRegisterOnDriftInvalid:
+    def test_rejects_unknown_on_drift_value(self, tmp_path):
+        db = tmp_path / "bad_flag.duckdb"
+        with _reopen(db) as lh, pytest.raises(ValueError, match="on_drift"):
+            lh.register(
+                TableDef(
+                    name="widgets",
+                    columns=(Col("id", "int", nullable=False, pk=True),),
+                ),
+                on_drift="wat",  # type: ignore[arg-type]
+            )


### PR DESCRIPTION
Bundles three related LocalLakehouse / lakehouse.py changes. All three touch the same module neighborhood and share a test harness, so one PR is cheaper to review than three.

## Fixes #49 — `LocalLakehouse.register` silent column drift

`register()` now detects additive drift (TableDef has columns that the existing table doesn't) and raises `LocalLakehouseSchemaDrift` by default. This is a **breaking change** vs. the prior silent no-op.

```python
lh.register(tables)                       # raises on drift (new default)
lh.register(tables, on_drift="ignore")    # preserve old behaviour
lh.register(tables, on_drift="evolve")    # ALTER TABLE ADD COLUMN for missing cols
lh.evolve_schema(tables)                  # standalone evolve without the raise default
```

`evolve_schema` creates missing tables and adds missing columns (as nullable — DuckDB can't add NOT NULL to a populated table). Type-change / column-removal detection is out of scope — additive drift only.

## Fixes #50 — `push_table` / `push_all` `target_schema` kwarg

Medallion pipelines with one DuckDB file across multiple layers (`dbo` / `silver` / `gold`) can now push each layer into a separate Fabric lakehouse whose target schema differs from the local DuckDB schema.

```python
lh = LocalLakehouse(..., schema="silver")
lh.push_table(cred, "foo", target_schema="dbo")   # reads silver.foo, writes Tables/dbo/foo
```

SELECT still reads from `self.schema`; only the destination OneLake path changes. Empty-string / whitespace `target_schema` is rejected with `ValueError`.

## Fixes #39 — Lakehouse DDL management

New functions in `pyfabric.data.lakehouse`:

- `delete_table(cred, ws, lh, table, *, schema="dbo")` — recursive DFS delete of `Tables/{schema}/{table}/`
- `drop_schema(cred, ws, lh, schema)` — recursive DFS delete of `Tables/{schema}/`
- `rename_table(cred, ws, lh, src, dst, *, schema="dbo")` — metadata-only DFS rename
- `rename_schema(cred, ws, lh, src_schema, dst_schema)` — moves every table in a schema; raises `LakehouseRenameSchemaError` on partial failure after attempting every table so callers can retry only the unmoved ones
- `list_schemas(cred, ws, lh)` / `list_tables(cred, ws, lh, *, schema=None)` — discovery

`LocalLakehouse.rename_schema(src, dst)` ships for local↔remote parity using the portable `CREATE TABLE AS + DROP` pattern (DuckDB 1.5.x has no `ALTER SCHEMA ... RENAME`).

Under the hood, two new OneLake DFS helpers: `onelake.delete_path(..., recursive=True)` and `onelake.rename_path(src, dst)`.

## Test plan

- [x] TDD: wrote failing tests first, then implemented — 40 new tests across 4 new/modified test files.
- [x] `pytest` — 576 passed, 1 skipped (pre-existing `PYFABRIC_TEST_WORKSPACE` skip).
- [x] `ruff check .` — clean.
- [x] `ruff format --check .` — clean.
- [x] `mypy --strict src/` — clean.
- [x] Pre-push hook (pytest + ruff + mypy) — passed.
- [ ] Integration: no live-Fabric tests ship in this PR. All DFS operations are mocked at the `pyfabric.data.onelake` seam. A follow-up could gate live DDL tests on `PYFABRIC_TEST_WORKSPACE` in the same style as `test_validate_e2e.py`.

## Compat notes

- **Breaking:** `LocalLakehouse.register()` default changed from silent-drift to raise. Callers that want the old behaviour must pass `on_drift="ignore"`.
- Non-breaking additions only for `push_table` / `push_all` (new kwarg defaults preserve current behaviour) and all of #39 (new public API).

🤖 Generated with [Claude Code](https://claude.com/claude-code)