### PR TITLE
Open Mirroring (PR A): MirroredDatabaseBuilder + REST lifecycle

### DIFF
--- a/src/pyfabric/items/mirrored_database.py
+++ b/src/pyfabric/items/mirrored_database.py
@@ -1,0 +1,342 @@
+"""Build and operate Microsoft Fabric Open Mirroring (Mirrored Database) items.
+
+Open Mirroring is a Fabric pattern where a Mirrored Database item operates
+in **GenericMirror** mode: producers push parquet files into a landing
+zone (``Files/LandingZone/...``) and Fabric replicates each file as
+rows in the matching Delta table under ``Tables/...``. The mirror item
+itself owns the lifecycle (start / stop / get status); the data plane
+is a separate concern handled by :mod:`pyfabric.data.open_mirror`
+(landing-zone uploads).
+
+This module covers the **item plane**:
+
+- :class:`MirroredDatabaseBuilder` — emit a canonical git-sync
+  ``MirroredDatabase`` artifact (``.platform`` + ``mirroring.json``)
+  with a startable ``GenericMirror`` source + ``MountedRelationalDatabase``
+  Delta target. Mirrors :class:`pyfabric.items.notebook.NotebookBuilder`
+  shape (``to_bundle``, ``save_to_disk``).
+- REST lifecycle helpers — :func:`create_mirrored_database`,
+  :func:`start_mirroring`, :func:`stop_mirroring`,
+  :func:`get_mirroring_status`, :func:`get_tables_mirroring_status`,
+  :func:`wait_for_running`. Each takes a ``FabricClient``-like object
+  (anything with ``post`` / ``get`` methods) so callers compose with
+  the existing client surface and tests can stub it cheaply.
+
+Usage::
+
+    from pyfabric.client.http import FabricClient
+    from pyfabric.items.mirrored_database import (
+        MirroredDatabaseBuilder,
+        create_mirrored_database,
+        start_mirroring,
+        wait_for_running,
+    )
+
+    # Build the artifact and ship via git-sync, OR push via REST:
+    builder = MirroredDatabaseBuilder(default_schema="dbo")
+    builder.save_to_disk("definitions/", display_name="open_bronze")
+
+    # Or create directly via REST:
+    client = FabricClient()
+    item = create_mirrored_database(client, ws_id, display_name="open_bronze")
+    start_mirroring(client, ws_id, item["id"])
+    status = wait_for_running(client, ws_id, item["id"], timeout_s=120)
+
+Credit
+------
+
+The Open Mirroring landing-zone protocol details — including the
+"GenericMirror" + "MountedRelationalDatabase" definition shape required
+for a startable open mirror — were first published as research notes by
+the *Learn Microsoft Fabric* community at
+https://github.com/UnifiedEducation/research/tree/main/open-mirroring.
+That repo currently ships without a license, so this implementation is
+**clean-room**: written from the publicly-documented Microsoft Fabric
+protocol, not by copying any code. The research repo is the recommended
+companion read for the *why* behind each shape.
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+import time
+from pathlib import Path
+from typing import Any, Protocol
+
+import structlog
+
+from pyfabric.items.bundle import ArtifactBundle
+from pyfabric.items.normalize import write_artifact_file
+
+log = structlog.get_logger()
+
+
+# ── Item builder ─────────────────────────────────────────────────────────────
+
+
+class MirroredDatabaseBuilder:
+    """Build a startable Open Mirroring ``MirroredDatabase`` item.
+
+    The output is a single ``mirroring.json`` paired with a ``.platform``
+    file. Both are written in canonical Fabric bytes (LF, no trailing
+    newline) so git-sync doesn't flap them on the next pull.
+
+    Args:
+        default_schema: Name of the destination schema in the mirrored
+            database. Maps to ``properties.target.typeProperties.defaultSchema``.
+            Defaults to ``"dbo"`` (the Fabric portal default).
+
+    Raises:
+        ValueError: If ``default_schema`` is empty / whitespace.
+    """
+
+    def __init__(self, default_schema: str = "dbo") -> None:
+        if not default_schema or not default_schema.strip():
+            raise ValueError(
+                f"default_schema must be a non-empty string; got {default_schema!r}"
+            )
+        self.default_schema = default_schema
+
+    def to_mirroring_json(self) -> str:
+        """Render the ``mirroring.json`` content as a string.
+
+        Output is ``json.dumps(..., indent=2)`` with no trailing newline —
+        matches Fabric's canonical bytes for this file.
+        """
+        body = {
+            "properties": {
+                "source": {
+                    "type": "GenericMirror",
+                    "typeProperties": {},
+                },
+                "target": {
+                    "type": "MountedRelationalDatabase",
+                    "typeProperties": {
+                        "defaultSchema": self.default_schema,
+                        "format": "Delta",
+                    },
+                },
+            }
+        }
+        return json.dumps(body, indent=2)
+
+    def to_bundle(
+        self,
+        display_name: str,
+        *,
+        logical_id: str | None = None,
+        description: str = "",
+    ) -> ArtifactBundle:
+        """Bundle the mirror artifact for disk save or REST upload.
+
+        ``mirroring.json`` is stored as **canonical bytes** (UTF-8, LF,
+        no trailing newline) so :func:`pyfabric.items.bundle.save_to_disk`
+        takes the ``write_bytes`` branch — preserves bytes on Windows
+        where ``write_text`` would inject CRLF.
+        """
+        canonical = self.to_mirroring_json().encode("utf-8")
+        kwargs: dict[str, Any] = {
+            "item_type": "MirroredDatabase",
+            "display_name": display_name,
+            "parts": {"mirroring.json": canonical},
+            "description": description,
+        }
+        if logical_id is not None:
+            kwargs["logical_id"] = logical_id
+        return ArtifactBundle(**kwargs)
+
+    def save_to_disk(
+        self,
+        output_dir: str | Path,
+        *,
+        display_name: str,
+        logical_id: str | None = None,
+        description: str = "",
+    ) -> Path:
+        """Write the artifact to disk in canonical Fabric bytes.
+
+        Routes both ``.platform`` and ``mirroring.json`` through
+        :func:`pyfabric.items.normalize.write_artifact_file`, so output
+        is identical across Linux / macOS / Windows.
+
+        Returns the artifact directory path.
+        """
+        bundle = self.to_bundle(
+            display_name=display_name,
+            logical_id=logical_id,
+            description=description,
+        )
+        artifact_dir = Path(output_dir) / bundle.dir_name
+        artifact_dir.mkdir(parents=True, exist_ok=True)
+
+        write_artifact_file(artifact_dir / ".platform", bundle.platform_json())
+        write_artifact_file(artifact_dir / "mirroring.json", self.to_mirroring_json())
+        log.info(
+            "mirrored_database_saved",
+            display_name=display_name,
+            default_schema=self.default_schema,
+            path=str(artifact_dir),
+        )
+        return artifact_dir
+
+
+# ── REST lifecycle ───────────────────────────────────────────────────────────
+
+
+class _ClientLike(Protocol):
+    """Subset of ``pyfabric.client.http.FabricClient`` the lifecycle helpers
+    need. Declared as a Protocol so tests can pass a tiny stub without
+    pulling in the whole client + credential machinery."""
+
+    def post(self, path: str, body: Any = None) -> dict[str, Any]: ...
+
+    def get(
+        self, path: str, params: dict[str, Any] | None = None
+    ) -> dict[str, Any]: ...
+
+
+def _items_path(workspace_id: str) -> str:
+    return f"workspaces/{workspace_id}/mirroredDatabases"
+
+
+def _item_path(workspace_id: str, mirror_id: str) -> str:
+    return f"{_items_path(workspace_id)}/{mirror_id}"
+
+
+def open_mirror_definition(default_schema: str = "dbo") -> dict[str, Any]:
+    """Return the minimal ``definition`` payload for a startable open mirror.
+
+    Fabric's ``POST /mirroredDatabases`` requires a ``definition`` with
+    a base64-encoded ``mirroring.json`` part. Without it, the item is
+    created but ``startMirroring`` returns ``MirroringDefinitionMissing``.
+    """
+    body = MirroredDatabaseBuilder(default_schema=default_schema).to_mirroring_json()
+    payload_b64 = base64.b64encode(body.encode("utf-8")).decode("ascii")
+    return {
+        "parts": [
+            {
+                "path": "mirroring.json",
+                "payload": payload_b64,
+                "payloadType": "InlineBase64",
+            }
+        ]
+    }
+
+
+def create_mirrored_database(
+    client: _ClientLike,
+    workspace_id: str,
+    *,
+    display_name: str,
+    description: str = "",
+    definition: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Create a Mirrored Database item.
+
+    Args:
+        client: A ``FabricClient`` (or anything with a compatible ``post``).
+        workspace_id: Target workspace ID.
+        display_name: Item display name.
+        description: Optional description.
+        definition: Inline-base64 definition. Defaults to
+            :func:`open_mirror_definition` (a startable GenericMirror /
+            MountedRelationalDatabase Delta target with ``defaultSchema=dbo``).
+    """
+    body = {
+        "displayName": display_name,
+        "description": description,
+        "definition": definition
+        if definition is not None
+        else open_mirror_definition(),
+    }
+    return client.post(_items_path(workspace_id), body)
+
+
+def get_mirrored_database(
+    client: _ClientLike, workspace_id: str, mirror_id: str
+) -> dict[str, Any]:
+    """Fetch the item record for an existing Mirrored Database."""
+    return client.get(_item_path(workspace_id, mirror_id))
+
+
+def start_mirroring(
+    client: _ClientLike, workspace_id: str, mirror_id: str
+) -> dict[str, Any]:
+    """Start replication on a Mirrored Database.
+
+    Returns whatever the endpoint returns (typically empty body, 202 with
+    LRO, or a small status object — the underlying client handles
+    polling). Callers usually follow with :func:`wait_for_running`.
+    """
+    return client.post(f"{_item_path(workspace_id, mirror_id)}/startMirroring")
+
+
+def stop_mirroring(
+    client: _ClientLike, workspace_id: str, mirror_id: str
+) -> dict[str, Any]:
+    """Stop replication on a Mirrored Database."""
+    return client.post(f"{_item_path(workspace_id, mirror_id)}/stopMirroring")
+
+
+def get_mirroring_status(
+    client: _ClientLike, workspace_id: str, mirror_id: str
+) -> dict[str, Any]:
+    """Return the mirror's overall status.
+
+    Body shape varies by Fabric version — typically includes ``status``
+    (or ``state``) with values like ``Initialized`` / ``Running`` /
+    ``Stopped``. :func:`wait_for_running` accepts either field.
+    """
+    return client.post(f"{_item_path(workspace_id, mirror_id)}/getMirroringStatus")
+
+
+def get_tables_mirroring_status(
+    client: _ClientLike, workspace_id: str, mirror_id: str
+) -> dict[str, Any]:
+    """Return per-table replication status.
+
+    Useful for diagnosing why a specific table isn't replicating after a
+    parquet drop (often a SchemaMergeFailure surfaces here before the
+    overall mirror status flips).
+    """
+    return client.post(
+        f"{_item_path(workspace_id, mirror_id)}/getTablesMirroringStatus"
+    )
+
+
+def wait_for_running(
+    client: _ClientLike,
+    workspace_id: str,
+    mirror_id: str,
+    *,
+    timeout_s: float = 300,
+    poll_interval_s: float = 5,
+) -> dict[str, Any]:
+    """Poll :func:`get_mirroring_status` until the mirror is running.
+
+    Accepts either ``status`` or ``state`` in the response (Fabric versions
+    have used both). Comparison is case-insensitive — a value of
+    ``"running"`` or ``"Running"`` both count.
+
+    Args:
+        timeout_s: Total wait budget. Set to ``0`` to make a single check
+            and raise immediately if not running.
+        poll_interval_s: Sleep between polls. Set to ``0`` in tests.
+
+    Raises:
+        TimeoutError: If the mirror does not reach ``Running`` within
+            ``timeout_s`` seconds.
+    """
+    deadline = time.monotonic() + timeout_s
+    last: dict[str, Any] = {}
+    while True:
+        last = get_mirroring_status(client, workspace_id, mirror_id)
+        state = last.get("status") or last.get("state") or ""
+        if isinstance(state, str) and state.lower() == "running":
+            return last
+        if time.monotonic() >= deadline:
+            raise TimeoutError(
+                f"Mirror did not reach Running within {timeout_s}s. Last status: {last}"
+            )
+        time.sleep(poll_interval_s)

