### PR TITLE
Open Mirroring (PR B): OpenMirrorClient landing-zone data plane

### DIFF
--- a/src/pyfabric/data/open_mirror.py
+++ b/src/pyfabric/data/open_mirror.py
@@ -1,0 +1,283 @@
+"""Open Mirroring landing-zone data plane.
+
+Producers push parquet files into a Fabric Open Mirror's landing zone;
+the mirror replicates each file's rows into the matching Delta table
+under ``Tables/...``. This module owns the **data plane** — pushing
+files. The **item plane** (creating / starting / stopping the mirror,
+git-sync artifact) lives in :mod:`pyfabric.items.mirrored_database`.
+
+Path shape (per the Microsoft Fabric Open Mirroring documentation)::
+
+    Files/LandingZone/[<schema>.schema/]<table>/_metadata.json
+    Files/LandingZone/[<schema>.schema/]<table>/<NNNNNNNNNNNNNNNNNNNN>.parquet
+
+``<schema>.schema/`` is optional; use it for multi-source namespacing.
+Sequential filenames are zero-padded to 20 digits — Fabric reads files
+in numeric order unless ``_metadata.json`` opts in to
+``LastUpdateTimeFileDetection``.
+
+Usage::
+
+    from pyfabric.client.auth import FabricCredential
+    from pyfabric.data.open_mirror import OpenMirrorClient
+
+    cred = FabricCredential()
+    mirror = OpenMirrorClient(cred, ws_id, mirror_id)
+    mirror.ensure_table("dim_customer", schema="bc2", key_columns=["id"])
+    name = mirror.next_data_filename("dim_customer", schema="bc2")
+    mirror.upload_data_file(
+        "dim_customer",
+        "tests/fixtures/dim_customer_001.parquet",
+        schema="bc2",
+        remote_filename=name,
+    )
+
+Credit
+------
+
+The Open Mirroring landing-zone protocol — path shape, ``_metadata.json``
+keys (``keyColumns``, ``isUpsertDefaultRowMarker``,
+``fileDetectionStrategy``), 20-digit sequential filename convention,
+``_ProcessedFiles`` retention behaviour, and the ``__rowMarker__``
+semantics covered in PR C — were first published as research notes by
+the *Learn Microsoft Fabric* community at
+https://github.com/UnifiedEducation/research/tree/main/open-mirroring.
+That repo currently ships without a license, so this implementation is
+**clean-room**: written from the publicly-documented Microsoft Fabric
+protocol and the public README + ``docs/landing-zone-format.md`` only.
+No code is copied. The research repo is the recommended companion read
+for the *why* behind each shape.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+import structlog
+
+from pyfabric.data import onelake
+
+if TYPE_CHECKING:
+    from pyfabric.client.auth import FabricCredential
+
+log = structlog.get_logger()
+
+
+_LANDING_ZONE_ROOT = "Files/LandingZone"
+_FILENAME_WIDTH = 20
+
+
+class OpenMirrorClient:
+    """Push parquet files into a Fabric Open Mirror's landing zone.
+
+    Args:
+        credential: Anything with a ``storage_token`` attribute that
+            yields a fresh OneLake DFS bearer token. In production this
+            is a :class:`pyfabric.client.auth.FabricCredential`; tests
+            pass a tiny stub.
+        workspace_id: Workspace GUID hosting the mirror.
+        mirror_id: Mirrored Database item GUID.
+    """
+
+    def __init__(
+        self,
+        credential: FabricCredential | Any,
+        workspace_id: str,
+        mirror_id: str,
+    ) -> None:
+        self._credential = credential
+        self.workspace_id = workspace_id
+        self.mirror_id = mirror_id
+
+    # ── Path helpers ─────────────────────────────────────────────────────────
+
+    @staticmethod
+    def table_folder(table: str, *, schema: str | None = None) -> str:
+        """Return the landing-zone folder path for a table.
+
+        Forward-slash, item-relative — pass straight to
+        :mod:`pyfabric.data.onelake` helpers as ``path``.
+        """
+        if schema:
+            return f"{_LANDING_ZONE_ROOT}/{schema}.schema/{table}"
+        return f"{_LANDING_ZONE_ROOT}/{table}"
+
+    # ── Table lifecycle ──────────────────────────────────────────────────────
+
+    def ensure_table(
+        self,
+        table: str,
+        *,
+        schema: str | None = None,
+        key_columns: list[str],
+        upsert_default: bool = False,
+        detect_by_last_update: bool = False,
+    ) -> None:
+        """Create / overwrite the table's ``_metadata.json``.
+
+        Fabric implicitly creates the table folder when the first file
+        lands at ``<folder>/_metadata.json``; no explicit directory
+        create is needed against the ADLS Gen2 hierarchical namespace.
+
+        Args:
+            table: Table name (no extension, no path separators).
+            schema: Optional ``<schema>.schema/`` namespace prefix.
+            key_columns: Required. Columns that uniquely identify a
+                row — Fabric uses these to resolve update/delete/upsert
+                row markers.
+            upsert_default: If True, sets
+                ``isUpsertDefaultRowMarker: true`` so rows without an
+                explicit ``__rowMarker__`` are treated as upserts (4).
+            detect_by_last_update: If True, sets
+                ``fileDetectionStrategy: LastUpdateTimeFileDetection``
+                so Fabric reads files in last-modified order instead of
+                requiring sequential filenames.
+
+        Raises:
+            ValueError: If ``key_columns`` is empty.
+        """
+        if not key_columns:
+            raise ValueError("key_columns must not be empty")
+
+        meta: dict[str, Any] = {"keyColumns": list(key_columns)}
+        if upsert_default:
+            meta["isUpsertDefaultRowMarker"] = True
+        if detect_by_last_update:
+            meta["fileDetectionStrategy"] = "LastUpdateTimeFileDetection"
+
+        folder = self.table_folder(table, schema=schema)
+        path = f"{folder}/_metadata.json"
+        payload = json.dumps(meta, indent=2).encode("utf-8")
+        onelake.upload_file(
+            self._credential.storage_token,
+            self.workspace_id,
+            self.mirror_id,
+            path,
+            payload,
+        )
+        log.info(
+            "open_mirror_ensure_table",
+            schema=schema,
+            table=table,
+            key_columns=list(key_columns),
+            upsert_default=upsert_default,
+            detect_by_last_update=detect_by_last_update,
+        )
+
+    # ── File management ─────────────────────────────────────────────────────
+
+    def next_data_filename(
+        self,
+        table: str,
+        *,
+        schema: str | None = None,
+        extension: str = "parquet",
+    ) -> str:
+        """Return the next zero-padded sequential filename for ``table``.
+
+        Lists the table folder (one level, non-recursive), parses every
+        file whose stem is exactly ``_FILENAME_WIDTH`` digits, returns
+        ``f\"{max+1:020d}.{extension}\"``. Subdirectories
+        (``_ProcessedFiles``, ``_FilesReadyToDelete``) and non-numeric
+        names are ignored.
+
+        Use only when the table is in **sequential-filename mode**; if
+        ``ensure_table(..., detect_by_last_update=True)`` was called,
+        any filename works and you don't need this.
+        """
+        folder = self.table_folder(table, schema=schema)
+        entries = onelake.list_paths(
+            self._credential.storage_token,
+            self.workspace_id,
+            self.mirror_id,
+            folder,
+            recursive=False,
+        )
+        max_num = 0
+        for e in entries:
+            if e.get("isDirectory", "false") == "true":
+                continue
+            base = Path(e.get("name", "")).name
+            stem = base.split(".", 1)[0]
+            if len(stem) == _FILENAME_WIDTH and stem.isdigit():
+                max_num = max(max_num, int(stem))
+        return f"{(max_num + 1):0{_FILENAME_WIDTH}d}.{extension}"
+
+    def upload_data_file(
+        self,
+        table: str,
+        local_path: str | Path,
+        *,
+        schema: str | None = None,
+        remote_filename: str | None = None,
+    ) -> str:
+        """Upload a local file into the table's landing-zone folder.
+
+        Args:
+            table: Table name.
+            local_path: Path to the file to upload — bytes are read
+                whole into memory (fine for the parquet sizes Open
+                Mirroring expects; if you need streaming, use
+                :func:`pyfabric.data.onelake.upload_file` directly).
+            schema: Optional ``<schema>.schema/`` namespace.
+            remote_filename: If set, used verbatim as the filename and
+                no folder listing is needed. If ``None``, falls back to
+                :meth:`next_data_filename` with the local file's
+                extension.
+
+        Returns:
+            The full DFS path that was written (``Files/LandingZone/...``).
+        """
+        local = Path(local_path)
+        if remote_filename is None:
+            ext = local.suffix.lstrip(".") or "parquet"
+            remote_filename = self.next_data_filename(
+                table, schema=schema, extension=ext
+            )
+        folder = self.table_folder(table, schema=schema)
+        remote_path = f"{folder}/{remote_filename}"
+        onelake.upload_file(
+            self._credential.storage_token,
+            self.workspace_id,
+            self.mirror_id,
+            remote_path,
+            local.read_bytes(),
+        )
+        log.info(
+            "open_mirror_upload_data_file",
+            schema=schema,
+            table=table,
+            remote=remote_path,
+            bytes=local.stat().st_size,
+        )
+        return remote_path
+
+    # ── Cleanup observability ───────────────────────────────────────────────
+
+    def list_processed(self, table: str, *, schema: str | None = None) -> list[str]:
+        """List filenames currently in the table's ``_ProcessedFiles`` folder.
+
+        Returns the basename of each file (no path). Returns ``[]`` when
+        the folder doesn't exist (Fabric only creates it after the first
+        file completes replication). Useful for cleanup helpers and
+        debugging \"why hasn't this row replicated?\" — a file that's
+        moved into ``_ProcessedFiles`` has been ingested.
+        """
+        folder = f"{self.table_folder(table, schema=schema)}/_ProcessedFiles"
+        entries = onelake.list_paths(
+            self._credential.storage_token,
+            self.workspace_id,
+            self.mirror_id,
+            folder,
+            recursive=False,
+        )
+        result: list[str] = []
+        for e in entries:
+            if e.get("isDirectory", "false") == "true":
+                continue
+            name = Path(e.get("name", "")).name
+            if name:
+                result.append(name)
+        return result

--- a/tests/data/test_open_mirror.py
+++ b/tests/data/test_open_mirror.py
@@ -1,0 +1,270 @@
+"""Tests for :class:`pyfabric.data.open_mirror.OpenMirrorClient`.
+
+Covers the landing-zone data-plane primitives — ``_metadata.json``
+shape, sequential-filename math, parquet upload routing, and
+``_ProcessedFiles`` listing — entirely against mocked DFS helpers
+(``pyfabric.data.onelake.upload_file`` and ``list_paths``). No
+network. Live Fabric coverage is tracked separately by #52.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from pyfabric.data.open_mirror import OpenMirrorClient
+
+WS = "00000000-0000-0000-0000-0000000000aa"
+MIRROR = "11111111-1111-1111-1111-111111111111"
+
+
+@pytest.fixture
+def fake_credential():
+    class _FakeCred:
+        storage_token = "fake-token"
+
+    return _FakeCred()
+
+
+def _path_entry(name: str, *, is_dir: bool = False) -> dict:
+    """Shape matches the DFS filesystem API response."""
+    return {"name": name, "isDirectory": "true" if is_dir else "false"}
+
+
+# ── ensure_table ────────────────────────────────────────────────────────────
+
+
+class TestEnsureTable:
+    def test_writes_metadata_with_key_columns_only(self, fake_credential):
+        client = OpenMirrorClient(fake_credential, WS, MIRROR)
+        with patch("pyfabric.data.open_mirror.onelake.upload_file") as up:
+            client.ensure_table("dim_customer", schema="bc2", key_columns=["id"])
+        up.assert_called_once()
+        path_arg = up.call_args.args[3]
+        assert path_arg == "Files/LandingZone/bc2.schema/dim_customer/_metadata.json"
+        meta_bytes = up.call_args.args[4]
+        meta = json.loads(meta_bytes.decode("utf-8"))
+        assert meta == {"keyColumns": ["id"]}
+
+    def test_flat_path_when_no_schema(self, fake_credential):
+        client = OpenMirrorClient(fake_credential, WS, MIRROR)
+        with patch("pyfabric.data.open_mirror.onelake.upload_file") as up:
+            client.ensure_table("dim_customer", key_columns=["id"])
+        path_arg = up.call_args.args[3]
+        assert path_arg == "Files/LandingZone/dim_customer/_metadata.json"
+
+    def test_includes_upsert_default_when_set(self, fake_credential):
+        client = OpenMirrorClient(fake_credential, WS, MIRROR)
+        with patch("pyfabric.data.open_mirror.onelake.upload_file") as up:
+            client.ensure_table(
+                "t", schema="s", key_columns=["id"], upsert_default=True
+            )
+        meta = json.loads(up.call_args.args[4].decode("utf-8"))
+        assert meta["isUpsertDefaultRowMarker"] is True
+
+    def test_includes_file_detection_strategy_when_set(self, fake_credential):
+        client = OpenMirrorClient(fake_credential, WS, MIRROR)
+        with patch("pyfabric.data.open_mirror.onelake.upload_file") as up:
+            client.ensure_table(
+                "t", schema="s", key_columns=["id"], detect_by_last_update=True
+            )
+        meta = json.loads(up.call_args.args[4].decode("utf-8"))
+        assert meta["fileDetectionStrategy"] == "LastUpdateTimeFileDetection"
+
+    def test_both_optional_keys_set_together(self, fake_credential):
+        client = OpenMirrorClient(fake_credential, WS, MIRROR)
+        with patch("pyfabric.data.open_mirror.onelake.upload_file") as up:
+            client.ensure_table(
+                "t",
+                schema="s",
+                key_columns=["a", "b"],
+                upsert_default=True,
+                detect_by_last_update=True,
+            )
+        meta = json.loads(up.call_args.args[4].decode("utf-8"))
+        assert meta == {
+            "keyColumns": ["a", "b"],
+            "isUpsertDefaultRowMarker": True,
+            "fileDetectionStrategy": "LastUpdateTimeFileDetection",
+        }
+
+    def test_empty_key_columns_rejected(self, fake_credential):
+        client = OpenMirrorClient(fake_credential, WS, MIRROR)
+        with (
+            patch("pyfabric.data.open_mirror.onelake.upload_file") as up,
+            pytest.raises(ValueError, match="key_columns"),
+        ):
+            client.ensure_table("t", schema="s", key_columns=[])
+        up.assert_not_called()
+
+
+# ── next_data_filename ──────────────────────────────────────────────────────
+
+
+class TestNextDataFilename:
+    def test_empty_folder_returns_one_padded_to_20(self, fake_credential):
+        client = OpenMirrorClient(fake_credential, WS, MIRROR)
+        with patch("pyfabric.data.open_mirror.onelake.list_paths", return_value=[]):
+            name = client.next_data_filename("t", schema="s")
+        assert name == "00000000000000000001.parquet"
+
+    def test_picks_max_plus_one(self, fake_credential):
+        client = OpenMirrorClient(fake_credential, WS, MIRROR)
+        entries = [
+            _path_entry(
+                f"{MIRROR}/Files/LandingZone/s.schema/t/00000000000000000001.parquet"
+            ),
+            _path_entry(
+                f"{MIRROR}/Files/LandingZone/s.schema/t/00000000000000000002.parquet"
+            ),
+            _path_entry(
+                f"{MIRROR}/Files/LandingZone/s.schema/t/00000000000000000005.parquet"
+            ),
+        ]
+        with patch(
+            "pyfabric.data.open_mirror.onelake.list_paths", return_value=entries
+        ):
+            name = client.next_data_filename("t", schema="s")
+        assert name == "00000000000000000006.parquet"
+
+    def test_ignores_non_sequential_filenames(self, fake_credential):
+        client = OpenMirrorClient(fake_credential, WS, MIRROR)
+        entries = [
+            _path_entry(f"{MIRROR}/Files/LandingZone/s.schema/t/_metadata.json"),
+            _path_entry(f"{MIRROR}/Files/LandingZone/s.schema/t/abc.parquet"),
+            _path_entry(
+                f"{MIRROR}/Files/LandingZone/s.schema/t/00000000000000000007.parquet"
+            ),
+        ]
+        with patch(
+            "pyfabric.data.open_mirror.onelake.list_paths", return_value=entries
+        ):
+            name = client.next_data_filename("t", schema="s")
+        assert name == "00000000000000000008.parquet"
+
+    def test_ignores_subfolders_like_processed(self, fake_credential):
+        client = OpenMirrorClient(fake_credential, WS, MIRROR)
+        entries = [
+            _path_entry(
+                f"{MIRROR}/Files/LandingZone/s.schema/t/_ProcessedFiles", is_dir=True
+            ),
+            _path_entry(
+                f"{MIRROR}/Files/LandingZone/s.schema/t/00000000000000000003.parquet"
+            ),
+        ]
+        with patch(
+            "pyfabric.data.open_mirror.onelake.list_paths", return_value=entries
+        ):
+            name = client.next_data_filename("t", schema="s")
+        assert name == "00000000000000000004.parquet"
+
+    def test_custom_extension(self, fake_credential):
+        client = OpenMirrorClient(fake_credential, WS, MIRROR)
+        with patch("pyfabric.data.open_mirror.onelake.list_paths", return_value=[]):
+            name = client.next_data_filename("t", schema="s", extension="parquet.gz")
+        assert name == "00000000000000000001.parquet.gz"
+
+
+# ── upload_data_file ────────────────────────────────────────────────────────
+
+
+class TestUploadDataFile:
+    def test_assigns_next_sequential_filename_by_default(
+        self, tmp_path, fake_credential
+    ):
+        local = tmp_path / "data.parquet"
+        local.write_bytes(b"PAR1FAKE")
+        client = OpenMirrorClient(fake_credential, WS, MIRROR)
+        with (
+            patch("pyfabric.data.open_mirror.onelake.list_paths", return_value=[]),
+            patch("pyfabric.data.open_mirror.onelake.upload_file") as up,
+        ):
+            remote = client.upload_data_file("t", local, schema="s")
+        assert remote == ("Files/LandingZone/s.schema/t/00000000000000000001.parquet")
+        # Bytes from disk land at the auto-named path.
+        up.assert_called_once()
+        assert up.call_args.args[3] == remote
+        assert up.call_args.args[4] == b"PAR1FAKE"
+
+    def test_uses_explicit_remote_filename_when_given(self, tmp_path, fake_credential):
+        local = tmp_path / "data.parquet"
+        local.write_bytes(b"x")
+        client = OpenMirrorClient(fake_credential, WS, MIRROR)
+        with (
+            patch("pyfabric.data.open_mirror.onelake.list_paths") as ls,
+            patch("pyfabric.data.open_mirror.onelake.upload_file") as up,
+        ):
+            remote = client.upload_data_file(
+                "t", local, schema="s", remote_filename="00000000000000000099.parquet"
+            )
+        assert remote == "Files/LandingZone/s.schema/t/00000000000000000099.parquet"
+        # No need to scan the folder when filename is explicit.
+        ls.assert_not_called()
+        assert up.call_args.args[3] == remote
+
+
+# ── list_processed ──────────────────────────────────────────────────────────
+
+
+class TestListProcessed:
+    def test_returns_basenames_when_processed_dir_exists(self, fake_credential):
+        client = OpenMirrorClient(fake_credential, WS, MIRROR)
+        entries = [
+            _path_entry(
+                f"{MIRROR}/Files/LandingZone/s.schema/t/_ProcessedFiles/00000000000000000001.parquet"
+            ),
+            _path_entry(
+                f"{MIRROR}/Files/LandingZone/s.schema/t/_ProcessedFiles/00000000000000000002.parquet"
+            ),
+        ]
+        with patch(
+            "pyfabric.data.open_mirror.onelake.list_paths", return_value=entries
+        ):
+            names = client.list_processed("t", schema="s")
+        assert sorted(names) == [
+            "00000000000000000001.parquet",
+            "00000000000000000002.parquet",
+        ]
+
+    def test_returns_empty_when_processed_dir_missing(self, fake_credential):
+        # list_paths returns [] on 404 (existing onelake.list_paths contract).
+        client = OpenMirrorClient(fake_credential, WS, MIRROR)
+        with patch("pyfabric.data.open_mirror.onelake.list_paths", return_value=[]):
+            names = client.list_processed("t", schema="s")
+        assert names == []
+
+
+# ── path builders ───────────────────────────────────────────────────────────
+
+
+class TestTableFolder:
+    def test_table_folder_with_schema(self, fake_credential):
+        client = OpenMirrorClient(fake_credential, WS, MIRROR)
+        assert (
+            client.table_folder("dim_customer", schema="bc2")
+            == "Files/LandingZone/bc2.schema/dim_customer"
+        )
+
+    def test_table_folder_without_schema(self, fake_credential):
+        client = OpenMirrorClient(fake_credential, WS, MIRROR)
+        assert client.table_folder("dim_customer") == "Files/LandingZone/dim_customer"
+
+
+# ── from research's contract ────────────────────────────────────────────────
+
+
+class TestProtocolNotes:
+    """Sanity checks on properties documented in the landing-zone format
+    reference but easy to regress: filename padding width, extension
+    handling, ``_metadata.json`` keys."""
+
+    def test_filename_padding_is_exactly_20_digits(self, fake_credential):
+        client = OpenMirrorClient(fake_credential, WS, MIRROR)
+        with patch("pyfabric.data.open_mirror.onelake.list_paths", return_value=[]):
+            name = client.next_data_filename("t", schema="s")
+        stem = Path(name).stem
+        assert len(stem) == 20
+        assert stem.isdigit()


