### PR TITLE
Add GitClient: workspace-to-git sync (pull direction)

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -43,6 +43,11 @@ Expand supported Fabric item types:
   pipeline or notebook
 - Wire up event-driven patterns for CI/CD and data pipeline automation
 - Integration with Power Automate flows
+- **Git Integration client** — typed wrappers for the Fabric workspace
+  ↔ git endpoints so post-commit "make Fabric match git" automation is
+  one Python call. Initial surface (`get_status`, `update_from_git`,
+  `sync_workspace`) covers the pull/CI direction; commit-to-git and
+  connection management to follow as use cases surface.
 
 ## Phase 4: LLM-Powered Data Analysis
 

--- a/src/pyfabric/client/__init__.py
+++ b/src/pyfabric/client/__init__.py
@@ -1,1 +1,5 @@
 """Fabric REST API client, authentication, and service clients."""
+
+from .git import GitClient, GitStatus, ItemChange
+
+__all__ = ["GitClient", "GitStatus", "ItemChange"]

--- a/src/pyfabric/client/git.py
+++ b/src/pyfabric/client/git.py
@@ -1,0 +1,266 @@
+"""
+Client for the Fabric Git Integration REST API.
+
+Wraps the workspace ↔ git repository sync endpoints with typed helpers.
+This module starts with the read + pull operations most useful for CI/CD
+automation:
+
+- :class:`GitClient.get_status` — what's different between workspace and remote
+- :class:`GitClient.update_from_git` — apply remote commits to the workspace (LRO)
+- :class:`GitClient.sync_workspace` — convenience: get_status then update if behind
+
+The Long-Running Operation (LRO) polling for 202 responses is handled by
+the underlying :class:`pyfabric.client.http.FabricClient`. Callers don't
+need to poll explicitly.
+
+Usage::
+
+    from pyfabric.client.auth import FabricCredential
+    from pyfabric.client.git import GitClient
+
+    git = GitClient(FabricCredential("contoso"))
+
+    # One-shot sync: pull remote into workspace if behind.
+    status = git.sync_workspace("00000000-0000-0000-0000-000000000000")
+    if status.is_synced:
+        print(f"In sync at {status.workspace_head[:8]}")
+    else:
+        print(f"Still {len(status.changes)} change(s) pending")
+
+API docs:
+    https://learn.microsoft.com/en-us/rest/api/fabric/core/git
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Literal
+
+import structlog
+
+from .auth import FabricCredential
+from .http import FabricClient
+
+log = structlog.get_logger()
+
+
+# ── Types ───────────────────────────────────────────────────────────────────
+
+ChangeType = Literal["Added", "Modified", "Deleted"]
+ConflictType = Literal["None", "Conflict", "SameChanges"]
+ConflictPolicy = Literal["PreferRemote", "PreferWorkspace"]
+
+
+@dataclass(frozen=True)
+class ItemChange:
+    """A single item that differs between workspace and remote git."""
+
+    item_type: str
+    """Fabric item type, e.g. ``"Notebook"``, ``"Lakehouse"``, ``"Report"``."""
+
+    display_name: str
+    """Human-readable item name. Falls back to the remote name when the
+    workspace doesn't have the item yet."""
+
+    workspace_change: ChangeType | None
+    """How the item changed on the workspace side, or ``None`` if it didn't."""
+
+    remote_change: ChangeType | None
+    """How the item changed on the remote side, or ``None`` if it didn't."""
+
+    conflict_type: ConflictType
+    """``"None"`` for one-sided changes, ``"Conflict"`` when both sides
+    changed differently, ``"SameChanges"`` when both sides made the
+    identical change."""
+
+    @classmethod
+    def _from_api(cls, payload: dict[str, Any]) -> ItemChange:
+        meta = payload.get("itemMetadata") or {}
+        return cls(
+            item_type=meta.get("itemType", ""),
+            display_name=meta.get("displayName", ""),
+            workspace_change=payload.get("workspaceChange"),
+            remote_change=payload.get("remoteChange"),
+            conflict_type=payload.get("conflictType", "None"),
+        )
+
+
+@dataclass(frozen=True)
+class GitStatus:
+    """Snapshot of the workspace ↔ remote git relationship."""
+
+    workspace_head: str
+    """The commit SHA the workspace is currently synced to."""
+
+    remote_commit_hash: str
+    """The latest commit SHA on the connected remote branch."""
+
+    changes: tuple[ItemChange, ...]
+    """Items that differ between workspace and remote since
+    ``workspace_head``."""
+
+    @property
+    def is_synced(self) -> bool:
+        """True when the workspace matches remote and no items differ."""
+        return self.workspace_head == self.remote_commit_hash and not self.changes
+
+    @property
+    def is_behind(self) -> bool:
+        """True when the remote has commits the workspace hasn't pulled.
+
+        This is the condition :meth:`GitClient.update_from_git` resolves."""
+        return self.workspace_head != self.remote_commit_hash
+
+    @classmethod
+    def _from_api(cls, payload: dict[str, Any]) -> GitStatus:
+        return cls(
+            workspace_head=payload.get("workspaceHead", ""),
+            remote_commit_hash=payload.get("remoteCommitHash", ""),
+            changes=tuple(ItemChange._from_api(c) for c in payload.get("changes", [])),
+        )
+
+
+# ── Client ──────────────────────────────────────────────────────────────────
+
+
+class GitClient:
+    """Typed wrapper for the Fabric workspace ↔ git endpoints.
+
+    Each method maps to one REST endpoint plus its LRO polling (handled
+    by the underlying :class:`FabricClient`).
+    """
+
+    def __init__(
+        self,
+        credential: FabricCredential | str | None = None,
+        *,
+        client: FabricClient | None = None,
+    ):
+        """Build a GitClient.
+
+        Args:
+            credential: Authentication. Either a :class:`FabricCredential`,
+                a raw bearer token string, or ``None`` to use the default
+                credential chain. Ignored when ``client`` is provided.
+            client: Pre-built :class:`FabricClient` to reuse. Useful in
+                tests and when sharing a session across multiple clients.
+        """
+        self._client = client if client is not None else FabricClient(credential)
+
+    def get_status(self, workspace_id: str) -> GitStatus:
+        """Return the current sync state of a workspace.
+
+        Args:
+            workspace_id: The workspace's GUID.
+
+        Returns:
+            A :class:`GitStatus` describing pending changes.
+
+        Raises:
+            FabricError: When the API returns 4xx/5xx. Common error codes:
+                ``WorkspaceNotConnectedToGit``, ``WorkspaceHasNoCapacityAssigned``,
+                ``InsufficientPrivileges``.
+        """
+        payload = self._client.get(f"workspaces/{workspace_id}/git/status")
+        return GitStatus._from_api(payload)
+
+    def update_from_git(
+        self,
+        workspace_id: str,
+        *,
+        remote_commit_hash: str,
+        workspace_head: str,
+        conflict_policy: ConflictPolicy = "PreferRemote",
+        allow_override_items: bool = True,
+    ) -> dict[str, Any]:
+        """Apply remote commits to the workspace.
+
+        This is a Long-Running Operation. The underlying client polls
+        until completion before returning.
+
+        Args:
+            workspace_id: The workspace's GUID.
+            remote_commit_hash: The remote SHA to advance the workspace
+                to. Get this from a fresh :meth:`get_status` call.
+            workspace_head: The SHA the workspace is currently at. The
+                server validates this matches its view to detect races.
+            conflict_policy: How to resolve items modified on both sides.
+                ``"PreferRemote"`` is the typical CI choice; pull always
+                wins. ``"PreferWorkspace"`` keeps workspace edits.
+            allow_override_items: When ``True`` (default), the update
+                proceeds even if remote items would replace workspace
+                items. When ``False`` and incoming items are present,
+                the operation refuses to start.
+
+        Returns:
+            The terminal operation result body, or ``{}`` for sync 200.
+
+        Raises:
+            FabricError: On API errors. Common codes:
+                ``WorkspaceHeadMismatch`` (someone else synced first;
+                re-read status and retry), ``WorkspacePreviousOperationInProgress``
+                (an earlier sync is still running), ``MissingDependency``,
+                ``InsufficientPrivileges``.
+        """
+        body: dict[str, Any] = {
+            "remoteCommitHash": remote_commit_hash,
+            "workspaceHead": workspace_head,
+            "conflictResolution": {
+                "conflictResolutionType": "Workspace",
+                "conflictResolutionPolicy": conflict_policy,
+            },
+            "options": {"allowOverrideItems": allow_override_items},
+        }
+        log.info(
+            "git.update_from_git",
+            workspace_id=workspace_id,
+            target=remote_commit_hash[:8],
+            from_=workspace_head[:8],
+            policy=conflict_policy,
+        )
+        return self._client.post(
+            f"workspaces/{workspace_id}/git/updateFromGit", body=body
+        )
+
+    def sync_workspace(
+        self,
+        workspace_id: str,
+        *,
+        conflict_policy: ConflictPolicy = "PreferRemote",
+        allow_override_items: bool = True,
+    ) -> GitStatus:
+        """Pull remote into workspace if behind. No-op if already in sync.
+
+        Wraps :meth:`get_status` and :meth:`update_from_git` for the common
+        "make Fabric match the latest git commit" flow.
+
+        Args:
+            workspace_id: The workspace's GUID.
+            conflict_policy: Forwarded to :meth:`update_from_git`.
+            allow_override_items: Forwarded to :meth:`update_from_git`.
+
+        Returns:
+            The :class:`GitStatus` observed after the sync (or the original
+            status when no sync was needed). When successful, the returned
+            ``workspace_head`` equals the ``remote_commit_hash`` that was
+            current when this call started.
+        """
+        status = self.get_status(workspace_id)
+        if not status.is_behind:
+            log.info(
+                "git.sync_workspace.in_sync",
+                workspace_id=workspace_id,
+                head=status.workspace_head[:8],
+            )
+            return status
+
+        self.update_from_git(
+            workspace_id,
+            remote_commit_hash=status.remote_commit_hash,
+            workspace_head=status.workspace_head,
+            conflict_policy=conflict_policy,
+            allow_override_items=allow_override_items,
+        )
+        # Re-read status so the caller gets the post-update snapshot
+        # (incl. any items the API flagged after the merge).
+        return self.get_status(workspace_id)

