### PR TITLE
docs: Phase B reconciliation + Environment lifecycle e2e test (#73, #74)

### DIFF
--- a/docs/execution-plan.md
+++ b/docs/execution-plan.md
@@ -42,15 +42,23 @@ Done-when: all five close, CI green, no new bypasses of `write_artifact_file` in
 Parallel with A. Different module, different reviewers, independent
 test surface.
 
-| Issue | Outcome |
-| ----- | ------- |
-| [#73](https://github.com/Creative-Planning/pyfabric/issues/73) | `NotebookBuilder.attach_environment()` plus emission of `notebook-settings.json`. Removes the need for consumers to hand-author the settings file that gates `Resources/` git-sync inclusion. |
-| [#74](https://github.com/Creative-Planning/pyfabric/issues/74) | `EnvironmentBuilder` + REST lifecycle (`publish`, `get_status`, `wait_for_published`). Replaces the hand-maintained Environment artifact pattern with a builder + driver. |
-| [#78](https://github.com/Creative-Planning/pyfabric/issues/78) | `NotebookBuilder.add_parameters_cell()` (or `parameters=True` kwarg). Required input for any deployment story that parameterizes notebook execution across environments. |
+**Status:** like Phase A, the bulk of Phase B was already in `main`
+before this plan was written and the issues just weren't auto-closed.
+PR #79 shipped `attach_environment` + `notebook-settings.json` (#73).
+PR #80 shipped the `EnvironmentBuilder` + REST lifecycle (#74). PR #94
+adds `add_parameters_cell` (#78) plus the first live REST-based E2E
+test pattern (`PYFABRIC_TEST_WORKSPACE_ID`-gated round-trip against a
+validation workspace) that the rest of the codebase can build on.
+
+| Issue | Status | Outcome |
+| ----- | ------ | ------- |
+| [#78](https://github.com/Creative-Planning/pyfabric/issues/78) | **Done** (PR #94) | `NotebookBuilder.add_parameters_cell(code)` emits `# PARAMETERS CELL ********************`. Live round-trip test against a validation workspace confirms the marker survives Fabric's canonicalization. |
+| [#73](https://github.com/Creative-Planning/pyfabric/issues/73) | **Done** (PR #79) | `NotebookBuilder.attach_environment(env_id, ws_id=None)` emits the dependencies.environment block; `save_to_disk` / `to_bundle` emit `notebook-settings.json` unconditionally. |
+| [#74](https://github.com/Creative-Planning/pyfabric/issues/74) | **Done** (PR #80) | `EnvironmentBuilder` (runtime/compute/pip) + `publish_environment` / `get_environment_status` / `wait_for_published`. Sparkcompute.yml CRLF + trailing-CRLF and environment.yml LF + no-trailing-newline rules live in `normalize._RULES`. |
 
 Done-when: a downstream consumer can describe a Notebook + Environment
 pair entirely through builders, with no hand-written
-`notebook-settings.json` / `fs-settings.json` / `Environment.platform`.
+`notebook-settings.json` / `fs-settings.json` / `Environment.platform`. ✓
 
 ## Phase C — fabric-cicd interoperability
 

--- a/src/pyfabric/items/environment.py
+++ b/src/pyfabric/items/environment.py
@@ -314,20 +314,30 @@ def publish_environment(
 def get_environment_status(
     client: _ClientLike, workspace_id: str, environment_id: str
 ) -> dict[str, Any]:
-    """Return the Environment's publish status.
+    """Return the Environment's record (publish status included after publish).
 
     Body shape (Fabric API v1)::
 
         {
           "id": "...",
+          "type": "Environment",
           "displayName": "...",
-          ...,
-          "publishDetails": {
+          "description": "...",
+          "workspaceId": "...",
+          "properties": {...},
+          "attributes": [...],
+          "publishDetails": {                # only after publish_environment
             "state": "Running" | "Success" | "Published" | "Failed" | "Cancelled",
             "targetVersion": "...",
             ...
           }
         }
+
+    ``publishDetails`` is **absent** for a freshly-created Environment
+    that has never been published; verified live 2026-05-27 against
+    Fabric API v1. :func:`wait_for_published` correctly handles its
+    absence (the missing field is treated as in-progress, so polling
+    continues until the publish operation populates it).
     """
     return client.get(_env_path(workspace_id, environment_id))
 

--- a/tests/items/test_environment_e2e.py
+++ b/tests/items/test_environment_e2e.py
@@ -1,0 +1,70 @@
+"""Live REST-based E2E tests for :mod:`pyfabric.items.environment`.
+
+Skipped when ``PYFABRIC_TEST_WORKSPACE_ID`` is unset, so CI and
+contributors without a validation workspace still get a green run.
+
+Each test creates a uniquely-named Environment item in the target
+workspace, exercises the REST helpers, and cleans up in a ``finally``
+block.
+
+Heavy operations like a real ``publish_environment`` + full
+``wait_for_published`` cycle (~5 min) are intentionally NOT exercised
+here — the mocked tests in :mod:`test_environment` cover the polling
+state machine. This file is for the shape-of-response and item
+acceptance guarantees that only a real Fabric workspace can verify.
+"""
+
+from __future__ import annotations
+
+import os
+import uuid
+
+import pytest
+
+from pyfabric.client.http import FabricClient
+from pyfabric.items.bundle import upload_to_workspace
+from pyfabric.items.crud import delete_item
+from pyfabric.items.environment import EnvironmentBuilder, get_environment_status
+
+
+def _workspace_id() -> str | None:
+    return os.environ.get("PYFABRIC_TEST_WORKSPACE_ID") or None
+
+
+@pytest.mark.e2e
+class TestEnvironmentLifecycleE2E:
+    @pytest.fixture(autouse=True)
+    def _require_workspace(self) -> None:
+        ws_id = _workspace_id()
+        if ws_id is None:
+            pytest.skip("PYFABRIC_TEST_WORKSPACE_ID not set")
+        self.ws_id = ws_id
+        self.client = FabricClient()
+
+    def test_environment_item_accepted_by_fabric(self) -> None:
+        # No pip pins → no Spark package install → cleanup is fast.
+        # Default compute settings match Fabric's portal-created shape.
+        # We deliberately do NOT trigger publish_environment here — a
+        # full publish + wait cycle is ~5min, and the mocked tests in
+        # test_environment cover the state-machine of wait_for_published.
+        display_name = f"pyfabric_e2e_env_{uuid.uuid4().hex[:8]}"
+        bundle = EnvironmentBuilder().to_bundle(display_name=display_name)
+
+        created = upload_to_workspace(bundle, self.client, self.ws_id)
+        item_id = created.get("id")
+        assert item_id, f"create_item returned no id: {created!r}"
+
+        try:
+            status = get_environment_status(self.client, self.ws_id, item_id)
+            # The newly-created Environment record:
+            #   {id, type, displayName, description, workspaceId,
+            #    properties, attributes}
+            # Note: publishDetails is NOT present until publish_environment
+            # is called. wait_for_published correctly handles its absence
+            # (treats as in-progress and keeps polling).
+            assert status.get("id") == item_id
+            assert status.get("displayName") == display_name
+            assert status.get("type") == "Environment"
+            assert status.get("workspaceId") == self.ws_id
+        finally:
+            delete_item(self.client, self.ws_id, item_id)


### PR DESCRIPTION
## Summary

Like Phase A, the bulk of Phase B was already in `main` before `docs/execution-plan.md` was written and just lacked closing references. Verified on `main`:

- **#73 — Done in PR #79.** `attach_environment(env_id, ws_id=None)` emits the `dependencies.environment` block with all-zeros workspace ID by default; `save_to_disk` / `to_bundle` emit `notebook-settings.json` unconditionally.
- **#74 — Done in PR #80.** `EnvironmentBuilder` + `publish_environment` / `get_environment_status` / `wait_for_published`. Sparkcompute.yml CRLF and environment.yml LF rules in `normalize._RULES`.
- **#78 — Done in PR #94** (pending merge).

This PR:

- Updates Phase B table in `docs/execution-plan.md` to reflect reality, mirroring the Status column added for Phase A in PR #93.
- Adds `tests/items/test_environment_e2e.py` — first live REST-based lifecycle test, gated on `PYFABRIC_TEST_WORKSPACE_ID`. Verifies builder output is accepted by Fabric, `get_environment_status` returns the expected record shape, cleanup works. Does NOT trigger `publish_environment` (5min wait); mocked tests cover the state machine.
- Updates `get_environment_status` docstring: discovered live that `publishDetails` is **absent** for an unpublished Environment. Response keys are `id, type, displayName, description, workspaceId, properties, attributes`. `wait_for_published` already handles the absence correctly via `last.get("publishDetails") or {}`, but the docstring implied it was always present.
- Closes #73, closes #74.

## Test plan

- [x] **Live E2E lifecycle test against a validation workspace** — 1 passed in 24s (create + getDefinition + assert shape + delete)
- [x] Full pytest — 774 passed, 2 skipped (both E2E gates)
- [x] `ruff check` / `ruff format` / `mypy` — all clean
- [x] Pre-commit + pre-push hooks all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)