### PR TITLE
PR 1/4 (v0.1.0rc1): small fixes — py311 floor, evolve_schema duck-typing, write_rows pre-stamp check, _poll_lro Completed, decode_part TypeError

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,7 +55,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.12", "3.13"]
+        python-version: ["3.11", "3.12", "3.13"]
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-python@v6

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,7 +12,7 @@ generate and test Fabric item definitions locally.
 
 ## Technical Stack
 
-- **Python**: 3.12+ (use modern syntax: `type X = ...`, `match`, `X | Y` unions)
+- **Python**: 3.11+ (use modern syntax: `match`, `X | Y` unions, `Self` from `typing`). Avoid 3.12-only syntax — Fabric Spark runtime 1.3 is 3.11. Specifically: do NOT use `type X = Y` (PEP 695, 3.12+) or `class Foo[T]` (PEP 695, 3.12+).
 - **Build**: hatchling with hatch-vcs (version from git tags)
 - **Layout**: src-layout (`src/pyfabric/`)
 - **Linting**: ruff (configured in pyproject.toml)
@@ -39,7 +39,7 @@ src/pyfabric/
 - All public functions and classes must have type annotations
 - Use `X | None` not `typing.Optional[X]`; use `X | Y` not `typing.Union`
 - Use `list`, `dict`, `tuple` not `typing.List`, `typing.Dict`, `typing.Tuple`
-- `from __future__ import annotations` is NOT needed (Python 3.12+)
+- `from __future__ import annotations` is NOT needed (Python 3.11+ supports `X | Y` unions natively via PEP 604)
 - Prefer `pathlib.Path` over `os.path`
 - Prefer dataclasses or named tuples over plain dicts for structured data
 - Tests use pytest fixtures; avoid unittest.TestCase

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ dynamic = ["version"]
 description = "Python libraries helping AI coding assistants create and locally validate Microsoft Fabric items compatible with Fabric git sync."
 readme = "README.md"
 license = "MIT"
-requires-python = ">=3.12"
+requires-python = ">=3.11"
 authors = [
     { name = "Creative Planning", email = "20804442+hughdecatte@users.noreply.github.com" },
 ]