### PR DESCRIPTION
Second of three PRs adding Open Mirroring support (closes #58). Builds on PR A (#60, merged). PR C (#59) adds high-level `write_rows` + `RowMarker` + offline schema-compat checks on top of this.

## What this ships

`pyfabric.data.open_mirror.OpenMirrorClient` is a thin layer over the existing `pyfabric.data.onelake` helpers (`upload_file`, `list_paths`) — **no new dependency**. ADLS Gen2 hierarchical namespace creates parent folders implicitly on file PUT, so the implementation is simpler than the research's `azure-storage-file-datalake` path: no separate `directory_client.create_directory()` call needed.

```python
from pyfabric.client.auth import FabricCredential
from pyfabric.data.open_mirror import OpenMirrorClient

cred = FabricCredential()
mirror = OpenMirrorClient(cred, ws_id, mirror_id)

mirror.ensure_table("dim_customer", schema="bc2", key_columns=["id"])
mirror.upload_data_file(
    "dim_customer",
    "tests/fixtures/dim_customer_001.parquet",
    schema="bc2",
)  # auto-assigns 00000000000000000001.parquet
```

### API

- `OpenMirrorClient.table_folder(table, schema=None)` — path builder. Returns `Files/LandingZone/<schema>.schema/<table>` or the flat `Files/LandingZone/<table>` when no schema is given.
- `ensure_table(table, *, schema=None, key_columns, upsert_default=False, detect_by_last_update=False)` — uploads `_metadata.json` with the documented keys. Empty `key_columns` rejected.
- `next_data_filename(table, *, schema=None, extension=\"parquet\")` — lists the folder, parses every basename whose stem is exactly 20 digits, returns `f\"{max+1:020d}.{extension}\"`. Skips subdirectories (`_ProcessedFiles`, `_FilesReadyToDelete`) and non-numeric names.
- `upload_data_file(table, local_path, *, schema=None, remote_filename=None)` — uploads bytes to the table's folder. When `remote_filename` is None, falls back to `next_data_filename` using the local file's extension. Returns the full DFS path.
- `list_processed(table, *, schema=None)` — returns basenames in `<table>/_ProcessedFiles`. Returns `[]` when the folder is missing (relies on `onelake.list_paths`'s 404 → `[]` contract).

## Test plan

- [x] **18 new tests** — path builders (with/without schema), metadata shape with every combination of optional flags (`upsert_default`, `detect_by_last_update`), sequential-filename math edge cases (empty folder, gaps in numbering, non-sequential names, `_ProcessedFiles` subdir skip), explicit vs auto-named upload, `list_processed` populated + missing-folder.
- [x] Total: **669 passed, 1 skipped**.
- [x] `ruff check . / ruff format --check . / mypy --strict src/ / codespell` all green.
- [x] Pre-push hook (ruff + mypy + pytest + codespell + markdownlint) passed.
- [ ] Live OneLake: not exercised here. Live coverage for the data plane is tracked by #52 (alongside the PR A REST lifecycle round-trips).

## Credit

The Open Mirroring landing-zone protocol — path shape, `_metadata.json` keys (`keyColumns`, `isUpsertDefaultRowMarker`, `fileDetectionStrategy`), 20-digit sequential filename convention, `_ProcessedFiles` retention behaviour — was first published as research notes by the *Learn Microsoft Fabric* community at <https://github.com/UnifiedEducation/research/tree/main/open-mirroring>.

That repo currently ships **without a license** (\"all rights reserved\" by default), so this implementation is **clean-room**: written from the publicly-documented Microsoft Fabric protocol and the public README + `docs/landing-zone-format.md` only. **No code is copied.** Module docstring carries the attribution.

## Compat notes

- All new public API; no behaviour changes to existing modules.
- New module is strictly typed (mypy `--strict` clean) — does not extend the `ignore_errors` override list.
- Reuses existing `[data]` extra (azure-storage / requests already declared); no new optional dependency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)