### PR TITLE
Workspace inspection demo: pyfabric demo + examples/workspace_demo.py (#53)

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,21 @@ pyfabric.
 
 ## Quick start
 
+### First-run smoke test
+
+After `pip install --pre "pyfabric[azure]"`, verify install + auth + the
+core read APIs in one command:
+
+```bash
+pyfabric demo "<your_workspace_display_name>"
+pyfabric demo "<your_workspace_display_name>" --show-definitions
+```
+
+It lists accessible workspaces, resolves the one you named (with
+case-insensitive and "did you mean" fallbacks), and summarises its
+items. Read-only — no writes, no pushes. Equivalent script form:
+[`examples/workspace_demo.py`](examples/workspace_demo.py).
+
 ### Validate a Fabric workspace
 
 ```python

--- a/examples/workspace_demo.py
+++ b/examples/workspace_demo.py
@@ -1,0 +1,23 @@
+"""
+Read-only workspace inspection demo.
+
+A self-contained smoke test for new pyfabric users:
+
+    python examples/workspace_demo.py "<workspace_name>"
+    python examples/workspace_demo.py "<workspace_name>" --show-definitions
+
+Equivalent to (and a thin wrapper around) the ``pyfabric demo``
+CLI subcommand. Both routes call ``pyfabric.demo.run_demo`` so they
+stay in lockstep.
+
+Requires the ``[azure]`` extra:
+
+    pip install --pre --upgrade "pyfabric[azure]"
+"""
+
+import sys
+
+from pyfabric.demo import main
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/pyfabric/cli.py
+++ b/src/pyfabric/cli.py
@@ -179,6 +179,11 @@ def main(argv: list[str] | None = None) -> int:
             "      *.yml, etc.) to the canonical bytes Fabric git-sync emits.\n"
             "      Idempotent. Use --dry-run to report drift without writing.\n"
             "\n"
+            "  pyfabric demo <workspace_name> [--show-definitions]\n"
+            "      Read-only workspace inspection: list workspaces, resolve\n"
+            "      one by display name, summarise items. First-run smoke\n"
+            "      test for install + auth.\n"
+            "\n"
             "  pyfabric --help\n"
             "      Show this help.\n"
         )
@@ -211,6 +216,11 @@ def main(argv: list[str] | None = None) -> int:
 
     if subcommand == "normalize-artifacts":
         return _normalize_artifacts_main(rest)
+
+    if subcommand == "demo":
+        from pyfabric.demo import main as demo_main
+
+        return demo_main(rest)
 
     print(f"pyfabric: unknown command '{subcommand}'", file=sys.stderr)
     print("Run 'pyfabric --help' for available commands.", file=sys.stderr)

--- a/src/pyfabric/demo.py
+++ b/src/pyfabric/demo.py
@@ -1,0 +1,288 @@
+"""
+Read-only workspace inspection demo.
+
+A self-contained smoke test that verifies the chain a new user has to
+get right before pyfabric becomes useful: install (with the right
+extra), auth, list workspaces, resolve a workspace by display name,
+and read items.
+
+Wired as ``pyfabric demo <workspace_name>`` and as
+``examples/workspace_demo.py``.
+
+This module never writes, never deletes, and never pushes. The most
+mutating thing it does is POST ``getDefinition`` for a single item
+(only when ``--show-definitions`` is passed); that endpoint is read-
+only despite the verb.
+"""
+
+import argparse
+import difflib
+import sys
+from collections import Counter
+from collections.abc import Sequence
+from typing import TYPE_CHECKING, Any, Protocol
+
+import structlog
+
+if TYPE_CHECKING:
+    from pyfabric.client.http import FabricClient
+
+log = structlog.get_logger()
+
+
+_INSTALL_HINT = (
+    "pyfabric demo: the [azure] extra is required.\n"
+    '  pip install --pre --upgrade "pyfabric[azure]"\n'
+)
+
+
+class _PagedClient(Protocol):
+    """Subset of ``FabricClient`` used by the demo (eases stubbing in tests)."""
+
+    def get_paged(
+        self, path: str, params: dict[str, Any] | None = None
+    ) -> list[dict[str, Any]]: ...
+
+    def post(self, path: str, body: Any = None) -> dict[str, Any]: ...
+
+
+# ── Public entrypoint ────────────────────────────────────────────────────────
+
+
+def run_demo(
+    workspace_name: str,
+    *,
+    client: "FabricClient | _PagedClient | None" = None,
+    show_definitions: bool = False,
+    out: Any = None,
+    err: Any = None,
+) -> int:
+    """Run the read-only workspace inspection demo.
+
+    Returns a process exit code: 0 success, 1 user-input error
+    (workspace not found / ambiguous), 2 environment error (missing
+    install extra).
+
+    Args:
+        workspace_name:    Workspace display name to inspect.
+        client:            Pre-built client (tests inject a stub).
+                           If ``None``, a real ``FabricClient`` is
+                           constructed — which requires the ``[azure]``
+                           extra.
+        show_definitions:  If True, fetch one item definition to
+                           demonstrate ``get_item_definition``.
+        out:               File for stdout (defaults to ``sys.stdout``).
+        err:               File for stderr (defaults to ``sys.stderr``).
+    """
+    out = out or sys.stdout
+    err = err or sys.stderr
+
+    if client is None:
+        try:
+            import requests  # noqa: F401  (probe for the [azure] extra)
+
+            from pyfabric.client.http import FabricClient as _FabricClient
+        except ImportError as e:
+            print(_INSTALL_HINT, file=err, end="")
+            print(f"  (underlying error: {e})", file=err)
+            return 2
+        client = _FabricClient()
+
+    from pyfabric.items.crud import list_items
+    from pyfabric.workspace.workspaces import list_workspaces
+
+    workspaces = list_workspaces(client)  # type: ignore[arg-type]
+    _print_workspace_list(workspaces, out=out)
+
+    resolved = _resolve_workspace(workspace_name, workspaces, out=out, err=err)
+    if resolved is None:
+        return 1
+
+    print(
+        f"\nResolved: {resolved['displayName']}  ({resolved['id']})",
+        file=out,
+    )
+
+    items = list_items(client, resolved["id"])  # type: ignore[arg-type]
+    _print_item_summary(items, out=out)
+
+    if show_definitions and items:
+        _print_one_definition(client, resolved["id"], items, out=out, err=err)
+
+    return 0
+
+
+# ── Workspace listing ────────────────────────────────────────────────────────
+
+
+def _print_workspace_list(workspaces: list[dict[str, Any]], *, out: Any) -> None:
+    print(f"Accessible workspaces ({len(workspaces)}):", file=out)
+    top = workspaces[:10]
+    for ws in top:
+        print(
+            f"  - {ws.get('displayName', '<no name>')}  ({ws.get('id', '?')})", file=out
+        )
+    remaining = len(workspaces) - len(top)
+    if remaining > 0:
+        print(f"  ... and {remaining} more", file=out)
+
+
+# ── Resolution ───────────────────────────────────────────────────────────────
+
+
+def _resolve_workspace(
+    name: str,
+    workspaces: list[dict[str, Any]],
+    *,
+    out: Any,
+    err: Any,
+) -> dict[str, Any] | None:
+    """Resolve a workspace by display name.
+
+    Resolution order: exact match, case-insensitive match, ambiguous
+    (>1 hit by either rule), did-you-mean suggestion, not-found.
+    """
+    exact = [w for w in workspaces if w.get("displayName") == name]
+    if len(exact) == 1:
+        return exact[0]
+    if len(exact) > 1:
+        _print_ambiguous(name, exact, err=err)
+        return None
+
+    lower = name.lower()
+    ci = [w for w in workspaces if str(w.get("displayName", "")).lower() == lower]
+    if len(ci) == 1:
+        match = ci[0]
+        print(
+            f"Note: case-insensitive match for {name!r} -> {match['displayName']!r}",
+            file=out,
+        )
+        return match
+    if len(ci) > 1:
+        _print_ambiguous(name, ci, err=err)
+        return None
+
+    candidates = [str(w.get("displayName", "")) for w in workspaces]
+    suggestions = difflib.get_close_matches(name, candidates, n=5, cutoff=0.5)
+    print(f"\nWorkspace not found: {name!r}", file=err)
+    if suggestions:
+        print("Did you mean:", file=err)
+        for s in suggestions:
+            print(f"  - {s}", file=err)
+    return None
+
+
+def _print_ambiguous(
+    name: str,
+    matches: list[dict[str, Any]],
+    *,
+    err: Any,
+) -> None:
+    print(
+        f"\nAmbiguous workspace name {name!r} — {len(matches)} matches:",
+        file=err,
+    )
+    for w in matches:
+        print(
+            f"  - {w.get('displayName', '<no name>')}  ({w.get('id', '?')})",
+            file=err,
+        )
+    print("Resolve by ID instead.", file=err)
+
+
+# ── Item summary ─────────────────────────────────────────────────────────────
+
+
+_ENUMERATED_TYPES = ("Lakehouse", "Notebook", "SemanticModel", "Report")
+
+
+def _print_item_summary(items: list[dict[str, Any]], *, out: Any) -> None:
+    print(f"\nItems ({len(items)}):", file=out)
+    counts = Counter(str(it.get("type", "Unknown")) for it in items)
+    for item_type, n in sorted(counts.items()):
+        print(f"  {item_type}: {n}", file=out)
+
+    for item_type in _ENUMERATED_TYPES:
+        matches = [it for it in items if it.get("type") == item_type]
+        if not matches:
+            continue
+        print(f"\n{item_type}(s):", file=out)
+        for it in matches[:10]:
+            print(
+                f"  - {it.get('displayName', '<no name>')}  ({it.get('id', '?')})",
+                file=out,
+            )
+        if len(matches) > 10:
+            print(f"  ... and {len(matches) - 10} more", file=out)
+
+
+# ── Optional definition fetch ────────────────────────────────────────────────
+
+
+def _print_one_definition(
+    client: "FabricClient | _PagedClient",
+    workspace_id: str,
+    items: list[dict[str, Any]],
+    *,
+    out: Any,
+    err: Any,
+) -> None:
+    from pyfabric.items.crud import get_item_definition
+
+    target = next(
+        (it for it in items if it.get("type") in _ENUMERATED_TYPES),
+        items[0],
+    )
+    name = target.get("displayName", "<no name>")
+    print(
+        f"\nFetching definition for {name!r} ({target.get('type')})...",
+        file=out,
+    )
+    try:
+        definition = get_item_definition(client, workspace_id, target["id"])  # type: ignore[arg-type]
+    except Exception as e:
+        print(f"  (definition fetch failed: {e})", file=err)
+        return
+    parts = definition.get("definition", {}).get("parts", [])
+    print(f"  {len(parts)} part(s):", file=out)
+    for p in parts[:5]:
+        print(f"    - {p.get('path', '?')}", file=out)
+    if len(parts) > 5:
+        print(f"    ... and {len(parts) - 5} more", file=out)
+
+
+# ── CLI entrypoint ───────────────────────────────────────────────────────────
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """CLI entrypoint for ``pyfabric demo``."""
+    parser = argparse.ArgumentParser(
+        prog="pyfabric demo",
+        description=(
+            "Read-only workspace inspection: list workspaces, resolve "
+            "one by display name, and summarise its items. Useful as a "
+            "first-run smoke test after install."
+        ),
+    )
+    parser.add_argument(
+        "workspace_name",
+        help="Workspace display name to inspect.",
+    )
+    parser.add_argument(
+        "--show-definitions",
+        action="store_true",
+        help="Fetch one item definition to demonstrate get_item_definition.",
+    )
+    try:
+        args = parser.parse_args(argv)
+    except SystemExit as e:
+        return int(e.code) if isinstance(e.code, int) else 2
+
+    return run_demo(
+        args.workspace_name,
+        show_definitions=args.show_definitions,
+    )
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_demo.py
+++ b/tests/test_demo.py
@@ -1,0 +1,247 @@
+"""Tests for ``pyfabric.demo`` (the read-only workspace inspection demo)."""
+
+import io
+import sys
+from typing import Any
+
+import pytest
+
+from pyfabric import demo
+
+# ── Stub client ──────────────────────────────────────────────────────────────
+
+
+class _StubClient:
+    """Minimal stand-in for FabricClient used by ``run_demo``."""
+
+    def __init__(
+        self,
+        *,
+        workspaces: list[dict[str, Any]] | None = None,
+        items_by_ws: dict[str, list[dict[str, Any]]] | None = None,
+        definitions: dict[str, dict[str, Any]] | None = None,
+    ) -> None:
+        self._workspaces = workspaces or []
+        self._items_by_ws = items_by_ws or {}
+        self._definitions = definitions or {}
+        self.post_calls: list[tuple[str, Any]] = []
+
+    def get_paged(
+        self, path: str, params: dict[str, Any] | None = None
+    ) -> list[dict[str, Any]]:
+        if path == "workspaces":
+            return list(self._workspaces)
+        if path.startswith("workspaces/") and path.endswith("/items"):
+            ws_id = path.split("/")[1]
+            return list(self._items_by_ws.get(ws_id, []))
+        raise AssertionError(f"unexpected get_paged path: {path}")
+
+    def post(self, path: str, body: Any = None) -> dict[str, Any]:
+        self.post_calls.append((path, body))
+        # Path looks like workspaces/{ws}/items/{id}/getDefinition
+        parts = path.split("/")
+        item_id = parts[3] if len(parts) >= 4 else ""
+        return self._definitions.get(item_id, {"definition": {"parts": []}})
+
+
+def _make_client(**kwargs: Any) -> _StubClient:
+    return _StubClient(**kwargs)
+
+
+# ── Happy path ───────────────────────────────────────────────────────────────
+
+
+class TestRunDemo:
+    def test_resolves_exact_match_and_prints_sections(self) -> None:
+        client = _make_client(
+            workspaces=[
+                {"id": "ws-1", "displayName": "Test WS"},
+                {"id": "ws-2", "displayName": "Other WS"},
+            ],
+            items_by_ws={
+                "ws-1": [
+                    {"id": "lh-1", "type": "Lakehouse", "displayName": "Bronze"},
+                    {"id": "lh-2", "type": "Lakehouse", "displayName": "Silver"},
+                    {"id": "nb-1", "type": "Notebook", "displayName": "Ingest"},
+                    {"id": "sm-1", "type": "SemanticModel", "displayName": "Sales"},
+                ],
+            },
+        )
+        out, err = io.StringIO(), io.StringIO()
+
+        rc = demo.run_demo("Test WS", client=client, out=out, err=err)
+
+        stdout = out.getvalue()
+        assert rc == 0
+        assert "Accessible workspaces (2)" in stdout
+        assert "Resolved: Test WS" in stdout
+        assert "ws-1" in stdout
+        assert "Items (4)" in stdout
+        assert "Lakehouse: 2" in stdout
+        assert "Notebook: 1" in stdout
+        assert "Lakehouse(s):" in stdout
+        assert "Bronze" in stdout and "Silver" in stdout
+
+    def test_case_insensitive_fallback(self) -> None:
+        client = _make_client(
+            workspaces=[{"id": "ws-1", "displayName": "Production"}],
+            items_by_ws={"ws-1": []},
+        )
+        out, err = io.StringIO(), io.StringIO()
+
+        rc = demo.run_demo("production", client=client, out=out, err=err)
+
+        assert rc == 0
+        assert "case-insensitive" in out.getvalue()
+        assert "Resolved: Production" in out.getvalue()
+
+    def test_show_definitions_fetches_one_item(self) -> None:
+        client = _make_client(
+            workspaces=[{"id": "ws-1", "displayName": "WS"}],
+            items_by_ws={
+                "ws-1": [
+                    {"id": "nb-1", "type": "Notebook", "displayName": "Demo"},
+                ],
+            },
+            definitions={
+                "nb-1": {
+                    "definition": {
+                        "parts": [
+                            {"path": "notebook-content.py", "payload": "..."},
+                            {"path": ".platform", "payload": "..."},
+                        ]
+                    }
+                }
+            },
+        )
+        out, err = io.StringIO(), io.StringIO()
+
+        rc = demo.run_demo("WS", client=client, show_definitions=True, out=out, err=err)
+
+        assert rc == 0
+        assert "Fetching definition for 'Demo'" in out.getvalue()
+        assert "2 part(s)" in out.getvalue()
+        assert "notebook-content.py" in out.getvalue()
+        assert any(path.endswith("/getDefinition") for path, _ in client.post_calls)
+
+    def test_lists_top_10_and_more_indicator(self) -> None:
+        many = [{"id": f"ws-{i}", "displayName": f"WS{i:02d}"} for i in range(15)]
+        client = _make_client(
+            workspaces=many,
+            items_by_ws={"ws-0": []},
+        )
+        out, err = io.StringIO(), io.StringIO()
+
+        demo.run_demo("WS00", client=client, out=out, err=err)
+
+        assert "and 5 more" in out.getvalue()
+
+
+# ── Resolution failures ──────────────────────────────────────────────────────
+
+
+class TestResolution:
+    def test_ambiguous_exit_1_lists_ids(self) -> None:
+        client = _make_client(
+            workspaces=[
+                {"id": "ws-A", "displayName": "Shared"},
+                {"id": "ws-B", "displayName": "Shared"},
+            ],
+        )
+        out, err = io.StringIO(), io.StringIO()
+
+        rc = demo.run_demo("Shared", client=client, out=out, err=err)
+
+        assert rc == 1
+        stderr = err.getvalue()
+        assert "Ambiguous" in stderr
+        assert "ws-A" in stderr and "ws-B" in stderr
+
+    def test_did_you_mean_suggestion_exit_1(self) -> None:
+        client = _make_client(
+            workspaces=[
+                {"id": "ws-1", "displayName": "Production"},
+                {"id": "ws-2", "displayName": "Staging"},
+            ],
+        )
+        out, err = io.StringIO(), io.StringIO()
+
+        rc = demo.run_demo("productn", client=client, out=out, err=err)
+
+        assert rc == 1
+        stderr = err.getvalue()
+        assert "not found" in stderr
+        assert "Did you mean" in stderr
+        assert "Production" in stderr
+
+    def test_not_found_no_close_match(self) -> None:
+        client = _make_client(
+            workspaces=[{"id": "ws-1", "displayName": "Production"}],
+        )
+        out, err = io.StringIO(), io.StringIO()
+
+        rc = demo.run_demo("zzzzzzzz", client=client, out=out, err=err)
+
+        assert rc == 1
+        assert "not found" in err.getvalue()
+        assert "Did you mean" not in err.getvalue()
+
+
+# ── Install-hint path ───────────────────────────────────────────────────────
+
+
+class TestMissingExtra:
+    def test_missing_requests_prints_install_hint_exit_2(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # Force ``import requests`` to fail inside run_demo.
+        monkeypatch.setitem(sys.modules, "requests", None)
+        # Also drop pyfabric.client.http so its module-level requests
+        # import re-runs (and fails) instead of returning the cached
+        # module that succeeded earlier in this test process.
+        monkeypatch.delitem(sys.modules, "pyfabric.client.http", raising=False)
+
+        out, err = io.StringIO(), io.StringIO()
+        rc = demo.run_demo("anything", client=None, out=out, err=err)
+
+        assert rc == 2
+        stderr = err.getvalue()
+        assert 'pip install --pre --upgrade "pyfabric[azure]"' in stderr
+
+
+# ── CLI surface ─────────────────────────────────────────────────────────────
+
+
+class TestCli:
+    def test_demo_subcommand_dispatches(
+        self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        called: dict[str, Any] = {}
+
+        def fake_main(argv: list[str]) -> int:
+            called["argv"] = argv
+            return 0
+
+        monkeypatch.setattr("pyfabric.demo.main", fake_main)
+
+        from pyfabric import cli
+
+        rc = cli.main(["demo", "My WS", "--show-definitions"])
+
+        assert rc == 0
+        assert called["argv"] == ["My WS", "--show-definitions"]
+
+    def test_demo_help_lists_subcommand(
+        self, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        from pyfabric import cli
+
+        rc = cli.main(["--help"])
+        assert rc == 0
+        assert "pyfabric demo" in capsys.readouterr().out
+
+    def test_demo_main_missing_arg_returns_nonzero(
+        self, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        rc = demo.main([])
+        assert rc != 0


### PR DESCRIPTION
## Summary

- Adds `pyfabric.demo.run_demo` — a read-only smoke test that lists workspaces, resolves one by display name, and summarises its items.
- Wires it as `pyfabric demo <workspace_name> [--show-definitions]` (CLI subcommand) and `examples/workspace_demo.py` (a thin wrapper).
- README Quick start gets a "First-run smoke test" section pointing new users at the demo.

## Closes

Closes #53

## Scope note

#53 framed `examples/workspace_demo.py` as the primary deliverable and `pyfabric demo` as a "Bonus" CLI subcommand. This PR ships **both** — they share one implementation (`pyfabric.demo.run_demo`), so they can't drift. The CLI route is what you'd actually point a new colleague at; the `examples/` file makes the script discoverable in the source tree and gives PR reviewers a place to look.

## Resolution behaviour

The demo's resolution order matches #53's TDD spec:

1. Exact display-name match → resolved.
2. Case-insensitive single match → resolved (with a note).
3. Multiple matches by either rule → exit 1, print all IDs ("resolve by ID instead").
4. No match but `difflib.get_close_matches` finds neighbours → exit 1 with "Did you mean:".
5. Otherwise → exit 1 with "not found".
6. `requests` not importable (i.e. `[azure]` extra missing) → exit 2 with the install-fix command.

## Implementation notes

- `requests` and `FabricClient` are lazy-imported inside `run_demo()` so the install-hint path can fire before the module-level import would otherwise fail.
- `run_demo()` accepts an injected client (`client: FabricClient | _PagedClient | None = None`) — tests pass a stub directly rather than monkeypatching globals.
- The new module is **not** added to `pyproject.toml`'s mypy ignore list. It's fully strict-typed.
- Read-only: no writes, no deletes. The `--show-definitions` path POSTs `getDefinition`, which is read-only despite the verb.

## Test plan

- [x] `pytest tests/test_demo.py` — 11 new tests covering all four #53 acceptance criteria + CLI dispatch.
- [x] `pytest` — full suite, 700 passed / 1 skipped.
- [x] `ruff check .` — clean.
- [x] `ruff format --check .` — clean.
- [x] `mypy src/` — clean (strict, no overrides).
- [x] `python examples/workspace_demo.py --help` — wrapper executes.
- [ ] Run `pyfabric demo "<your_workspace>"` end-to-end against a real Fabric tenant once the wheel is rebuilt locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)