@@ -17,6 +17,7 @@ classifiers = [
     "Intended Audience :: Developers",
     "License :: OSI Approved :: MIT License",
     "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
     "Typing :: Typed",
@@ -97,7 +98,7 @@ packages = ["src/pyfabric"]
 # -- Ruff ------------------------------------------------------------------
 
 [tool.ruff]
-target-version = "py312"
+target-version = "py311"
 line-length = 88
 indent-width = 4
 extend-exclude = [
@@ -131,7 +132,7 @@ docstring-code-format = true
 # -- Mypy ------------------------------------------------------------------
 
 [tool.mypy]
-python_version = "3.12"
+python_version = "3.11"
 strict = true
 warn_return_any = true
 warn_unused_configs = true

--- a/src/pyfabric/client/http.py
+++ b/src/pyfabric/client/http.py
@@ -154,7 +154,10 @@ class FabricClient:
             if resp.status_code == 200:
                 body = resp.json() if resp.text else {}
                 status = body.get("status", "")
-                if status in ("Succeeded", ""):
+                # Fabric LRO success vocabulary varies by surface:
+                # "Succeeded" for items/workspaces, "Completed" for the
+                # Jobs API (RunNotebook). Empty body == sync 200.
+                if status in ("Succeeded", "Completed", ""):
                     return body
                 if status in ("Failed", "Cancelled"):
                     raise FabricError(resp.status_code, resp.text, location)

--- a/src/pyfabric/data/local_lakehouse.py
+++ b/src/pyfabric/data/local_lakehouse.py
@@ -252,8 +252,14 @@ class LocalLakehouse:
         by_name = {t.name: t for t in tables}
         for table_name, missing in drift.items():
             table = by_name[table_name]
+            # Walk .columns directly instead of calling table.column(name).
+            # The latter is an in-pyfabric helper not part of the documented
+            # protocol — duck-typed TableDef-like objects from downstream
+            # callers (which expose `.columns`, `.name`, `.to_duckdb_ddl()`)
+            # don't have it.
+            cols_by_name = {c.name: c for c in table.columns}
             for col_name in missing:
-                col = table.column(col_name)
+                col = cols_by_name[col_name]
                 duck_type = DUCKDB_TYPES[col.type_key]
                 self._conn.execute(
                     f"ALTER TABLE {self.schema}.{table_name} "

--- a/src/pyfabric/data/open_mirror.py
+++ b/src/pyfabric/data/open_mirror.py
@@ -410,9 +410,13 @@ class OpenMirrorClient:
           Useful when one file mixes inserts / updates / deletes.
 
         If ``expected_schema`` is provided, :func:`assert_schema_compat`
-        runs **before** any upload — a mismatched schema raises
-        :class:`OpenMirrorSchemaIncompatible` with no DFS side effect.
-        Catches Fabric's silent ``SchemaMergeFailure`` gotcha at the
+        runs **before any auto-stamp or upload** — the schema is
+        compared against the caller's arrow table as supplied, not the
+        post-stamp shape. So under ``mode != None``, ``expected_schema``
+        should NOT include ``__rowMarker__``; it represents the
+        producer's natural columns. A mismatch raises
+        :class:`OpenMirrorSchemaIncompatible` with no DFS side effect,
+        catching Fabric's silent ``SchemaMergeFailure`` gotcha at the
         producer's pre-commit boundary.
 
         Args:
@@ -442,6 +446,10 @@ class OpenMirrorClient:
 
         column_names = arrow_table.column_names
 
+        # Structural validation first — cheap checks that protect against
+        # ambiguous mode + marker combinations. Running these before
+        # assert_schema_compat keeps their precise ValueError diagnostics
+        # rather than letting schema-compat fire a less specific message.
         if mode is not None:
             if _ROW_MARKER_COLUMN in column_names:
                 raise ValueError(
@@ -449,12 +457,6 @@ class OpenMirrorClient:
                     "table already contains that column — pass mode=None to use "
                     "the existing values, or drop the column to auto-stamp."
                 )
-            marker = _MODE_TO_MARKER[mode]
-            row_count = arrow_table.num_rows
-            arrow_table = arrow_table.append_column(
-                _ROW_MARKER_COLUMN,
-                pa_mod.array([int(marker)] * row_count, type=pa_mod.int32()),
-            )
         else:
             if _ROW_MARKER_COLUMN not in column_names:
                 raise ValueError(
@@ -468,8 +470,22 @@ class OpenMirrorClient:
                     f"{column_names[-1]!r} after it."
                 )
 
+        # Validate caller's schema BEFORE any auto-stamping. The
+        # expected_schema is the producer's view of the data, which
+        # naturally excludes __rowMarker__ when mode != None. Running
+        # the check against the post-stamp shape would either reject
+        # legitimate writes (when append_column produces a NOT NULL
+        # field) or produce a misleading "new column added" diagnostic.
         if expected_schema is not None:
             assert_schema_compat(expected_schema, arrow_table.schema)
+
+        if mode is not None:
+            marker = _MODE_TO_MARKER[mode]
+            row_count = arrow_table.num_rows
+            arrow_table = arrow_table.append_column(
+                _ROW_MARKER_COLUMN,
+                pa_mod.array([int(marker)] * row_count, type=pa_mod.int32()),
+            )
 
         buf = io.BytesIO()
         pq.write_table(arrow_table, buf)

--- a/src/pyfabric/items/crud.py
+++ b/src/pyfabric/items/crud.py
@@ -185,5 +185,32 @@ def encode_part(path: str, content: str | bytes) -> dict:
 
 
 def decode_part(part: dict) -> bytes:
-    """Decode the base64 payload from a definition part dict."""
+    """
+    Decode the base64 payload from a definition part dict.
+
+    Inverse of :func:`encode_part` — pass the whole part dict
+    (e.g. an entry from ``defn["definition"]["parts"]``), not the
+    bare ``payload`` string::
+
+        part = encode_part("notebook-content.py", "print('hi')")
+        assert decode_part(part) == b"print('hi')"
+
+    Args:
+        part: A part dict with at least a ``"payload"`` key holding a
+            base64-encoded string (``payloadType: "InlineBase64"``).
+
+    Returns:
+        The decoded bytes of ``part["payload"]``.
+
+    Raises:
+        TypeError: If ``part`` is not a dict. The most common cause is
+            passing ``part["payload"]`` directly; the message points
+            back to the right call shape.
+    """
+    if not isinstance(part, dict):
+        raise TypeError(
+            f"decode_part expects a part dict (e.g. an entry from "
+            f"definition['parts']), got {type(part).__name__}. "
+            f"Pass the whole part dict, not part['payload']."
+        )
     return base64.b64decode(part["payload"])

--- a/tests/client/test_http.py
+++ b/tests/client/test_http.py
@@ -129,3 +129,63 @@ class TestFabricClientRequests:
         client = self._make_client(mock_requests_session)
         result = client.post("workspaces", {"displayName": "test"})
         assert result["id"] == "new"
+
+
+class TestPollLroTerminalStatus:
+    """The LRO poller must terminate on every Fabric-emitted success
+    status — not just ``Succeeded``. The Jobs API (used to trigger
+    notebook runs) reports ``Completed`` as its terminal success
+    state; ``Succeeded``-only would loop forever.
+
+    Each non-terminal poll path calls ``time.sleep``; the test patches
+    it to raise so an inadvertent loop fails fast instead of hanging
+    the suite.
+    """
+
+    def _make_client(self, mock_session):
+        client = FabricClient("fake-token")
+        client._session = mock_session
+        return client
+
+    def _poll_response(self, status: str):
+        resp = MagicMock()
+        resp.status_code = 200
+        resp.text = f'{{"status": "{status}"}}'
+        resp.content = resp.text.encode()
+        resp.headers = {}
+        resp.json.return_value = {"status": status}
+        return resp
+
+    @pytest.fixture(autouse=True)
+    def _no_sleep(self):
+        with patch(
+            "pyfabric.client.http.time.sleep",
+            side_effect=AssertionError("LRO poller did not terminate on first reply"),
+        ):
+            yield
+
+    def test_succeeded_terminates(self, mock_requests_session):
+        mock_requests_session.request.return_value = self._poll_response("Succeeded")
+        client = self._make_client(mock_requests_session)
+        body = client._poll_lro("https://example.com/op/1")
+        assert body == {"status": "Succeeded"}
+
+    def test_completed_terminates(self, mock_requests_session):
+        """Jobs API LRO returns ``Completed``; poller must accept it
+        as a terminal success rather than loop."""
+        mock_requests_session.request.return_value = self._poll_response("Completed")
+        client = self._make_client(mock_requests_session)
+        body = client._poll_lro("https://example.com/op/1")
+        assert body == {"status": "Completed"}
+
+    def test_empty_status_terminates(self, mock_requests_session):
+        mock_requests_session.request.return_value = self._poll_response("")
+        client = self._make_client(mock_requests_session)
+        body = client._poll_lro("https://example.com/op/1")
+        assert body == {"status": ""}
+
+    def test_failed_raises(self, mock_requests_session):
+        mock_requests_session.request.return_value = self._poll_response("Failed")
+        client = self._make_client(mock_requests_session)
+        with pytest.raises(FabricError):
+            client._poll_lro("https://example.com/op/1")

--- a/tests/data/test_local_lakehouse_schema_drift.py
+++ b/tests/data/test_local_lakehouse_schema_drift.py
@@ -267,3 +267,70 @@ class TestRegisterOnDriftInvalid:
                 ),
                 on_drift="wat",  # type: ignore[arg-type]
             )
+
+
+class TestEvolveSchemaDuckTypedTableDef:
+    """``evolve_schema`` should accept any object exposing ``.name``,
+    ``.columns: Iterable[Col]``, and ``.to_duckdb_ddl(schema)`` — not
+    require the in-pyfabric ``TableDef.column(name)`` helper. Downstream
+    packages that built TableDef-like classes against the earlier API
+    surface (columns + to_duckdb_ddl + column_names) hit AttributeError
+    when ``evolve_schema`` calls ``table.column(col_name)``.
+    """
+
+    def test_evolve_schema_accepts_ducktyped_table_def(self, tmp_path):
+        from dataclasses import dataclass
+
+        @dataclass(frozen=True)
+        class _DuckTableDef:
+            """Minimal TableDef-like class — no ``.column(name)`` method."""
+
+            name: str
+            columns: tuple[Col, ...]
+
+            def to_duckdb_ddl(self, schema: str | None = None) -> str:
+                from pyfabric.data.schema import DUCKDB_TYPES
+
+                lines = []
+                for c in self.columns:
+                    duck_type = DUCKDB_TYPES[c.type_key]
+                    null = "" if c.nullable else " NOT NULL"
+                    lines.append(f"  {c.name} {duck_type}{null}")
+                cols = ",\n".join(lines)
+                qualified = f"{schema}.{self.name}" if schema else self.name
+                return f"CREATE TABLE IF NOT EXISTS {qualified} (\n{cols}\n)"
+
+        db = tmp_path / "duck.duckdb"
+        with _reopen(db) as lh:
+            v1 = _DuckTableDef(
+                name="widgets",
+                columns=(
+                    Col("id", "int", nullable=False, pk=True),
+                    Col("name", "string"),
+                ),
+            )
+            # Bootstrap the table via execute_ddl since register() doesn't
+            # accept duck-typed defs (it stores them in self._tables for
+            # insert_typed validation, which is fine to skip).
+            lh.execute_ddl([v1.to_duckdb_ddl(lh.schema)])
+
+        with _reopen(db) as lh:
+            v2 = _DuckTableDef(
+                name="widgets",
+                columns=(
+                    Col("id", "int", nullable=False, pk=True),
+                    Col("name", "string"),
+                    Col("color", "string"),  # NEW
+                ),
+            )
+            n_altered = lh.evolve_schema([v2])  # must not raise AttributeError
+            assert n_altered == 1
+            cols = [
+                r[0]
+                for r in lh.conn.execute(
+                    "SELECT column_name FROM information_schema.columns "
+                    "WHERE table_schema = 'dbo' AND table_name = 'widgets' "
+                    "ORDER BY ordinal_position"
+                ).fetchall()
+            ]
+            assert cols == ["id", "name", "color"]

--- a/tests/data/test_open_mirror_write_rows.py
+++ b/tests/data/test_open_mirror_write_rows.py
@@ -333,3 +333,93 @@ class TestWriteRowsSchemaCheck:
         ):
             client.write_rows("t", tbl, schema="s", expected_schema=expected)
         up.assert_called_once()