--- a/src/pyfabric/items/normalize.py
+++ b/src/pyfabric/items/normalize.py
@@ -82,6 +82,8 @@ ARTIFACT_GLOBS: tuple[str, ...] = (
     "*.Report/definition.pbir",
     "*.Report/definition/**/*.json",
     "*.Report/definition/**/*.pbir",
+    "*.MirroredDatabase/.platform",
+    "*.MirroredDatabase/mirroring.json",
 )
 
 # File-type-specific rules. First match wins. Order matters.
@@ -278,5 +280,6 @@ _ITEM_TYPES: frozenset[str] = frozenset(
         "VariableLibrary",
         "SemanticModel",
         "Report",
+        "MirroredDatabase",
     }
 )

--- a/tests/fixtures/mirrors/mirror_custom.MirroredDatabase/mirroring.json
+++ b/tests/fixtures/mirrors/mirror_custom.MirroredDatabase/mirroring.json
@@ -1,0 +1,15 @@
+{
+  "properties": {
+    "source": {
+      "type": "GenericMirror",
+      "typeProperties": {}
+    },
+    "target": {
+      "type": "MountedRelationalDatabase",
+      "typeProperties": {
+        "defaultSchema": "bronze",
+        "format": "Delta"
+      }
+    }
+  }
+}

