### PR TITLE
Fix NotebookBuilder blank-line bytes for Fabric round-trip

### DIFF
--- a/src/pyfabric/items/notebook.py
+++ b/src/pyfabric/items/notebook.py
@@ -333,9 +333,13 @@ class NotebookBuilder:
     @staticmethod
     def _render_markdown_cell(content: str) -> str:
         lines = content.split("\n")
-        # Blank lines render as bare ``#`` (no trailing space) — matches
-        # Fabric's round-tripped output.
-        prefixed = ["#" if line == "" else f"# {line}" for line in lines]
+        # Blank lines must be rendered as ``# `` (hash + trailing space).
+        # Fabric's git-sync strips bare-``#`` lines on portal save, which
+        # round-trips the file and pollutes git history. The trailing
+        # space survives both Fabric's parser and downstream
+        # trailing-newline / line-ending byte normalizers (which leave
+        # internal whitespace alone).
+        prefixed = ["# " if line == "" else f"# {line}" for line in lines]
         return "# MARKDOWN ********************\n\n" + "\n".join(prefixed) + "\n"
 
     def _render_code_cell(self, code: str, language: CellLanguage) -> str:

--- a/tests/items/test_notebook.py
+++ b/tests/items/test_notebook.py
@@ -93,11 +93,15 @@ class TestMarkdownCell:
         src = nb.to_source_string()
         assert "# MARKDOWN ********************\n\n# Line 1\n# Line 2\n" in src
 
-    def test_blank_line_is_rendered_as_hash_only(self):
+    def test_blank_line_emits_hash_space(self):
         nb = NotebookBuilder().add_markdown("Para one\n\nPara two")
         src = nb.to_source_string()
-        # Fabric emits "# " with trailing space stripped — rendered as "#".
-        assert "# Para one\n#\n# Para two" in src
+        # Blank lines must be "# " (hash + trailing space), not bare "#".
+        # Fabric's git-sync silently strips bare-"#" lines on portal save,
+        # producing spurious "fix" round-trips. The trailing-space form
+        # survives both Fabric's parser and trailing-newline byte
+        # normalizers downstream.
+        assert "# Para one\n# \n# Para two" in src
 
 
 class TestPythonCell:


### PR DESCRIPTION
## Summary

`NotebookBuilder._render_markdown_cell` emitted bare `#` for blank input lines inside markdown cells. Empirically, the Fabric portal's git-sync silently strips every bare-`#` line on save and round-trips the file — producing spurious "ui fixes" commits that collapse all paragraphs into one continuous block. Confirmed reproducible by observing such a round-trip commit on a downstream repo.

This PR changes the blank-line bytes to `# ` (hash + trailing space). That form:

- survives the Fabric portal save (verified on the same downstream repo by replacing the bare-`#` lines with `# ` lines and observing no further auto-edits),
- survives downstream trailing-newline / line-ending byte normalizers, which leave internal whitespace alone,
- matches the convention already used by round-trip-clean notebooks in the wild.

The test pinning the old (buggy) behavior is renamed from `test_blank_line_is_rendered_as_hash_only` to `test_blank_line_emits_hash_space` and updated to assert the new bytes. The previous comment claiming "Fabric emits '# ' with trailing space stripped" was based on a misread of Fabric's behavior — Fabric strips the whole line, not just the trailing space.

## Test plan
- [x] `pytest tests/items/test_notebook.py` — 30/30 pass
- [x] Full suite — `pytest -q` 762 passed, 1 skipped (unrelated workspace gate)
- [x] `ruff check` clean on touched files
- [x] `ruff format --check` clean on touched files
- [x] `mypy src/` clean
- [x] Pre-commit hooks all pass on push (ruff / ruff-format / mypy / codespell / pytest)