### PR TITLE
fix: route ArtifactBundle.save_to_disk through write_artifact_file (#91)

### DIFF
--- a/docs/execution-plan.md
+++ b/docs/execution-plan.md
@@ -27,15 +27,21 @@ explicit dependency chain. Update as issues land or new ones are filed.
 
 Land first. Each is small surface, high return.
 
-| Issue | Symptom | Fix shape |
-| ----- | ------- | --------- |
-| [#66](https://github.com/Creative-Planning/pyfabric/issues/66) | `run_notebook._poll_lro` loops forever because the Jobs API returns `Completed` not `Succeeded` | Treat both as terminal-success in the polling state machine; add a regression test against a mocked Jobs response. |
-| [#67](https://github.com/Creative-Planning/pyfabric/issues/67) | `write_rows(expected_schema=...)` always fails on auto-stamped tables — schema check runs after `__rowMarker__` is appended | Move the schema check to before the marker append, or include the marker column in the expected schema when present. |
-| [#69](https://github.com/Creative-Planning/pyfabric/issues/69) | `LocalLakehouse.evolve_schema` requires `TableDef.column(name)` — duck-type clients can't use it | Replace `TableDef`-specific method calls with attribute/dict access that any matching shape can satisfy. |
-| [#64](https://github.com/Creative-Planning/pyfabric/issues/64) | `decode_part` API pairing with `encode_part` is confusing; wrong input raises an unhelpful `TypeError` | Clearer signature, type-check at the boundary, error message that names both the expected shape and the received one. |
-| [#91](https://github.com/Creative-Planning/pyfabric/issues/91) | `ArtifactBundle.save_to_disk()` and the writers in `src/pyfabric/items/bundle.py` still call `Path.write_text` / `Path.write_bytes` directly instead of `write_artifact_file`. Notebook, SemanticModel, Report, and Environment builders all migrated; bundle.py is the last bypass and represents a re-introduction risk for the byte-flap class of bug normalization was built to prevent. | Migrate every direct write in `bundle.py` (lines 102, 111, 113) to `pyfabric.items.normalize.write_artifact_file`. Add a unit test that loads a bundle, saves it, and asserts every emitted file passes `is_canonical`. |
+**Status:** four of the five Phase A items (#64, #66, #67, #69) were
+already resolved by PR #76 ("small fixes", merged 2026-04-28) and just
+hadn't been auto-closed. Verified on `main` at PR-92 merge: targeted
+test subset is 66 passed in 3.42s; the four issues are closing with
+references back to PR #76. Only #91 remains.
 
-Done-when: all five close, CI green, no new bypasses of `write_artifact_file` in `src/`.
+| Issue | Status | Symptom | Fix shape |
+| ----- | ------ | ------- | --------- |
+| [#91](https://github.com/Creative-Planning/pyfabric/issues/91) | **Open** | `ArtifactBundle.save_to_disk()` and the writers in `src/pyfabric/items/bundle.py` still call `Path.write_text` / `Path.write_bytes` directly instead of `write_artifact_file`. Notebook, SemanticModel, Report, and Environment builders all migrated; bundle.py is the last bypass and represents a re-introduction risk for the byte-flap class of bug normalization was built to prevent. | Migrate every direct write in `bundle.py` (lines 102, 111, 113) to `pyfabric.items.normalize.write_artifact_file`. Add a unit test that loads a bundle, saves it, and asserts every emitted file passes `is_canonical`. |
+| [#66](https://github.com/Creative-Planning/pyfabric/issues/66) | **Done** (PR #76) | `run_notebook._poll_lro` looped forever because the Jobs API returns `Completed` not `Succeeded` | `src/pyfabric/client/http.py:160` accepts both terminal states. |
+| [#67](https://github.com/Creative-Planning/pyfabric/issues/67) | **Done** (PR #76) | `write_rows(expected_schema=...)` failed on auto-stamped tables — schema check ran after `__rowMarker__` was appended | `src/pyfabric/data/open_mirror.py:479` runs `assert_schema_compat` pre-stamp. |
+| [#69](https://github.com/Creative-Planning/pyfabric/issues/69) | **Done** (PR #76) | `LocalLakehouse.evolve_schema` required `TableDef.column(name)` method access | Implementation iterates `table.columns` and uses `.name` attribute access. |
+| [#64](https://github.com/Creative-Planning/pyfabric/issues/64) | **Done** (PR #76) | `decode_part` API pairing with `encode_part` was confusing; wrong input raised unhelpful `TypeError` | `src/pyfabric/items/crud.py:210` guards with a clear error message naming the right call shape. |
+
+Done-when: #91 closes, CI green, no new bypasses of `write_artifact_file` in `src/`.
 
 ## Phase B — Notebook + Environment authoring
 

--- a/src/pyfabric/items/bundle.py
+++ b/src/pyfabric/items/bundle.py
@@ -35,6 +35,7 @@ from typing import Any
 import structlog
 
 from pyfabric.items.crud import encode_part
+from pyfabric.items.normalize import write_artifact_file
 
 log = structlog.get_logger()
 
@@ -97,20 +98,16 @@ def save_to_disk(bundle: ArtifactBundle, output_dir: str | Path) -> Path:
     artifact_dir = output_dir / bundle.dir_name
     artifact_dir.mkdir(parents=True, exist_ok=True)
 
-    # Write .platform
+    # Every write routes through write_artifact_file so the emitted bytes
+    # match Fabric's canonical form (LF, no BOM, per-file-type trailing
+    # newline). Binary parts fall through canonical_bytes unchanged.
     platform_path = artifact_dir / ".platform"
-    platform_path.write_text(bundle.platform_json(), encoding="utf-8")
+    write_artifact_file(platform_path, bundle.platform_json())
     log.debug("Wrote %s", platform_path)
 
-    # Write definition parts
     for rel_path, content in bundle.parts.items():
         part_path = artifact_dir / rel_path
-        part_path.parent.mkdir(parents=True, exist_ok=True)
-
-        if isinstance(content, bytes):
-            part_path.write_bytes(content)
-        else:
-            part_path.write_text(content, encoding="utf-8")
+        write_artifact_file(part_path, content)
         log.debug("Wrote %s", part_path)
 
     log.info("Saved artifact: %s", artifact_dir)

--- a/tests/items/test_bundle.py
+++ b/tests/items/test_bundle.py
@@ -1,0 +1,64 @@
+"""Tests for :func:`pyfabric.items.bundle.save_to_disk` byte canonicalization."""
+
+from __future__ import annotations
+
+from pyfabric.items.bundle import ArtifactBundle, save_to_disk
+from pyfabric.items.normalize import is_canonical
+
+
+class TestSaveToDiskCanonicalBytes:
+    def test_every_emitted_file_passes_is_canonical(self, tmp_path):
+        bundle = ArtifactBundle(
+            item_type="Notebook",
+            display_name="NB_Test",
+            parts={
+                "notebook-content.py": "# cell 1\nprint('hi')\n",
+                "definition/tables/dim_test.tmdl": (
+                    "table dim_test\n\tcolumn id\n\t\tdataType: int64"
+                ),
+                "Resources/builtin/sample.whl": b"\xff\xfe\x00\x01binary\x80\x81",
+            },
+        )
+        artifact_dir = save_to_disk(bundle, tmp_path)
+
+        for emitted in artifact_dir.rglob("*"):
+            if emitted.is_file():
+                assert is_canonical(emitted), (
+                    f"non-canonical: {emitted.relative_to(tmp_path)}"
+                )
+
+    def test_crlf_input_becomes_lf_on_disk(self, tmp_path):
+        bundle = ArtifactBundle(
+            item_type="Notebook",
+            display_name="NB_Crlf",
+            parts={
+                "notebook-content.py": "# line one\r\n# line two\r\nprint('hi')\r\n",
+            },
+        )
+        artifact_dir = save_to_disk(bundle, tmp_path)
+        raw = (artifact_dir / "notebook-content.py").read_bytes()
+        assert b"\r\n" not in raw
+        # notebook-content.py's rule is LF + trailing newline
+        assert raw.endswith(b"\n")
+
+    def test_binary_part_preserves_bytes(self, tmp_path):
+        # bytes(range(256)) contains 0xC0/0xC1 and 0xF5-0xFF — invalid UTF-8
+        # lead bytes — so canonical_bytes triggers its passthrough branch.
+        payload = b"\x89PNG\r\n\x1a\n" + bytes(range(256))
+        bundle = ArtifactBundle(
+            item_type="Notebook",
+            display_name="NB_Binary",
+            parts={"Resources/builtin/sample.png": payload},
+        )
+        artifact_dir = save_to_disk(bundle, tmp_path)
+        on_disk = (artifact_dir / "Resources" / "builtin" / "sample.png").read_bytes()
+        assert on_disk == payload
+
+    def test_platform_file_is_canonical(self, tmp_path):
+        bundle = ArtifactBundle(
+            item_type="Notebook",
+            display_name="NB_Platform",
+            parts={"notebook-content.py": "print('hi')\n"},
+        )
+        artifact_dir = save_to_disk(bundle, tmp_path)
+        assert is_canonical(artifact_dir / ".platform")


### PR DESCRIPTION
## Summary

- Routes the three `Path.write_text` / `Path.write_bytes` call sites in `src/pyfabric/items/bundle.py` through `pyfabric.items.normalize.write_artifact_file`, so `ArtifactBundle.save_to_disk()` emits bytes in Fabric's canonical form (LF, no BOM, per-file-type trailing newline).
- Adds `tests/items/test_bundle.py` — four cases covering `is_canonical` across mixed content, CRLF→LF on disk, binary-passthrough, and `.platform` canonicalization.
- Updates `docs/execution-plan.md` Phase A table to reflect that PR #76 (merged 2026-04-28) already retired four of the five Phase A items (#64, #66, #67, #69); only #91 was real new work. Verified on `main` with a targeted test subset (`tests/items/test_crud.py`, `tests/client/test_http.py`, `tests/data/test_local_lakehouse_schema_drift.py`, `tests/data/test_open_mirror_write_rows.py`) — 66 passed in 3.42s.
- Closes #91. Stale #64, #66, #67, #69 are being closed separately with references to PR #76.

## Test plan

- [x] `pytest tests/items/test_bundle.py -v` — 4 passed
- [x] Full `pytest` — 778 passed, 1 skipped (the existing `PYFABRIC_TEST_WORKSPACE`-gated test)
- [x] `ruff check` / `ruff format --check` / `mypy` on changed files — all clean
- [x] Pre-commit + pre-push hooks all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)