### PR TITLE
PR 3/4 (v0.1.0rc1): NotebookBuilder — emit notebook-settings.json + attach_environment

### DIFF
--- a/src/pyfabric/items/notebook.py
+++ b/src/pyfabric/items/notebook.py
@@ -64,10 +64,20 @@ class _Lakehouse:
 
 
 @dataclass
+class _Environment:
+    env_id: str
+    ws_id: str  # all-zeros means "same workspace as the notebook"
+
+
+@dataclass
 class _Cell:
     kind: Literal["markdown", "code"]
     content: str
     language: CellLanguage | None = None  # code-only
+
+
+_SAME_WORKSPACE_ID = "00000000-0000-0000-0000-000000000000"
+_NOTEBOOK_SETTINGS_JSON = '{"includeResourcesInGit": "on"}'
 
 
 class NotebookBuilder:
@@ -87,6 +97,7 @@ class NotebookBuilder:
         self.kernel = kernel
         self._lakehouses: list[_Lakehouse] = []
         self._default_lakehouse_idx: int | None = None
+        self._environment: _Environment | None = None
         self._cells: list[_Cell] = []
 
     # ── Lakehouse attach ─────────────────────────────────────────────────────
@@ -114,6 +125,39 @@ class NotebookBuilder:
         self._lakehouses.append(_Lakehouse(ws_id=ws_id, lh_id=lh_id, lh_name=lh_name))
         if default:
             self._default_lakehouse_idx = len(self._lakehouses) - 1
+        return self
+
+    # ── Environment attach ───────────────────────────────────────────────────
+
+    def attach_environment(
+        self,
+        env_id: str,
+        *,
+        ws_id: str | None = None,
+    ) -> "NotebookBuilder":
+        """Attach a Fabric Environment dependency to the notebook.
+
+        Adds an ``environment`` block under ``dependencies`` in the
+        notebook header METADATA. The environment supplies any
+        non-runtime Python packages the notebook needs (e.g. a
+        project's own helper wheel pinned via the Environment's
+        custom libraries).
+
+        Args:
+            env_id: Environment logicalId (the GUID Fabric uses to
+                identify the Environment item).
+            ws_id: Workspace GUID hosting the Environment. Pass
+                ``None`` (default) when the Environment lives in the
+                same workspace as the notebook — Fabric's convention
+                is to render that as an all-zeros GUID.
+
+        A second call replaces the first attachment; only one
+        environment per notebook is supported.
+        """
+        self._environment = _Environment(
+            env_id=env_id,
+            ws_id=ws_id if ws_id is not None else _SAME_WORKSPACE_ID,
+        )
         return self
 
     # ── Cells ────────────────────────────────────────────────────────────────
