### PR TITLE
chore: pre-commit codespell + markdownlint scan full repo (match CI)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,11 +25,29 @@ repos:
       - id: codespell
         additional_dependencies: [tomli]
         args: [--config=.codespellrc]
+        # Full-repo scan to match CI behavior — CI runs
+        # `codespell --config=.codespellrc` with no positional args, which
+        # codespell defaults to scanning the cwd recursively. Pre-commit's
+        # default is to pass only staged files, which would miss
+        # pre-existing typos in unchanged files and surface them in CI
+        # against unrelated PRs.
+        pass_filenames: false
+        always_run: true
 
   - repo: https://github.com/DavidAnson/markdownlint-cli2
     rev: v0.14.0
     hooks:
       - id: markdownlint-cli2
+        # Full-repo scan to match CI behavior — CI runs
+        # markdownlint-cli2-action which reads .markdownlint-cli2.jsonc's
+        # `globs: ["**/*.md"]` and scans every markdown file in the repo.
+        # Without these settings, pre-commit passes only staged files; the
+        # hook reports `(no files to check) Skipped` when a commit has no
+        # .md changes, missing pre-existing violations in unchanged docs
+        # that the CI job then flags against unrelated PRs. Match the
+        # CI's behavior so violations are caught at commit time.
+        pass_filenames: false
+        always_run: true
 
   - repo: local
     hooks:


### PR DESCRIPTION
Follow-up to #87, captured in [this PR comment](https://github.com/Creative-Planning/pyfabric/pull/87#issuecomment-4474500739).

## What

Sets `pass_filenames: false` + `always_run: true` on the **codespell** and **markdownlint-cli2** hooks in `.pre-commit-config.yaml` so both run a full-repo scan on every commit, matching how CI invokes them.

## Why

The pre-commit framework's default behavior is to pass only **staged files** to each hook. For lint tools that have their own globs in config (`.codespellrc`, `.markdownlint-cli2.jsonc`), this creates a scope asymmetry between local and CI:

| Where | Invocation | Files checked |
| --- | --- | --- |
| Local pre-commit | `markdownlint-cli2 <staged-only>` | Only files in the current commit |
| CI (`DavidAnson/markdownlint-cli2-action`) | `markdownlint-cli2` reads its config directly | Every file matching the config's `globs` |

Concrete impact landed on **#87**: a Python-only commit shipped to CI where the docs-lint action surfaced **130 pre-existing MD060/table-column-style violations** across `CONTRIBUTING.md`, `README.md`, `docs/api.md`, `docs/roadmap.md`, `docs/testing.md`, and `src/pyfabric/claude_memory/open_mirror_landing_zone.md`. The local pre-commit hook reported `(no files to check) Skipped` on the same commit because no `.md` files were staged. **The violations existed in unchanged docs; the local lint never looked at them.**

Same gap applies to `codespell` — CI runs it standalone (`codespell --config=.codespellrc`, which recursively scans cwd); pre-commit currently passes only staged files.

## The change

Two hooks updated identically. Comments inline explain the rationale so future readers see *why* the deviation from pre-commit's default exists:

```yaml
- id: codespell
  ...
  pass_filenames: false
  always_run: true

- id: markdownlint-cli2
  pass_filenames: false
  always_run: true
```

Tools continue to read their own configs (`.codespellrc`, `.markdownlint-cli2.jsonc`) for globs and ignores. Behavior is now identical between local pre-commit and CI.

mypy and pytest hooks already have this pattern; ruff doesn't need it because its scope is naturally just-staged-files (it auto-fixes touched files).

## Cost

~5–10 s of additional per-commit latency for the two tool invocations, even on commits that touch only Python files. Acceptable for the correctness benefit of catching pre-existing violations at commit time instead of CI time.

## Verification

Locally injected a deliberate MD012 violation into `README.md` while staging only `.pre-commit-config.yaml`. With the fix:

```
markdownlint-cli2........................................................Failed
Finding: **/*.md !.venv/** !build/** !dist/** !*.egg-info/** !node_modules/** !.git/**
Linting: 18 file(s)
Summary: 1 error(s)
README.md:195 MD012/no-multiple-blanks ...
```

The hook now scans every markdown file regardless of staging, and reports the unrelated-file violation as expected. Without the fix the hook would have reported `(no files to check) Skipped`.