--- a/tests/client/test_git.py
+++ b/tests/client/test_git.py
@@ -1,0 +1,280 @@
+"""Tests for GitClient (workspace ↔ git sync)."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from pyfabric.client.git import (
+    GitClient,
+    GitStatus,
+    ItemChange,
+)
+
+# ── ItemChange._from_api / GitStatus._from_api ─────────────────────────────
+
+
+class TestItemChangeFromApi:
+    def test_remote_only_change(self):
+        payload = {
+            "itemMetadata": {"itemType": "Notebook", "displayName": "nb_extract"},
+            "remoteChange": "Modified",
+            "conflictType": "None",
+        }
+        ch = ItemChange._from_api(payload)
+        assert ch.item_type == "Notebook"
+        assert ch.display_name == "nb_extract"
+        assert ch.remote_change == "Modified"
+        assert ch.workspace_change is None
+        assert ch.conflict_type == "None"
+
+    def test_workspace_only_change(self):
+        payload = {
+            "itemMetadata": {"itemType": "Report", "displayName": "rpt_status"},
+            "workspaceChange": "Added",
+            "conflictType": "None",
+        }
+        ch = ItemChange._from_api(payload)
+        assert ch.workspace_change == "Added"
+        assert ch.remote_change is None
+
+    def test_two_sided_conflict(self):
+        payload = {
+            "itemMetadata": {"itemType": "SemanticModel", "displayName": "sm_kpi"},
+            "workspaceChange": "Modified",
+            "remoteChange": "Modified",
+            "conflictType": "Conflict",
+        }
+        ch = ItemChange._from_api(payload)
+        assert ch.conflict_type == "Conflict"
+        assert ch.workspace_change == "Modified"
+        assert ch.remote_change == "Modified"
+
+    def test_missing_metadata_defaults_empty(self):
+        ch = ItemChange._from_api({})
+        assert ch.item_type == ""
+        assert ch.display_name == ""
+        assert ch.conflict_type == "None"
+
+
+class TestGitStatusFromApi:
+    def test_in_sync_payload(self):
+        payload = {
+            "workspaceHead": "abc123",
+            "remoteCommitHash": "abc123",
+            "changes": [],
+        }
+        status = GitStatus._from_api(payload)
+        assert status.is_synced
+        assert not status.is_behind
+        assert status.changes == ()
+
+    def test_behind_payload(self):
+        payload = {
+            "workspaceHead": "abc123",
+            "remoteCommitHash": "def456",
+            "changes": [
+                {
+                    "itemMetadata": {"itemType": "Notebook", "displayName": "n"},
+                    "remoteChange": "Modified",
+                    "conflictType": "None",
+                }
+            ],
+        }
+        status = GitStatus._from_api(payload)
+        assert status.is_behind
+        assert not status.is_synced
+        assert len(status.changes) == 1
+        assert status.changes[0].item_type == "Notebook"
+
+    def test_same_hash_but_workspace_dirty_not_synced(self):
+        # Edge case: hashes match but workspace has unpushed local edits.
+        # The Fabric API surfaces this as workspaceChange entries with
+        # matching hashes. is_synced should be False so callers don't
+        # assume "nothing to do."
+        payload = {
+            "workspaceHead": "abc123",
+            "remoteCommitHash": "abc123",
+            "changes": [
+                {
+                    "itemMetadata": {"itemType": "Report", "displayName": "r"},
+                    "workspaceChange": "Modified",
+                    "conflictType": "None",
+                }
+            ],
+        }
+        status = GitStatus._from_api(payload)
+        assert not status.is_synced
+        assert not status.is_behind  # head matches; workspace just dirty
+
+
+# ── GitClient ──────────────────────────────────────────────────────────────
+
+
+def _make_client(get_return=None, post_return=None):
+    """Build a GitClient wrapping a MagicMock FabricClient."""
+    fabric = MagicMock()
+    if get_return is not None:
+        fabric.get.return_value = get_return
+    if post_return is not None:
+        fabric.post.return_value = post_return
+    return GitClient(client=fabric), fabric
+
+
+class TestGitClientGetStatus:
+    def test_calls_correct_path(self):
+        client, fabric = _make_client(
+            get_return={
+                "workspaceHead": "a" * 40,
+                "remoteCommitHash": "a" * 40,
+                "changes": [],
+            }
+        )
+        client.get_status("ws-1")
+        fabric.get.assert_called_once_with("workspaces/ws-1/git/status")
+
+    def test_returns_typed_status(self):
+        client, _ = _make_client(
+            get_return={
+                "workspaceHead": "old",
+                "remoteCommitHash": "new",
+                "changes": [
+                    {
+                        "itemMetadata": {
+                            "itemType": "Notebook",
+                            "displayName": "nb_x",
+                        },
+                        "remoteChange": "Added",
+                        "conflictType": "None",
+                    }
+                ],
+            }
+        )
+        status = client.get_status("ws-1")
+        assert isinstance(status, GitStatus)
+        assert status.is_behind
+        assert status.changes[0].display_name == "nb_x"
+
+
+class TestGitClientUpdateFromGit:
+    def test_request_body_shape(self):
+        client, fabric = _make_client(post_return={})
+        client.update_from_git(
+            "ws-1",
+            remote_commit_hash="new",
+            workspace_head="old",
+        )
+        path, kwargs = fabric.post.call_args
+        # FabricClient.post(path, body=...)
+        assert path[0] == "workspaces/ws-1/git/updateFromGit"
+        body = kwargs["body"]
+        assert body["remoteCommitHash"] == "new"
+        assert body["workspaceHead"] == "old"
+        assert body["conflictResolution"]["conflictResolutionPolicy"] == "PreferRemote"
+        assert body["conflictResolution"]["conflictResolutionType"] == "Workspace"
+        assert body["options"]["allowOverrideItems"] is True
+
+    def test_overrides_propagate(self):
+        client, fabric = _make_client(post_return={})
+        client.update_from_git(
+            "ws-1",
+            remote_commit_hash="new",
+            workspace_head="old",
+            conflict_policy="PreferWorkspace",
+            allow_override_items=False,
+        )
+        body = fabric.post.call_args.kwargs["body"]
+        assert (
+            body["conflictResolution"]["conflictResolutionPolicy"] == "PreferWorkspace"
+        )
+        assert body["options"]["allowOverrideItems"] is False
+
+
+class TestGitClientSyncWorkspace:
+    def test_noop_when_in_sync(self):
+        client, fabric = _make_client(
+            get_return={
+                "workspaceHead": "abc",
+                "remoteCommitHash": "abc",
+                "changes": [],
+            }
+        )
+        status = client.sync_workspace("ws-1")
+        # Only one get_status call; no update_from_git invocation.
+        assert fabric.get.call_count == 1
+        fabric.post.assert_not_called()
+        assert status.is_synced
+
+    def test_pulls_when_behind(self):
+        # First get_status returns 'behind', then update_from_git, then
+        # second get_status returns 'in sync'.
+        behind = {
+            "workspaceHead": "old",
+            "remoteCommitHash": "new",
+            "changes": [
+                {
+                    "itemMetadata": {"itemType": "Notebook", "displayName": "n"},
+                    "remoteChange": "Modified",
+                    "conflictType": "None",
+                }
+            ],
+        }
+        in_sync = {"workspaceHead": "new", "remoteCommitHash": "new", "changes": []}
+        fabric = MagicMock()
+        fabric.get.side_effect = [behind, in_sync]
+        fabric.post.return_value = {}
+        client = GitClient(client=fabric)
+
+        status = client.sync_workspace("ws-1")
+        assert fabric.get.call_count == 2
+        # update_from_git was called with the hashes from the first status read
+        body = fabric.post.call_args.kwargs["body"]
+        assert body["remoteCommitHash"] == "new"
+        assert body["workspaceHead"] == "old"
+        assert status.is_synced
+
+    def test_sync_propagates_conflict_policy(self):
+        behind = {
+            "workspaceHead": "old",
+            "remoteCommitHash": "new",
+            "changes": [],
+        }
+        in_sync = {"workspaceHead": "new", "remoteCommitHash": "new", "changes": []}
+        fabric = MagicMock()
+        fabric.get.side_effect = [behind, in_sync]
+        fabric.post.return_value = {}
+        client = GitClient(client=fabric)
+
+        client.sync_workspace("ws-1", conflict_policy="PreferWorkspace")
+        body = fabric.post.call_args.kwargs["body"]
+        assert (
+            body["conflictResolution"]["conflictResolutionPolicy"] == "PreferWorkspace"
+        )
+
+
+# ── Constructor ────────────────────────────────────────────────────────────
+
+
+class TestGitClientConstructor:
+    def test_reuses_supplied_client(self):
+        fabric = MagicMock()
+        client = GitClient(client=fabric)
+        assert client._client is fabric
+
+    def test_builds_fabric_client_when_none(self, monkeypatch):
+        sentinel = MagicMock()
+        called: dict[str, object] = {}
+
+        def fake_ctor(credential):
+            called["credential"] = credential
+            return sentinel
+
+        monkeypatch.setattr("pyfabric.client.git.FabricClient", fake_ctor)
+        client = GitClient("static-token")
+        assert client._client is sentinel
+        assert called["credential"] == "static-token"
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Summary

Adds `pyfabric.client.git` with two REST wrappers and one convenience
method covering the read + pull half of the Fabric Git Integration API:

- `GitClient.get_status(workspace_id)` — `GET /workspaces/{id}/git/status` returning a typed `GitStatus(workspace_head, remote_commit_hash, changes)` with `is_synced` / `is_behind` helpers
- `GitClient.update_from_git(workspace_id, *, remote_commit_hash, workspace_head, conflict_policy="PreferRemote", allow_override_items=True)` — `POST /workspaces/{id}/git/updateFromGit`, LRO handled by `FabricClient._submit_and_poll`
- `GitClient.sync_workspace(workspace_id, *, conflict_policy="PreferRemote")` — read status, pull if behind, return post-sync status; no-op when already in sync

Dataclasses: `GitStatus` and `ItemChange` exposed at `pyfabric.client.git`.

## Scope choice

Read + pull only. `commit_to_git`, `connect`, `disconnect`,
`initialize_connection`, and credential management are deliberately
deferred to follow-up PRs. The CI/CD "make Fabric match what just
landed in git" flow is the most common ask and it's a clean slice
to ship first.

## Tests

16 new unit tests, all mocked (no network). Covers:
- `ItemChange` / `GitStatus` parsing from API payloads
- `is_synced` / `is_behind` semantics (including same-hash-but-dirty)
- `get_status` URL and return type
- `update_from_git` request body shape + override propagation
- `sync_workspace` no-op vs. pull paths + conflict policy plumbing
- Constructor: supplied client vs. default `FabricClient`

Total suite: 762 passed, 1 skipped (pre-existing network-gated test).

## Roadmap

Listed under Phase 3 (Event-Driven Automation).

## Test plan

- [ ] CI lint + format + mypy + tests + dependency-review pass
- [ ] Verify against a real Fabric workspace: get_status returns sane shape, sync_workspace is a no-op when remote == workspace, sync_workspace pulls when remote is ahead

🤖 Generated with [Claude Code](https://claude.com/claude-code)