@@ -174,13 +218,25 @@ class NotebookBuilder:
         line endings on non-Unix hosts.
         """
         source = self.to_source_string()
-        canonical = canonical_bytes(
+        canonical_content = canonical_bytes(
             "nb.Notebook/notebook-content.py", source.encode("utf-8")
         )
+        # notebook-settings.json: required for Fabric to include
+        # Resources/ in git-sync. Emit unconditionally — a no-op when
+        # Resources/ is empty, but the moment a project wheel ships
+        # via pip_install_from_resources the file is mandatory.
+        canonical_settings = canonical_bytes(
+            "nb.Notebook/notebook-settings.json",
+            _NOTEBOOK_SETTINGS_JSON.encode("utf-8"),
+        )
+        parts: dict[str, bytes | str] = {
+            "notebook-content.py": canonical_content,
+            "notebook-settings.json": canonical_settings,
+        }
         kwargs: dict[str, object] = {
             "item_type": "Notebook",
             "display_name": display_name,
-            "parts": {"notebook-content.py": canonical},
+            "parts": parts,
             "description": description,
         }
         if logical_id is not None:
@@ -212,11 +268,14 @@ class NotebookBuilder:
         artifact_dir = Path(output_dir) / bundle.dir_name
         artifact_dir.mkdir(parents=True, exist_ok=True)
 
-        # Route both files through write_artifact_file so line-ending
+        # Route every file through write_artifact_file so line-ending
         # rules are applied regardless of OS default.
         write_artifact_file(artifact_dir / ".platform", bundle.platform_json())
         write_artifact_file(
             artifact_dir / "notebook-content.py", self.to_source_string()
+        )
+        write_artifact_file(
+            artifact_dir / "notebook-settings.json", _NOTEBOOK_SETTINGS_JSON
         )
         log.info(
             "notebook_saved",
@@ -241,20 +300,29 @@ class NotebookBuilder:
         return self._meta_block(body)
 
     def _dependencies_block(self) -> dict[str, object] | None:
-        if not self._lakehouses:
+        if not self._lakehouses and self._environment is None:
             return None
         dep: dict[str, object] = {}
-        lakehouse: dict[str, object] = {}
 
-        if self._default_lakehouse_idx is not None:
-            default = self._lakehouses[self._default_lakehouse_idx]
-            lakehouse["default_lakehouse"] = default.lh_id
-            if default.lh_name is not None:
-                lakehouse["default_lakehouse_name"] = default.lh_name
-            lakehouse["default_lakehouse_workspace_id"] = default.ws_id
+        if self._lakehouses:
+            lakehouse: dict[str, object] = {}
+            if self._default_lakehouse_idx is not None:
+                default = self._lakehouses[self._default_lakehouse_idx]
+                lakehouse["default_lakehouse"] = default.lh_id
+                if default.lh_name is not None:
+                    lakehouse["default_lakehouse_name"] = default.lh_name
+                lakehouse["default_lakehouse_workspace_id"] = default.ws_id
+            lakehouse["known_lakehouses"] = [
+                {"id": lh.lh_id} for lh in self._lakehouses
+            ]
+            dep["lakehouse"] = lakehouse
 
-        lakehouse["known_lakehouses"] = [{"id": lh.lh_id} for lh in self._lakehouses]
-        dep["lakehouse"] = lakehouse
+        if self._environment is not None:
+            dep["environment"] = {
+                "environmentId": self._environment.env_id,
+                "workspaceId": self._environment.ws_id,
+            }
+
         return dep
 
     def _render_cell(self, cell: _Cell) -> str:

--- a/tests/items/test_notebook.py
+++ b/tests/items/test_notebook.py
@@ -213,3 +213,127 @@ class TestSaveToDisk:
         artifact_dir = nb.save_to_disk(tmp_path, display_name="nb_test")
         assert artifact_dir == tmp_path / "nb_test.Notebook"
         assert artifact_dir.is_dir()
+
+
+class TestNotebookSettingsJson:
+    """Fabric requires ``notebook-settings.json`` with
+    ``{"includeResourcesInGit": "on"}`` to include the
+    ``Resources/`` subtree in git-sync. Without it, wheels under
+    ``Resources/builtin/`` are silently excluded from the
+    workspace item, so a `%pip install "builtin/..."` cell in
+    ``notebook-content.py`` fails at runtime.
+
+    ``save_to_disk`` and ``to_bundle`` must emit the file
+    unconditionally — a no-op when ``Resources/`` is empty, but
+    necessary the moment a project ships any wheel via
+    ``pip_install_from_resources``.
+    """
+
+    def test_save_to_disk_emits_notebook_settings_json(self, tmp_path):
+        nb = NotebookBuilder().pip_install_from_resources(
+            "my_project-0.1.0-py3-none-any.whl"
+        )
+        artifact_dir = nb.save_to_disk(tmp_path, display_name="nb_x")
+        settings_path = artifact_dir / "notebook-settings.json"
+        assert settings_path.is_file()
+        import json
+
+        body = json.loads(settings_path.read_text(encoding="utf-8"))
+        assert body == {"includeResourcesInGit": "on"}
+
+    def test_save_to_disk_emits_settings_even_without_resources(self, tmp_path):
+        """Always-on guarantees: a notebook that doesn't currently use
+        Resources/ but later grows one stays correct without rewriting
+        save_to_disk callers."""
+        nb = NotebookBuilder()
+        artifact_dir = nb.save_to_disk(tmp_path, display_name="nb_y")
+        assert (artifact_dir / "notebook-settings.json").is_file()
+
+    def test_notebook_settings_uses_lf_no_trailing_newline(self, tmp_path):
+        """notebook-settings.json follows the standard "JSON config"
+        convention: LF, no trailing newline (same as .platform)."""
+        nb = NotebookBuilder()
+        artifact_dir = nb.save_to_disk(tmp_path, display_name="nb_z")
+        raw = (artifact_dir / "notebook-settings.json").read_bytes()
+        assert b"\r\n" not in raw
+        assert not raw.endswith(b"\n")
+
+    def test_to_bundle_includes_notebook_settings_part(self):
+        nb = NotebookBuilder()
+        bundle = nb.to_bundle(display_name="nb_b")
+        assert "notebook-settings.json" in bundle.parts
+
+
+class TestAttachEnvironment:
+    """``attach_environment`` adds a Fabric environment dependency
+    to the notebook header METADATA block. The environment block
+    accompanies any ``lakehouse`` block under ``dependencies``.
+
+    Workspace ID convention: when the environment lives in the
+    same workspace as the notebook (the common case), Fabric uses
+    an all-zeros ``workspaceId`` instead of the actual workspace
+    GUID. ``ws_id=None`` selects this default.
+    """
+
+    _ZERO_WS = "00000000-0000-0000-0000-000000000000"
+
+    def test_default_ws_id_is_all_zeros(self):
+        nb = NotebookBuilder().attach_environment("env-logical-1")
+        src = nb.to_source_string()
+        assert '"environment"' in src
+        assert '"environmentId": "env-logical-1"' in src
+        assert f'"workspaceId": "{self._ZERO_WS}"' in src
+
+    def test_explicit_ws_id_is_emitted(self):
+        nb = NotebookBuilder().attach_environment(
+            "env-logical-2", ws_id="aaaaaaaa-1111-2222-3333-bbbbbbbbbbbb"
+        )
+        src = nb.to_source_string()
+        assert '"environmentId": "env-logical-2"' in src
+        assert '"workspaceId": "aaaaaaaa-1111-2222-3333-bbbbbbbbbbbb"' in src
+
+    def test_environment_block_lives_under_dependencies(self):
+        nb = NotebookBuilder().attach_environment("env-1")
+        src = nb.to_source_string()
+        # The environment block must be inside the dependencies object,
+        # not a sibling of kernel_info.
+        deps_idx = src.index('"dependencies"')
+        env_idx = src.index('"environment"')
+        kernel_idx = src.index('"kernel_info"')
+        assert kernel_idx < deps_idx < env_idx
+
+    def test_environment_alongside_lakehouse(self):
+        nb = (
+            NotebookBuilder()
+            .attach_lakehouse(
+                ws_id="ws-1",
+                lh_id="lh-1",
+                lh_name="lh_primary",
+                default=True,
+            )
+            .attach_environment("env-1")
+        )
+        src = nb.to_source_string()
+        assert '"lakehouse"' in src
+        assert '"environment"' in src
+        assert '"environmentId": "env-1"' in src
+
+    def test_chainable(self):
+        nb = NotebookBuilder()
+        result = nb.attach_environment("env-1")
+        assert result is nb
+
+    def test_second_call_replaces_first(self):
+        """Only one environment can be attached at a time. A second
+        call replaces the first rather than producing two
+        ``environment`` keys (which Fabric would silently reduce to
+        the last one anyway, so the explicit replace is more
+        honest)."""
+        nb = (
+            NotebookBuilder()
+            .attach_environment("env-old")
+            .attach_environment("env-new")
+        )
+        src = nb.to_source_string()
+        assert '"environmentId": "env-new"' in src
+        assert "env-old" not in src


### PR DESCRIPTION
Third of four PRs targeting **v0.1.0rc1**. NotebookBuilder fills two gaps that block the standard Fabric notebook + project-wheel pattern.

## Summary

- **#70** — \`save_to_disk\` and \`to_bundle\` now always emit \`notebook-settings.json\` with \`{\"includeResourcesInGit\": \"on\"}\`. Without it, Fabric does not include the \`Resources/\` subtree in git-sync, so wheels placed under \`Resources/builtin/\` silently disappear on the workspace side and the \`%pip install \"builtin/...\"\` cell fails at runtime. Emitting unconditionally is a no-op when \`Resources/\` is empty.
- **#73** — new \`attach_environment(env_id, *, ws_id=None)\` method. Adds an \`environment\` block under \`dependencies\` in the notebook header METADATA, sibling to \`lakehouse\`. Convention: when \`ws_id\` is None, the notebook and environment share a workspace and the emitted \`workspaceId\` is all-zeros — matching Fabric's portal round-trip output. Pass an explicit \`ws_id\` to reference an environment in another workspace. Only one environment per notebook; a second call replaces the first.

## File-byte conventions

\`notebook-settings.json\` falls under the default normalize rule (LF, no trailing newline) and is routed through \`write_artifact_file\` like everything else, so output is byte-identical across Linux / macOS / Windows.

## Verification

- \`pytest\`: 710 passed, 1 skipped (e2e env-gated). Existing fixture-based byte-equality tests for \`nb_minimal\` / \`nb_full\` continue to pass — the dependencies-block change is purely additive when no environment is attached.
- \`ruff check . && ruff format --check .\`: clean
- \`mypy --strict src/\`: clean

## Test plan

- [ ] Confirm the new \`TestNotebookSettingsJson\` and \`TestAttachEnvironment\` cover the documented contracts
- [ ] Spot-check a builder that combines \`attach_lakehouse\` + \`attach_environment\` round-trips through \`save_to_disk\` + \`load_workspace\` cleanly
- [ ] Verify \`to_bundle\` + \`pyfabric.items.bundle.save_to_disk\` produce the same files as \`NotebookBuilder.save_to_disk\` (the secondary route)

Closes #70, #73.