+
+
+class TestWriteRowsSchemaCheckPreStamp:
+    """The ``expected_schema`` validation must run against the
+    *caller-visible* shape of ``arrow_table`` — i.e. the shape before
+    ``write_rows`` auto-stamps ``__rowMarker__``. Otherwise callers
+    using ``mode='insert'`` (etc.) are forced to either include the
+    marker in ``expected_schema`` (defeating the purpose of mode-based
+    stamping) or skip the check entirely.
+    """
+
+    def test_auto_stamp_accepts_expected_schema_without_row_marker(
+        self, fake_credential
+    ):
+        """Passing ``mode='insert'`` should auto-stamp ``__rowMarker__``,
+        and ``expected_schema`` should be compared against the table the
+        caller handed in (no marker), not the post-stamp shape."""
+        client = OpenMirrorClient(fake_credential, WS, MIRROR)
+        # Caller's natural schema — no __rowMarker__ since mode auto-stamps.
+        expected = _schema_with(
+            ("id", pa.string(), False),
+            ("name", pa.string(), True),
+        )
+        tbl = pa.table({"id": ["a"], "name": ["alpha"]})
+        with (
+            patch("pyfabric.data.open_mirror.onelake.list_paths", return_value=[]),
+            patch("pyfabric.data.open_mirror.onelake.upload_file") as up,
+        ):
+            client.write_rows(
+                "t", tbl, schema="s", mode="insert", expected_schema=expected
+            )
+        up.assert_called_once()
+
+    def test_schema_compat_runs_against_pre_stamp_arrow_table(self, fake_credential):
+        """Verifies the order of operations directly: ``assert_schema_compat``
+        receives the caller-provided ``expected_schema`` and the
+        caller-provided arrow table's schema (no ``__rowMarker__``).
+
+        This is the contract: even if a future pyarrow makes
+        ``append_column`` produce a NOT NULL field by default, the
+        check must not see it.
+        """
+        client = OpenMirrorClient(fake_credential, WS, MIRROR)
+        expected = _schema_with(
+            ("id", pa.string(), False),
+            ("name", pa.string(), True),
+        )
+        tbl = pa.table({"id": ["a"], "name": ["alpha"]})
+        captured: dict[str, pa.Schema] = {}
+
+        def _spy(old: pa.Schema, new: pa.Schema) -> None:
+            captured["old"] = old
+            captured["new"] = new
+
+        with (
+            patch("pyfabric.data.open_mirror.onelake.list_paths", return_value=[]),
+            patch("pyfabric.data.open_mirror.onelake.upload_file"),
+            patch("pyfabric.data.open_mirror.assert_schema_compat", side_effect=_spy),
+        ):
+            client.write_rows(
+                "t", tbl, schema="s", mode="insert", expected_schema=expected
+            )
+        assert captured["old"] == expected
+        # The schema seen by assert_schema_compat must be the caller's
+        # pre-stamp shape — no __rowMarker__ column.
+        assert "__rowMarker__" not in captured["new"].names
+
+    def test_auto_stamp_mismatch_raises_pre_stamp(self, fake_credential):
+        """Mismatch on the caller-visible columns must still raise —
+        proving the check actually runs (not silently skipped)."""
+        client = OpenMirrorClient(fake_credential, WS, MIRROR)
+        expected = _schema_with(
+            ("id", pa.string(), False),
+            ("posts", pa.int32(), True),
+        )
+        # Type drift on "posts": int32 expected, int64 supplied.
+        tbl = pa.table(
+            {
+                "id": ["a"],
+                "posts": pa.array([1], type=pa.int64()),
+            }
+        )
+        with (
+            patch("pyfabric.data.open_mirror.onelake.upload_file") as up,
+            pytest.raises(OpenMirrorSchemaIncompatible),
+        ):
+            client.write_rows(
+                "t", tbl, schema="s", mode="insert", expected_schema=expected
+            )
+        up.assert_not_called()

