### PR TITLE
feat(notebook): add add_parameters_cell for Jobs API parameter injection (#78)

### DIFF
--- a/src/pyfabric/items/notebook.py
+++ b/src/pyfabric/items/notebook.py
@@ -74,6 +74,7 @@ class _Cell:
     kind: Literal["markdown", "code"]
     content: str
     language: CellLanguage | None = None  # code-only
+    parameters: bool = False  # code-only; emits PARAMETERS CELL marker
 
 
 _SAME_WORKSPACE_ID = "00000000-0000-0000-0000-000000000000"
@@ -171,6 +172,23 @@ class NotebookBuilder:
     def add_python(self, code: str) -> "NotebookBuilder":
         """Append a Python code cell."""
         self._cells.append(_Cell(kind="code", content=code, language="python"))
+        return self
+
+    def add_parameters_cell(self, code: str) -> "NotebookBuilder":
+        """Append a Python parameters cell.
+
+        Emits ``# PARAMETERS CELL ********************`` instead of the
+        regular ``# CELL`` marker. The trailing METADATA block is
+        identical to a normal Python cell.
+
+        A parameters cell is the injection target for the Jobs API
+        ``executionData.parameters`` field — values passed to
+        ``runOnDemand`` overwrite the matching variable assignments
+        in this cell at runtime.
+        """
+        self._cells.append(
+            _Cell(kind="code", content=code, language="python", parameters=True)
+        )
         return self
 
     def pip_install_from_resources(self, wheel_name: str) -> "NotebookBuilder":
@@ -328,7 +346,9 @@ class NotebookBuilder:
     def _render_cell(self, cell: _Cell) -> str:
         if cell.kind == "markdown":
             return self._render_markdown_cell(cell.content)
-        return self._render_code_cell(cell.content, cell.language or "python")
+        return self._render_code_cell(
+            cell.content, cell.language or "python", parameters=cell.parameters
+        )
 
     @staticmethod
     def _render_markdown_cell(content: str) -> str:
@@ -342,7 +362,9 @@ class NotebookBuilder:
         prefixed = ["# " if line == "" else f"# {line}" for line in lines]
         return "# MARKDOWN ********************\n\n" + "\n".join(prefixed) + "\n"
 
-    def _render_code_cell(self, code: str, language: CellLanguage) -> str:
+    def _render_code_cell(
+        self, code: str, language: CellLanguage, *, parameters: bool = False
+    ) -> str:
         meta_body = json.dumps(
             {
                 "language": language,
@@ -350,11 +372,13 @@ class NotebookBuilder:
             },
             indent=2,
         )
+        marker = (
+            "# PARAMETERS CELL ********************"
+            if parameters
+            else "# CELL ********************"
+        )
         return (
-            "# CELL ********************\n\n"
-            + code.rstrip("\n")
-            + "\n\n"
-            + self._meta_block(meta_body)
+            marker + "\n\n" + code.rstrip("\n") + "\n\n" + self._meta_block(meta_body)
         )
 
     @staticmethod

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -215,3 +215,15 @@ def real_workspace() -> Path | None:
         if p.is_dir():
             return p
     return None
+
+
+@pytest.fixture
+def real_workspace_id() -> str | None:
+    """Workspace ID (GUID) for REST-based E2E testing.
+
+    Distinct from ``real_workspace`` (which is a local git-synced path).
+    Set the PYFABRIC_TEST_WORKSPACE_ID environment variable to enable.
+    Returns None if the env var is not set so tests skip cleanly for
+    contributors who don't have a validation workspace.
+    """
+    return os.environ.get("PYFABRIC_TEST_WORKSPACE_ID") or None

--- a/tests/items/test_notebook.py
+++ b/tests/items/test_notebook.py
@@ -126,6 +126,57 @@ class TestPipInstallFromResources:
         assert '%pip install "builtin/my_pkg-1.0.0-py3-none-any.whl" --quiet' in src
 
 
+class TestParametersCell:
+    """``add_parameters_cell`` emits the Fabric parameters-cell marker.
+
+    The Jobs API ``runOnDemand`` ``executionData.parameters`` payload is
+    injected by Fabric into the cell tagged with this marker, overwriting
+    matching variable assignments at runtime.
+    """
+
+    def test_emits_parameters_cell_marker(self):
+        nb = NotebookBuilder().add_parameters_cell('BATCH_FILE = "default.csv"')
+        src = nb.to_source_string()
+        assert "# PARAMETERS CELL ********************" in src
+
+    def test_parameters_cell_does_not_emit_regular_cell_marker(self):
+        # When a notebook contains ONLY a parameters cell, the regular
+        # cell marker must not appear anywhere.
+        nb = NotebookBuilder().add_parameters_cell('BATCH = "x"')
+        src = nb.to_source_string()
+        assert "# CELL ********************" not in src
+
+    def test_parameters_cell_keeps_standard_metadata_block(self):
+        nb = NotebookBuilder().add_parameters_cell('BATCH = "x"')
+        src = nb.to_source_string()
+        # The trailing METADATA block is identical to a regular Python cell.
+        assert '"language": "python"' in src
+        assert '"language_group": "synapse_pyspark"' in src
+
+    def test_mixed_cells_use_correct_markers(self):
+        nb = (
+            NotebookBuilder()
+            .add_parameters_cell('BATCH = "x"')
+            .add_python("print(BATCH)")
+        )
+        src = nb.to_source_string()
+        assert "# PARAMETERS CELL ********************" in src
+        assert "# CELL ********************" in src
+        # Parameters marker must come first since add_parameters_cell was
+        # called first.
+        assert src.index("# PARAMETERS CELL") < src.index("# CELL")
+
+    def test_add_parameters_cell_returns_builder_for_chaining(self):
+        nb = NotebookBuilder().add_parameters_cell("X = 1").add_python("pass")
+        assert isinstance(nb, NotebookBuilder)
+
+    def test_parameters_cell_content_is_preserved_verbatim(self):
+        code = 'BATCH = "x"\nLIMIT = 100'
+        nb = NotebookBuilder().add_parameters_cell(code)
+        src = nb.to_source_string()
+        assert code in src
+
+
 # ── attach_lakehouse ────────────────────────────────────────────────────────
 
 

--- a/tests/items/test_notebook_e2e.py
+++ b/tests/items/test_notebook_e2e.py
@@ -1,0 +1,68 @@
+"""Live REST-based E2E tests for :mod:`pyfabric.items.notebook`.
+
+Skipped when ``PYFABRIC_TEST_WORKSPACE_ID`` is unset, so CI and
+contributors without a validation workspace still get a green run.
+
+Each test creates a uniquely-named notebook in the target workspace,
+verifies the round-tripped definition, and cleans up in a ``finally``
+block so failure paths don't leak items.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+
+from pyfabric.client.http import FabricClient
+from pyfabric.items.bundle import upload_to_workspace
+from pyfabric.items.crud import decode_part, delete_item, get_item_definition
+from pyfabric.items.notebook import NotebookBuilder
+
+
+@pytest.mark.e2e
+class TestParametersCellRoundTrip:
+    """Publish a notebook with a parameters cell to a real workspace,
+    fetch it back via getDefinition, and assert the marker survives."""
+
+    @pytest.fixture(autouse=True)
+    def _require_workspace(self, real_workspace_id: str | None) -> None:
+        if real_workspace_id is None:
+            pytest.skip("PYFABRIC_TEST_WORKSPACE_ID not set")
+        self.ws_id = real_workspace_id
+        self.client = FabricClient()
+
+    def test_parameters_cell_marker_survives_publish_and_fetch(self) -> None:
+        # Unique name so a failed cleanup from a prior run doesn't collide.
+        display_name = f"pyfabric_e2e_params_{uuid.uuid4().hex[:8]}"
+        nb = (
+            NotebookBuilder()
+            .add_parameters_cell('BATCH = "default"')
+            .add_python("print(BATCH)")
+        )
+        bundle = nb.to_bundle(display_name=display_name)
+
+        created = upload_to_workspace(bundle, self.client, self.ws_id)
+        item_id = created.get("id")
+        assert item_id, f"create_item returned no id: {created!r}"
+
+        try:
+            definition = get_item_definition(self.client, self.ws_id, item_id)
+            parts = definition.get("definition", {}).get("parts", [])
+            content_part = next(
+                (p for p in parts if p["path"] == "notebook-content.py"),
+                None,
+            )
+            assert content_part is not None, (
+                f"notebook-content.py missing from fetched parts: "
+                f"{[p['path'] for p in parts]}"
+            )
+            content = decode_part(content_part).decode("utf-8")
+            assert "# PARAMETERS CELL ********************" in content, (
+                f"parameters cell marker absent from fetched notebook:\n{content}"
+            )
+            assert "# CELL ********************" in content, (
+                "regular cell marker absent — round-trip dropped the python cell"
+            )
+        finally:
+            delete_item(self.client, self.ws_id, item_id)


### PR DESCRIPTION
## Summary

- `NotebookBuilder.add_parameters_cell(code)` emits the Fabric parameters-cell marker (`# PARAMETERS CELL ********************`) instead of the regular `# CELL` marker. Trailing METADATA block is identical to a normal Python cell.
- A parameters cell is the injection target for the Jobs API `runOnDemand` `executionData.parameters` payload — values passed at run time overwrite the matching variable assignments in this cell. Without this, callers wanting parameterized notebook execution had to set the cell up via the Fabric UI as a workaround.
- Adds six unit tests covering marker presence, METADATA correctness, mixed-cell ordering, chainability, and verbatim content preservation.
- Adds a live REST-based E2E test (`tests/items/test_notebook_e2e.py`) that publishes a notebook with a parameters cell to a real workspace, fetches the definition back, asserts the marker survives the round trip, and cleans up. Gated on `PYFABRIC_TEST_WORKSPACE_ID` so CI / contributors without a validation workspace get a clean skip.
- Adds a new `real_workspace_id` pytest fixture in `tests/conftest.py` (distinct from the existing path-based `real_workspace`) for REST-based E2E tests.
- Closes #78.

## Test plan

- [x] Unit tests — 36 passed in `tests/items/test_notebook.py` (6 new in `TestParametersCell`)
- [x] Full pytest — 780 passed, 2 skipped (both E2E gates)
- [x] **Live E2E roundtrip against a validation workspace** — 1 passed in 48s (publish + getDefinition + assert marker preserved + cleanup)
- [x] `ruff check` / `ruff format` / `mypy` — all clean
- [x] Pre-commit + pre-push hooks all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)