--- a/tests/fixtures/mirrors/mirror_default.MirroredDatabase/mirroring.json
+++ b/tests/fixtures/mirrors/mirror_default.MirroredDatabase/mirroring.json
@@ -1,0 +1,15 @@
+{
+  "properties": {
+    "source": {
+      "type": "GenericMirror",
+      "typeProperties": {}
+    },
+    "target": {
+      "type": "MountedRelationalDatabase",
+      "typeProperties": {
+        "defaultSchema": "dbo",
+        "format": "Delta"
+      }
+    }
+  }
+}

--- a/tests/items/test_mirrored_database.py
+++ b/tests/items/test_mirrored_database.py
@@ -1,0 +1,338 @@
+"""Tests for :mod:`pyfabric.items.mirrored_database`.
+
+Covers:
+
+- ``MirroredDatabaseBuilder`` round-trip: produces byte-identical
+  ``mirroring.json`` to checked-in fixtures (default ``dbo`` and a
+  custom default-schema variant). The exact byte shape matters because
+  Fabric git-sync rewrites these files; a builder that doesn't match
+  Fabric-canonical bytes flaps the file on every sync.
+- ``MirroredDatabaseBuilder.save_to_disk`` enforces LF + no trailing
+  newline on Windows (regression coverage for the same write_text
+  CRLF gotcha NotebookBuilder addressed).
+- REST lifecycle helpers (create, get, start, stop, status, table
+  status, wait_for_running) issue the right verbs at the right URLs
+  via a mocked ``requests.Session``.
+
+The Open Mirroring landing-zone protocol details surfaced in
+<https://github.com/UnifiedEducation/research/tree/main/open-mirroring>
+were used as documentation; this test suite is independently authored.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from pyfabric.items.mirrored_database import (
+    MirroredDatabaseBuilder,
+    create_mirrored_database,
+    get_mirrored_database,
+    get_mirroring_status,
+    get_tables_mirroring_status,
+    start_mirroring,
+    stop_mirroring,
+    wait_for_running,
+)
+
+FIXTURES = Path(__file__).parent.parent / "fixtures" / "mirrors"
+WS = "00000000-0000-0000-0000-0000000000aa"
+MIRROR_ID = "11111111-1111-1111-1111-111111111111"
+
+
+def _fixture_bytes(name: str) -> bytes:
+    return (FIXTURES / f"{name}.MirroredDatabase" / "mirroring.json").read_bytes()
+
+
+# ── Builder ──────────────────────────────────────────────────────────────────
+
+
+class TestBuilderDefault:
+    def test_default_builder_matches_fixture(self):
+        b = MirroredDatabaseBuilder()
+        assert b.to_mirroring_json().encode("utf-8") == _fixture_bytes("mirror_default")
+
+    def test_default_schema_is_dbo(self):
+        b = MirroredDatabaseBuilder()
+        body = json.loads(b.to_mirroring_json())
+        assert body["properties"]["target"]["typeProperties"]["defaultSchema"] == "dbo"
+
+    def test_format_is_delta(self):
+        b = MirroredDatabaseBuilder()
+        body = json.loads(b.to_mirroring_json())
+        assert body["properties"]["target"]["typeProperties"]["format"] == "Delta"
+
+    def test_source_type_is_generic_mirror(self):
+        """``GenericMirror`` is the source type required for Open Mirroring;
+        a create body without it is rejected by ``startMirroring``."""
+        b = MirroredDatabaseBuilder()
+        body = json.loads(b.to_mirroring_json())
+        assert body["properties"]["source"]["type"] == "GenericMirror"
+
+
+class TestBuilderCustomSchema:
+    def test_custom_default_schema_propagates(self):
+        b = MirroredDatabaseBuilder(default_schema="bronze")
+        assert b.to_mirroring_json().encode("utf-8") == _fixture_bytes("mirror_custom")
+
+    def test_empty_default_schema_rejected(self):
+        with pytest.raises(ValueError, match="default_schema"):
+            MirroredDatabaseBuilder(default_schema="")
+
+
+# ── Bundle + disk integration ───────────────────────────────────────────────
+
+
+class TestToBundle:
+    def test_mirroring_json_is_stored_as_canonical_bytes(self):
+        b = MirroredDatabaseBuilder()
+        bundle = b.to_bundle(display_name="open_bronze")
+        content = bundle.parts["mirroring.json"]
+        assert isinstance(content, bytes)
+        assert b"\r\n" not in content
+        assert not content.endswith(b"\n")
+
+    def test_bundle_metadata(self):
+        b = MirroredDatabaseBuilder()
+        bundle = b.to_bundle(display_name="open_bronze")
+        assert bundle.item_type == "MirroredDatabase"
+        assert bundle.display_name == "open_bronze"
+        assert bundle.dir_name == "open_bronze.MirroredDatabase"
+
+    def test_logical_id_override(self):
+        b = MirroredDatabaseBuilder()
+        bundle = b.to_bundle(
+            display_name="open_bronze",
+            logical_id="22222222-2222-2222-2222-222222222222",
+        )
+        assert bundle.logical_id == "22222222-2222-2222-2222-222222222222"
+
+
+class TestSaveToDisk:
+    def test_writes_mirroring_json_with_lf_and_no_trailing_newline(self, tmp_path):
+        """Per Fabric convention, ``mirroring.json`` is LF + no trailing
+        newline. Routing through write_artifact_file keeps that invariant
+        on Windows hosts where ``write_text`` would inject CRLF."""
+        b = MirroredDatabaseBuilder()
+        artifact_dir = b.save_to_disk(tmp_path, display_name="m_test")
+        raw = (artifact_dir / "mirroring.json").read_bytes()
+        assert b"\r\n" not in raw
+        assert not raw.endswith(b"\n")
+
+    def test_writes_platform_json_with_lf_and_no_trailing_newline(self, tmp_path):
+        b = MirroredDatabaseBuilder()
+        artifact_dir = b.save_to_disk(tmp_path, display_name="m_test")
+        raw = (artifact_dir / ".platform").read_bytes()
+        assert b"\r\n" not in raw
+        assert not raw.endswith(b"\n")
+
+    def test_returns_artifact_directory_path(self, tmp_path):
+        b = MirroredDatabaseBuilder()
+        artifact_dir = b.save_to_disk(tmp_path, display_name="m_test")
+        assert artifact_dir == tmp_path / "m_test.MirroredDatabase"
+        assert artifact_dir.is_dir()
+
+
+# ── REST lifecycle helpers ──────────────────────────────────────────────────
+
+
+def _make_response(status: int, body: dict | None = None) -> MagicMock:
+    """Shape a MagicMock to look like a requests.Response for FabricClient."""
+    resp = MagicMock()
+    resp.status_code = status
+    payload = json.dumps(body or {})
+    resp.text = payload
+    resp.content = payload.encode("utf-8")
+    resp.json.return_value = body or {}
+    resp.headers = {}
+    return resp
+
+
+class _StubClient:
+    """A minimal stand-in for FabricClient. Records calls, returns canned
+    responses. Avoids spinning up the real client (and its credential)."""
+
+    def __init__(self, responses: dict[tuple[str, str], dict] | None = None) -> None:
+        self.responses = responses or {}
+        self.calls: list[tuple[str, str, object]] = []
+
+    def post(self, path: str, body: object = None) -> dict:
+        self.calls.append(("POST", path, body))
+        return self.responses.get(("POST", path), {})
+
+    def get(self, path: str, params: dict | None = None) -> dict:
+        self.calls.append(("GET", path, params))
+        return self.responses.get(("GET", path), {})
+
+    def delete(self, path: str) -> None:
+        self.calls.append(("DELETE", path, None))
+
+
+class TestCreate:
+    def test_create_posts_to_mirrored_databases_collection(self):
+        client = _StubClient(
+            {
+                ("POST", f"workspaces/{WS}/mirroredDatabases"): {
+                    "id": MIRROR_ID,
+                    "displayName": "open_bronze",
+                }
+            }
+        )
+        result = create_mirrored_database(
+            client, WS, display_name="open_bronze", description="bronze ingest"
+        )
+        assert result["id"] == MIRROR_ID
+        assert client.calls[0][0] == "POST"
+        assert client.calls[0][1] == f"workspaces/{WS}/mirroredDatabases"
+
+    def test_create_attaches_default_definition_when_none_provided(self):
+        client = _StubClient()
+        create_mirrored_database(client, WS, display_name="open_bronze")
+        body = client.calls[0][2]
+        assert isinstance(body, dict)
+        assert "definition" in body
+        # The default definition must include a base64-encoded mirroring.json
+        # part so startMirroring is allowed.
+        parts = body["definition"]["parts"]
+        assert any(p["path"] == "mirroring.json" for p in parts)
+
+    def test_create_uses_caller_definition_when_provided(self):
+        client = _StubClient()
+        custom_definition = {"parts": [{"path": "mirroring.json", "payload": "Zm9v"}]}
+        create_mirrored_database(
+            client,
+            WS,
+            display_name="open_bronze",
+            definition=custom_definition,
+        )
+        body = client.calls[0][2]
+        assert body["definition"] is custom_definition
+
+
+class TestGet:
+    def test_get_calls_correct_path(self):
+        client = _StubClient(
+            {
+                ("GET", f"workspaces/{WS}/mirroredDatabases/{MIRROR_ID}"): {
+                    "id": MIRROR_ID
+                }
+            }
+        )
+        result = get_mirrored_database(client, WS, MIRROR_ID)
+        assert result["id"] == MIRROR_ID
+
+
+class TestStartStop:
+    def test_start_posts_to_start_mirroring(self):
+        client = _StubClient()
+        start_mirroring(client, WS, MIRROR_ID)
+        assert client.calls[0] == (
+            "POST",
+            f"workspaces/{WS}/mirroredDatabases/{MIRROR_ID}/startMirroring",
+            None,
+        )
+
+    def test_stop_posts_to_stop_mirroring(self):
+        client = _StubClient()
+        stop_mirroring(client, WS, MIRROR_ID)
+        assert client.calls[0] == (
+            "POST",
+            f"workspaces/{WS}/mirroredDatabases/{MIRROR_ID}/stopMirroring",
+            None,
+        )
+
+
+class TestStatus:
+    def test_get_mirroring_status_returns_status_dict(self):
+        client = _StubClient(
+            {
+                (
+                    "POST",
+                    f"workspaces/{WS}/mirroredDatabases/{MIRROR_ID}/getMirroringStatus",
+                ): {"status": "Running"}
+            }
+        )
+        result = get_mirroring_status(client, WS, MIRROR_ID)
+        assert result["status"] == "Running"
+
+    def test_get_tables_status_returns_table_dict(self):
+        client = _StubClient(
+            {
+                (
+                    "POST",
+                    f"workspaces/{WS}/mirroredDatabases/{MIRROR_ID}/getTablesMirroringStatus",
+                ): {"data": [{"sourceTableName": "dim_x", "status": "Replicating"}]}
+            }
+        )
+        result = get_tables_mirroring_status(client, WS, MIRROR_ID)
+        assert result["data"][0]["status"] == "Replicating"
+
+
+class TestWaitForRunning:
+    def test_returns_when_status_is_running(self):
+        client = _StubClient(
+            {
+                (
+                    "POST",
+                    f"workspaces/{WS}/mirroredDatabases/{MIRROR_ID}/getMirroringStatus",
+                ): {"status": "Running"}
+            }
+        )
+        result = wait_for_running(client, WS, MIRROR_ID, timeout_s=5, poll_interval_s=0)
+        assert result["status"] == "Running"
+
+    def test_polls_until_running(self, monkeypatch):
+        """Initial polls return Initialized, eventual poll returns Running."""
+        responses = iter([{"status": "Initialized"}, {"status": "Running"}])
+
+        class _PollingClient(_StubClient):
+            def post(self, path: str, body: object = None) -> dict:
+                self.calls.append(("POST", path, body))
+                return next(responses)
+
+        client = _PollingClient()
+        result = wait_for_running(client, WS, MIRROR_ID, timeout_s=5, poll_interval_s=0)
+        assert result["status"] == "Running"
+        assert len(client.calls) == 2
+
+    def test_times_out_when_never_running(self, monkeypatch):
+        client = _StubClient(
+            {
+                (
+                    "POST",
+                    f"workspaces/{WS}/mirroredDatabases/{MIRROR_ID}/getMirroringStatus",
+                ): {"status": "Initialized"}
+            }
+        )
+        # Force the timeout immediately by setting timeout_s=0.
+        with pytest.raises(TimeoutError, match="Running"):
+            wait_for_running(client, WS, MIRROR_ID, timeout_s=0, poll_interval_s=0)
+
+    def test_status_field_case_insensitive(self):
+        """Some endpoints return ``state`` instead of ``status``; helper must
+        accept either, and the value comparison is case-insensitive."""
+        client = _StubClient(
+            {
+                (
+                    "POST",
+                    f"workspaces/{WS}/mirroredDatabases/{MIRROR_ID}/getMirroringStatus",
+                ): {"state": "running"}
+            }
+        )
+        result = wait_for_running(client, WS, MIRROR_ID, timeout_s=5, poll_interval_s=0)
+        assert (result.get("status") or result.get("state", "")).lower() == "running"
+
+
+# ── Item-type registration ──────────────────────────────────────────────────
+
+
+class TestItemTypeAlignment:
+    def test_mirrored_database_is_in_normalize_glob_list(self):
+        """ARTIFACT_GLOBS must cover MirroredDatabase so ``normalize-artifacts``
+        walks into these folders."""
+        from pyfabric.items.normalize import ARTIFACT_GLOBS
+
+        assert any("MirroredDatabase" in g for g in ARTIFACT_GLOBS)


### PR DESCRIPTION
First of three PRs adding Open Mirroring support to pyfabric (closes #57). Subsequent PRs are tracked by #58 (landing-zone data plane) and #59 (high-level `write_rows` / `RowMarker` / schema-compat checks).

## What this ships

### `pyfabric.items.mirrored_database.MirroredDatabaseBuilder`

Mirrors `NotebookBuilder`'s pattern from #54: emits a canonical git-sync `MirroredDatabase` artifact (`.platform` + `mirroring.json`) for a **startable** open mirror — `GenericMirror` source + `MountedRelationalDatabase` Delta target.

```python
from pyfabric.items.mirrored_database import MirroredDatabaseBuilder

builder = MirroredDatabaseBuilder(default_schema=\"dbo\")
builder.save_to_disk(\"definitions/\", display_name=\"open_bronze\")
```

`mirroring.json` is stored in the bundle as canonical bytes so `bundle.save_to_disk` preserves LF on Windows; `MirroredDatabaseBuilder.save_to_disk` routes both files through `write_artifact_file` for OS-independent output.

### REST lifecycle helpers (free functions)

Each takes a `FabricClient`-like object (declared as a `Protocol` so tests can stub it cheaply without spinning up the real client + credential):

- `create_mirrored_database(client, ws_id, *, display_name, description=\"\", definition=None)` — default `definition` is a startable open mirror; callers can override.
- `get_mirrored_database(client, ws_id, mirror_id)`
- `start_mirroring(client, ws_id, mirror_id)` / `stop_mirroring(...)`
- `get_mirroring_status(...)` / `get_tables_mirroring_status(...)`
- `wait_for_running(client, ws_id, mirror_id, *, timeout_s=300, poll_interval_s=5)` — polls until `status` (or `state`) == `\"Running\"` (case-insensitive). Raises `TimeoutError` cleanly. `timeout_s=0` works as a single-shot check.

### `pyfabric.items.normalize`

`ARTIFACT_GLOBS` and `_ITEM_TYPES` extended to walk into `*.MirroredDatabase/` folders so `pyfabric normalize-artifacts` handles them in a workspace tree.

## Test plan

- [x] **25 new tests** — round-trip vs scrubbed-ID fixtures (default + custom `defaultSchema`), `save_to_disk` LF + no-trailing-newline discipline, mocked REST lifecycle (path correctness, default-definition shape, polling, timeout, case-insensitive status field).
- [x] Total: **651 passed, 1 skipped**.
- [x] `ruff check . / ruff format --check . / mypy --strict src/ / codespell` all green.
- [x] Pre-push hook (ruff + mypy + pytest + codespell + markdownlint) passed.
- [ ] Live Fabric: not exercised here. The integration test issue (#52) covers that tier — a follow-up will add `PYFABRIC_TEST_MIRROR_ID` lifecycle round-trips against `ws_pyfabric_validation`.

## Credit

The Open Mirroring landing-zone protocol details — including the `GenericMirror` + `MountedRelationalDatabase` definition shape required for a startable open mirror — were first published as research notes by the *Learn Microsoft Fabric* community at <https://github.com/UnifiedEducation/research/tree/main/open-mirroring>.

That repo currently ships **without a license** (\"all rights reserved\" by default), so this implementation is **clean-room**: written from the publicly-documented Microsoft Fabric protocol and the public README + `docs/landing-zone-format.md` only. **No code is copied.** The module docstring carries the attribution; PR B and PR C will continue to credit it.

## Compat notes

- All new public API; no behaviour changes to existing modules.
- New module is strictly typed (mypy `--strict` clean) — does not extend the `ignore_errors` override list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)