--- a/tests/items/test_crud.py
+++ b/tests/items/test_crud.py
@@ -2,6 +2,8 @@
 
 import base64
 
+import pytest
+
 from pyfabric.items.crud import (
     create_item,
     decode_part,
@@ -32,6 +34,29 @@ class TestDecodePart:
         payload = base64.b64encode(b"hello world").decode()
         result = decode_part({"payload": payload})
         assert result == b"hello world"
+
+    def test_round_trip_with_encode_part(self):
+        """``decode_part(encode_part(path, content))`` returns the
+        original content. Documents the inverse pairing."""
+        original = b"some bytes \x01\x02"
+        part = encode_part("file.bin", original)
+        assert decode_part(part) == original
+
+    def test_string_input_raises_helpful_typeerror(self):
+        """A caller who passes ``part['payload']`` (the base64 string)
+        instead of the part dict gets a clear pointer to the right
+        usage, not a cryptic ``string indices must be integers``.
+        """
+        payload = base64.b64encode(b"x").decode()
+        with pytest.raises(TypeError) as exc:
+            decode_part(payload)  # type: ignore[arg-type]
+        msg = str(exc.value)
+        assert "decode_part" in msg
+        assert "dict" in msg
+
+    def test_non_dict_non_string_raises_typeerror(self):
+        with pytest.raises(TypeError):
+            decode_part(42)  # type: ignore[arg-type]
 
 
 class TestItemCrud:

--- a/tests/test_pyproject_metadata.py
+++ b/tests/test_pyproject_metadata.py
@@ -1,0 +1,44 @@
+"""Tests against pyproject.toml metadata.
+
+Catches regressions where the published wheel's requires-python is bumped
+above the Python version Fabric Spark runs at runtime — pip enforces
+Requires-Python regardless of --no-deps, so a too-strict pin makes
+pyfabric uninstallable inside Fabric Environment artifacts and notebook
+%pip cells.
+"""
+
+import re
+import tomllib
+from pathlib import Path
+
+_PYPROJECT = Path(__file__).parent.parent / "pyproject.toml"
+
+
+def _requires_python_min() -> tuple[int, int]:
+    data = tomllib.loads(_PYPROJECT.read_text(encoding="utf-8"))
+    requires = data["project"]["requires-python"]
+    m = re.match(r">=\s*(\d+)\.(\d+)", requires)
+    assert m, f"unexpected requires-python format: {requires!r}"
+    return int(m.group(1)), int(m.group(2))
+
+
+def test_requires_python_allows_fabric_spark_runtime() -> None:
+    """Fabric Spark runtime 1.3 runs Python 3.11 (cluster path
+    ~/cluster-env/trident_env/lib/python3.11/). requires-python must be
+    <= 3.11 so the wheel installs there.
+    """
+    major, minor = _requires_python_min()
+    assert (major, minor) <= (3, 11), (
+        f"requires-python = {major}.{minor} blocks installation in "
+        f"Fabric Spark runtime 1.3 (Python 3.11). Lower to >=3.11."
+    )
+
+
+def test_requires_python_does_not_regress_below_310() -> None:
+    """Lower bound: don't accept ancient Pythons that we definitely
+    don't test on. 3.10 is the floor for `match`/PEP 604."""
+    major, minor = _requires_python_min()
+    assert (major, minor) >= (3, 10), (
+        f"requires-python = {major}.{minor} is too low; the codebase "
+        f"uses syntax that needs 3.10+ at minimum."
+    )


### PR DESCRIPTION
First of four PRs targeting **v0.1.0rc1**. Bundles five small fixes that share short fix surfaces.

## Summary

- **#75** — Lower `requires-python` to `>=3.11` so the package installs in Fabric Spark runtime 1.3. Includes a unit test on `pyproject.toml` to lock the floor.
- **#69** — `evolve_schema` now walks `.columns` directly instead of calling `table.column(name)` (an in-pyfabric helper not part of the documented duck-type protocol). Downstream callers with TableDef-like classes no longer hit `AttributeError`.
- **#67** — `write_rows` runs the `expected_schema` check **before** auto-stamping `__rowMarker__`. Previously the check ran against the post-stamp shape and either produced a misleading "new column added" diagnostic or hid drift entirely depending on pyarrow's `append_column` nullability default. Structural validation still happens first to preserve the precise `ValueError` diagnostics.
- **#66** — `_poll_lro` now terminates on `"Completed"` (Jobs API / RunNotebook) in addition to `"Succeeded"` and empty body. Without this, `RunNotebook` LROs loop forever.
- **#64** — `decode_part` raises a clear `TypeError` when given the base64 string instead of the part dict, with a message pointing at the right call shape. Docstring documents the round-trip with `encode_part`.

## Breaking change in `expected_schema` semantics (#67)

Under `mode != None`, `expected_schema` must **NOT** include `__rowMarker__` — it's the producer's natural shape. Callers that previously included the marker to work around the bug should drop it.

## Verification

- `pytest`: 713 passed, 1 skipped (e2e env-gated)
- `ruff check .` + `ruff format --check .`: clean
- `mypy --strict src/`: clean
- `pip-audit`: only environment-level findings (pip, pytest, requests, pygments) — no pyfabric runtime concerns

## Test plan

- [ ] Review CI matrix run on 3.11 / 3.12 / 3.13
- [ ] Spot-check the new failing-then-passing tests in `tests/data/test_open_mirror_write_rows.py::TestWriteRowsSchemaCheckPreStamp`, `tests/client/test_http.py::TestPollLroTerminalStatus::test_completed_terminates`
- [ ] Confirm `assert_schema_compat` ordering reads correctly in the diff

Closes #75, #69, #67, #66, #64.