### PR TITLE
feat(datapipeline): DataPipelineBuilder + normalize coverage for DataPipeline

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -221,6 +221,38 @@ CRUD operations for Fabric workspace items via REST API.
 | `encode_part(path, content)` | Build a definition part dict for the API. |
 | `decode_part(part)` | Decode base64 payload from a part dict. |
 
+### pyfabric.items.datapipeline
+
+Build Fabric Data Pipeline (`pipeline-content.json`) artifacts that round-trip
+cleanly through git-sync. Emits Fabric's canonical form: notebook activities
+reference the target notebook's git `logicalId` (not its workspace object id),
+`workspaceId` is zeroed, keys follow Fabric's order, and bytes are LF with no
+trailing newline.
+
+| Function / Class | Description |
+| ----------------- | ------------- |
+| `DataPipelineBuilder(description="")` | Builder for a pipeline definition. |
+| `.add_notebook_activity(name, notebook, *, parameters=None, depends_on=None, workspace_id=None)` | Add a `TridentNotebook` activity. `notebook` is a `.Notebook` dir, its `.platform`, or a logicalId GUID. Returns the activity name. |
+| `.add_semantic_model_refresh(name, *, dataset_id, connection, depends_on=None)` | Add a `PBISemanticModelRefresh` activity. `connection` must be a real provisioned Power BI connection id. |
+| `.add_activity(name, activity_type, type_properties, *, depends_on=None, external_references=None)` | Generic activity escape hatch. |
+| `.to_pipeline_content()` | Render `pipeline-content.json` as a string. |
+| `.to_bundle(display_name, *, logical_id=None)` / `.save_to_disk(output_dir, *, display_name, ...)` | Materialize an `ArtifactBundle` / write the `.DataPipeline` folder with canonical bytes. |
+| `notebook_logical_id(notebook)` | Resolve a notebook's git logicalId from its `.platform` (or pass a GUID through). |
+
+Activity names are validated to Fabric's allowed set (letters, numbers, `-`,
+`_`, spaces) — anything else raises before the pipeline reaches the portal.
+
+**Example:**
+
+```python
+from pyfabric.items.datapipeline import DataPipelineBuilder
+
+pl = DataPipelineBuilder(description="Daily refresh")
+pl.add_notebook_activity("Extract", "ws/nb_extract.Notebook", parameters={"path": ""})
+pl.add_notebook_activity("Transform", "ws/nb_transform.Notebook", depends_on=["Extract"])
+pl.save_to_disk("ws/", display_name="pl_daily")
+```
+
 ---
 
 ## pyfabric.data — Data Access

--- a/src/pyfabric/items/datapipeline.py
+++ b/src/pyfabric/items/datapipeline.py
@@ -1,0 +1,324 @@
+"""Programmatic emission of Fabric ``pipeline-content.json`` files.
+
+Hand-authoring a Data Pipeline definition flaps on the first git-sync because
+Fabric re-serializes it to a canonical form that differs from the obvious one:
+
+* an activity's ``typeProperties.notebookId`` is the referenced notebook's git
+  **logicalId** (from that ``*.Notebook/.platform``), NOT its workspace object id;
+* ``typeProperties.workspaceId`` is **zeroed** (``00000000-...``), resolved at
+  runtime within the workspace;
+* keys are emitted in a fixed order — activity ``type, typeProperties, policy,
+  name, dependsOn`` and policy ``timeout, retry, retryIntervalInSeconds,
+  secureInput, secureOutput``.
+
+:class:`DataPipelineBuilder` centralizes those conventions so callers describe a
+pipeline at a higher level (notebook activities + success dependencies) and trust
+the output round-trips cleanly through git-sync. Bytes are written via
+:func:`pyfabric.items.normalize.write_artifact_file` (LF, no trailing newline),
+which requires the ``*.DataPipeline`` globs registered in
+:data:`pyfabric.items.normalize.ARTIFACT_GLOBS`.
+
+Usage::
+
+    from pyfabric.items.datapipeline import DataPipelineBuilder
+
+    pl = (
+        DataPipelineBuilder(description="Daily refresh")
+        # reference notebooks by their .Notebook dir — the logicalId is read
+        # from each notebook's .platform automatically:
+        .add_notebook_activity(
+            "Extract", "definitions/nb_extract.Notebook", parameters={"path": ""}
+        )
+    )
+    pl.add_notebook_activity(
+        "Transform", "definitions/nb_transform.Notebook", depends_on=["Extract"]
+    )
+    pl.save_to_disk("definitions/", display_name="pl_daily")
+"""
+
+import json
+import re
+from pathlib import Path
+
+import structlog
+
+from pyfabric.items.bundle import ArtifactBundle
+from pyfabric.items.normalize import canonical_bytes, write_artifact_file
+from pyfabric.items.types import parse_platform
+
+log = structlog.get_logger()
+
+#: Activity type for a Fabric notebook (Trident) run.
+NOTEBOOK_ACTIVITY_TYPE = "TridentNotebook"
+#: Activity type for a Power BI / Fabric semantic model refresh.
+SEMANTIC_MODEL_REFRESH_TYPE = "PBISemanticModelRefresh"
+
+#: Same-workspace sentinel — Fabric zeroes ``workspaceId`` in git and resolves it
+#: at runtime within the pipeline's own workspace.
+_SAME_WORKSPACE_ID = "00000000-0000-0000-0000-000000000000"
+
+_DEFAULT_TIMEOUT = "0.12:00:00"
+_GUID_RE = re.compile(
+    r"[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}"
+)
+# Fabric rejects activity names with any character outside this set — letters,
+# numbers, dashes, underscores, spaces. (Parentheses, etc. fail with
+# "Activity name should only contain letters, numbers, dashes (-), underscores
+# (_), or spaces.") Validate at build time so the pipeline isn't rejected only
+# after it reaches the portal.
+_VALID_ACTIVITY_NAME_RE = re.compile(r"^[A-Za-z0-9_\- ]+$")
+
+# Pipeline-relative path for canonical_bytes rule matching (LF, no trailing).
+_PIPELINE_REL = "pl.DataPipeline/pipeline-content.json"
+
+
+def notebook_logical_id(notebook: str | Path) -> str:
+    """Resolve a notebook's git ``logicalId`` from its ``.platform``.
+
+    ``notebook`` may be the ``*.Notebook`` directory, the ``.platform`` file
+    itself, or a bare logicalId GUID (returned as-is). Raising means the
+    ``.platform`` is missing or malformed — fail loud rather than emit a
+    pipeline that references a non-existent notebook.
+    """
+    s = str(notebook)
+    if _GUID_RE.fullmatch(s.strip()):
+        return s.strip()
+    path = Path(notebook)
+    platform = path if path.name == ".platform" else path / ".platform"
+    return parse_platform(platform.read_text(encoding="utf-8")).config.logical_id
+
+
+def _param_type(value: object) -> str:
+    if isinstance(value, bool):
+        return "bool"
+    if isinstance(value, int):
+        return "int"
+    if isinstance(value, float):
+        return "float"
+    return "string"
+
+
+class DataPipelineBuilder:
+    """Build a Fabric ``pipeline-content.json`` programmatically.
+
+    Construct, chain ``add_*`` calls to describe the activities, then call
+    :meth:`to_pipeline_content`, :meth:`to_bundle`, or :meth:`save_to_disk`.
+
+    Args:
+        description: Optional pipeline description, emitted as
+            ``properties.description`` in ``pipeline-content.json``.
+    """
+
+    def __init__(self, *, description: str = "") -> None:
+        self.description = description
+        self._activities: list[dict[str, object]] = []
+        self._names: set[str] = set()
+
+    # ── Activities ───────────────────────────────────────────────────────────
+
+    def add_notebook_activity(
+        self,
+        name: str,
+        notebook: str | Path,
+        *,
+        parameters: dict[str, object] | None = None,
+        depends_on: list[str] | None = None,
+        workspace_id: str | None = None,
+        timeout: str = _DEFAULT_TIMEOUT,
+        retry: int = 0,
+        retry_interval_seconds: int = 30,
+    ) -> str:
+        """Append a notebook (``TridentNotebook``) activity.
+
+        Args:
+            name: Activity display name (unique within the pipeline).
+            notebook: The referenced notebook — a ``*.Notebook`` directory, its
+                ``.platform`` file, or a bare logicalId GUID. The activity's
+                ``notebookId`` is resolved to the notebook's git **logicalId**.
+            parameters: Notebook parameters; each value is wrapped as
+                ``{"value": v, "type": <inferred>}`` (str/int/float/bool).
+            depends_on: Names of activities that must succeed first.
+            workspace_id: Override the (zeroed) same-workspace default.
+
+        Returns the activity ``name`` (handy for chaining ``depends_on``).
+        """
+        type_props: dict[str, object] = {
+            "notebookId": notebook_logical_id(notebook),
+            "workspaceId": workspace_id or _SAME_WORKSPACE_ID,
+        }
+        if parameters:
+            type_props["parameters"] = {
+                k: {"value": v, "type": _param_type(v)} for k, v in parameters.items()
+            }
+        return self.add_activity(
+            name,
+            NOTEBOOK_ACTIVITY_TYPE,
+            type_props,
+            depends_on=depends_on,
+            timeout=timeout,
+            retry=retry,
+            retry_interval_seconds=retry_interval_seconds,
+        )
+
+    def add_semantic_model_refresh(
+        self,
+        name: str,
+        *,
+        dataset_id: str,
+        connection: str,
+        workspace_id: str | None = None,
+        depends_on: list[str] | None = None,
+        commit_mode: str = "transactional",
+        refresh_type: str = "Full",
+        timeout: str = _DEFAULT_TIMEOUT,
+        retry: int = 0,
+        retry_interval_seconds: int = 30,
+    ) -> str:
+        """Append a ``PBISemanticModelRefresh`` activity.
+
+        NOTE: ``connection`` MUST be a real provisioned Power BI connection id —
+        a placeholder/zero GUID makes Fabric reject the whole pipeline on
+        git-sync with ``RequestValidationFailed: User does not have access to the
+        connection``. Provision the connection in the portal first (it is usually
+        configured there), then pass its id here. ``dataset_id`` is the semantic
+        model's id; ``workspace_id`` defaults to the (zeroed) same-workspace.
+        """
+        type_props: dict[str, object] = {
+            "method": "POST",
+            "groupId": workspace_id or _SAME_WORKSPACE_ID,
+            "datasetId": dataset_id,
+            "type": refresh_type,
+            "commitMode": commit_mode,
+            "waitOnCompletion": True,
+            "operationType": "RefreshDataset",
+        }
+        return self.add_activity(
+            name,
+            SEMANTIC_MODEL_REFRESH_TYPE,
+            type_props,
+            depends_on=depends_on,
+            timeout=timeout,
+            retry=retry,
+            retry_interval_seconds=retry_interval_seconds,
+            external_references={"connection": connection},
+        )
+
+    def add_activity(
+        self,
+        name: str,
+        activity_type: str,
+        type_properties: dict[str, object],
+        *,
+        depends_on: list[str] | None = None,
+        timeout: str = _DEFAULT_TIMEOUT,
+        retry: int = 0,
+        retry_interval_seconds: int = 30,
+        external_references: dict[str, object] | None = None,
+    ) -> str:
+        """Append an activity of an arbitrary type (escape hatch).
+
+        Emits keys in Fabric's canonical order: ``type, typeProperties, policy,
+        [externalReferences,] name, dependsOn``. ``depends_on`` names must refer
+        to already-added activities.
+        """
+        if not _VALID_ACTIVITY_NAME_RE.fullmatch(name):
+            raise ValueError(
+                f"invalid activity name {name!r}: Fabric allows only letters, "
+                f"numbers, dashes (-), underscores (_), and spaces"
+            )
+        if name in self._names:
+            raise ValueError(f"duplicate activity name: {name!r}")
+        for dep in depends_on or []:
+            if dep not in self._names:
+                raise ValueError(
+                    f"activity {name!r} depends on unknown activity {dep!r}"
+                )
+        activity: dict[str, object] = {
+            "type": activity_type,
+            "typeProperties": type_properties,
+            "policy": {
+                "timeout": timeout,
+                "retry": retry,
+                "retryIntervalInSeconds": retry_interval_seconds,
+                "secureInput": False,
+                "secureOutput": False,
+            },
+        }
+        if external_references is not None:
+            activity["externalReferences"] = external_references
+        activity["name"] = name
+        activity["dependsOn"] = [
+            {"activity": dep, "dependencyConditions": ["Succeeded"]}
+            for dep in (depends_on or [])
+        ]
+        self._activities.append(activity)
+        self._names.add(name)
+        return name
+
+    # ── Emission ─────────────────────────────────────────────────────────────
+
+    def to_pipeline_content(self) -> str:
+        """Render ``pipeline-content.json`` as a string (2-space indent)."""
+        properties: dict[str, object] = {}
+        if self.description:
+            properties["description"] = self.description
+        properties["activities"] = self._activities
+        return json.dumps({"properties": properties}, indent=2)
+
+    def to_bundle(
+        self,
+        display_name: str,
+        *,
+        logical_id: str | None = None,
+        description: str = "",
+    ) -> ArtifactBundle:
+        """Bundle the pipeline for disk save or REST upload.
+
+        ``pipeline-content.json`` is stored as canonical bytes (LF, no trailing
+        newline, no BOM) so :func:`pyfabric.items.bundle.save_to_disk` preserves
+        LF on Windows. ``description`` is the item (.platform) description; the
+        pipeline-content description is set on the builder.
+        """
+        content = canonical_bytes(
+            _PIPELINE_REL, self.to_pipeline_content().encode("utf-8")
+        )
+        kwargs: dict[str, object] = {
+            "item_type": "DataPipeline",
+            "display_name": display_name,
+            "parts": {"pipeline-content.json": content},
+            "description": description,
+        }
+        if logical_id is not None:
+            kwargs["logical_id"] = logical_id
+        return ArtifactBundle(**kwargs)  # type: ignore[arg-type]
+
+    def save_to_disk(
+        self,
+        output_dir: str | Path,
+        *,
+        display_name: str,
+        logical_id: str | None = None,
+        description: str = "",
+    ) -> Path:
+        """Write ``{display_name}.DataPipeline/`` with canonical bytes.
+
+        Routes ``.platform`` and ``pipeline-content.json`` through
+        :func:`pyfabric.items.normalize.write_artifact_file`. Returns the
+        artifact directory path.
+        """
+        bundle = self.to_bundle(
+            display_name, logical_id=logical_id, description=description
+        )
+        artifact_dir = Path(output_dir) / bundle.dir_name
+        artifact_dir.mkdir(parents=True, exist_ok=True)
+        write_artifact_file(artifact_dir / ".platform", bundle.platform_json())
+        write_artifact_file(
+            artifact_dir / "pipeline-content.json", self.to_pipeline_content()
+        )
+        log.info(
+            "datapipeline_saved",
+            display_name=display_name,
+            path=str(artifact_dir),
+            activities=len(self._activities),
+        )
+        return artifact_dir

--- a/src/pyfabric/items/normalize.py
+++ b/src/pyfabric/items/normalize.py
@@ -23,11 +23,13 @@ from Fabric git-sync auto-commits across two separate workspaces — every one o
 touched only a model description still rewrote each single-``\\n`` table file to
 add the trailing blank line.
 
-Fabric *tolerates* a single trailing ``\\n`` on import (it normalizes trailing
-newlines when diffing git, so a one-newline file is not flagged as drift), but
-the next portal edit re-serializes the whole model to the ``\\n\\n`` form. Writing
-``\\n\\n`` up front keeps committed bytes identical to whatever Fabric will emit,
-so that later re-serialize produces no spurious diff.
+A single-trailing-``\\n`` TMDL has been observed sitting in a workspace's git
+without being flagged for an inbound update — but that is also consistent with
+Fabric simply not having re-serialized that model yet (it re-emits the whole
+model, in ``\\n\\n`` form, on the next portal edit), so whether Fabric actively
+treats ``\\n`` ≡ ``\\n\\n`` when diffing is unconfirmed. Either way, writing
+``\\n\\n`` up front keeps committed bytes identical to whatever Fabric emits, so
+a later re-serialize produces no spurious diff — which is why we match it.
 
 If committed bytes don't match this convention, every Fabric sync cycle
 flags the file as "changed by Fabric" and pushes a no-op edit back into

--- a/src/pyfabric/items/normalize.py
+++ b/src/pyfabric/items/normalize.py
@@ -12,6 +12,7 @@ commits directly:
 | ``*.Environment/Setting/Sparkcompute.yml``    | CRLF         | Yes (CRLF)  |
 | ``*.Notebook/notebook-content.py``            | LF           | Yes (LF)    |
 | ``*.Notebook/notebook-content.sql``           | LF           | Yes (LF)    |
+| ``*.DataPipeline/pipeline-content.json``      | LF           | No          |
 | everything else in Fabric artifact folders    | LF           | No          |
 
 If committed bytes don't match this convention, every Fabric sync cycle
@@ -84,6 +85,8 @@ ARTIFACT_GLOBS: tuple[str, ...] = (
     "*.Report/definition/**/*.pbir",
     "*.MirroredDatabase/.platform",
     "*.MirroredDatabase/mirroring.json",
+    "*.DataPipeline/.platform",
+    "*.DataPipeline/pipeline-content.json",
 )
 
 # File-type-specific rules. First match wins. Order matters.
@@ -281,5 +284,6 @@ _ITEM_TYPES: frozenset[str] = frozenset(
         "SemanticModel",
         "Report",
         "MirroredDatabase",
+        "DataPipeline",
     }
 )

--- a/src/pyfabric/items/normalize.py
+++ b/src/pyfabric/items/normalize.py
@@ -12,8 +12,22 @@ commits directly:
 | ``*.Environment/Setting/Sparkcompute.yml``    | CRLF         | Yes (CRLF)  |
 | ``*.Notebook/notebook-content.py``            | LF           | Yes (LF)    |
 | ``*.Notebook/notebook-content.sql``           | LF           | Yes (LF)    |
+| ``*.SemanticModel/**/*.tmdl``                 | LF           | Blank (LFLF)|
 | ``*.DataPipeline/pipeline-content.json``      | LF           | No          |
 | everything else in Fabric artifact folders    | LF           | No          |
+
+SemanticModel ``*.tmdl`` files are the one type Fabric ends with a trailing
+**blank line** (two LF bytes, ``…content\\n\\n``), not zero and not one. Verified
+from Fabric git-sync auto-commits across two separate workspaces — every one of
+26+ Fabric-authored ``.tmdl`` files ended ``\\n\\n``, and a portal edit that
+touched only a model description still rewrote each single-``\\n`` table file to
+add the trailing blank line.
+
+Fabric *tolerates* a single trailing ``\\n`` on import (it normalizes trailing
+newlines when diffing git, so a one-newline file is not flagged as drift), but
+the next portal edit re-serializes the whole model to the ``\\n\\n`` form. Writing
+``\\n\\n`` up front keeps committed bytes identical to whatever Fabric will emit,
+so that later re-serialize produces no spurious diff.
 
 If committed bytes don't match this convention, every Fabric sync cycle
 flags the file as "changed by Fabric" and pushes a no-op edit back into
@@ -90,18 +104,25 @@ ARTIFACT_GLOBS: tuple[str, ...] = (
 )
 
 # File-type-specific rules. First match wins. Order matters.
-# Tuple shape: (path-glob, line-ending, trailing-newline-bool).
-_RULES: tuple[tuple[str, str, bool], ...] = (
+# Tuple shape: (path-glob, line-ending, trailing-newline-bool, trailing-blank-line-bool).
+# When the blank-line flag is set it supersedes the plain trailing-newline flag
+# (the file ends in two line-endings); the trailing-newline value is then ignored.
+# fnmatch (used by ``rule_for``) does NOT special-case ``/`` or ``**``, so a bare
+# ``*`` in a glob spans directory separators — ``*.SemanticModel/*.tmdl`` matches
+# ``definition/model.tmdl`` and ``definition/tables/x.tmdl`` alike.
+_RULES: tuple[tuple[str, str, bool, bool], ...] = (
     # CRLF + no trailing newline
-    ("*.Lakehouse/alm.settings.json", "\r\n", False),
+    ("*.Lakehouse/alm.settings.json", "\r\n", False, False),
     # CRLF + trailing CRLF
-    ("*.Environment/Setting/Sparkcompute.yml", "\r\n", True),
-    ("*.Environment/Setting/*.yml", "\r\n", True),  # future-proofing
+    ("*.Environment/Setting/Sparkcompute.yml", "\r\n", True, False),
+    ("*.Environment/Setting/*.yml", "\r\n", True, False),  # future-proofing
     # LF + trailing LF
-    ("*.Notebook/notebook-content.py", "\n", True),
-    ("*.Notebook/notebook-content.sql", "\n", True),
+    ("*.Notebook/notebook-content.py", "\n", True, False),
+    ("*.Notebook/notebook-content.sql", "\n", True, False),
+    # LF + trailing BLANK line — Fabric ends every SemanticModel TMDL with "\n\n"
+    ("*.SemanticModel/*.tmdl", "\n", False, True),
     # LF + no trailing — default for everything else
-    ("*", "\n", False),
+    ("*", "\n", False, False),
 )
 
 
@@ -114,6 +135,10 @@ class FileRule:
 
     line_ending: str  # "\n" or "\r\n"
     trailing_newline: bool
+    # When True the file ends with a trailing BLANK line (two ``line_ending``s,
+    # e.g. ``…\n\n``) — Fabric's form for SemanticModel TMDL. This supersedes
+    # ``trailing_newline``; if set, ``trailing_newline`` is ignored.
+    trailing_blank_line: bool = False
 
 
 @dataclass
@@ -141,9 +166,13 @@ def rule_for(rel_path: str) -> FileRule:
     slashes. The first matching glob in ``_RULES`` wins; the catch-all
     ``"*"`` ensures every artifact path resolves to a rule.
     """
-    for pattern, eol, trailing in _RULES:
+    for pattern, eol, trailing, blank in _RULES:
         if fnmatch.fnmatch(rel_path, pattern):
-            return FileRule(line_ending=eol, trailing_newline=trailing)
+            return FileRule(
+                line_ending=eol,
+                trailing_newline=trailing,
+                trailing_blank_line=blank,
+            )
     # Defensive fallback — the catch-all in _RULES means we never reach here.
     return FileRule(line_ending="\n", trailing_newline=False)
 
@@ -162,7 +191,15 @@ def canonical_bytes(rel_path: str, raw: bytes) -> bytes:
     except UnicodeDecodeError:
         return raw
     rule = rule_for(rel_path)
-    joined = rule.line_ending.join(text.splitlines())
+    lines = text.splitlines()
+    if rule.trailing_blank_line:
+        # splitlines keeps interior blank lines, so collapse any trailing ones
+        # before re-appending exactly one — otherwise normalization isn't a
+        # fixed point (``…\n\n`` would grow a third newline each pass).
+        while lines and lines[-1] == "":
+            lines.pop()
+        return (rule.line_ending.join(lines) + rule.line_ending * 2).encode("utf-8")
+    joined = rule.line_ending.join(lines)
     if rule.trailing_newline:
         joined += rule.line_ending
     return joined.encode("utf-8")

--- a/tests/fixtures/datapipelines/pl_sample.DataPipeline/pipeline-content.json
+++ b/tests/fixtures/datapipelines/pl_sample.DataPipeline/pipeline-content.json
@@ -1,0 +1,52 @@
+{
+  "properties": {
+    "description": "Example two-step pipeline.",
+    "activities": [
+      {
+        "type": "TridentNotebook",
+        "typeProperties": {
+          "notebookId": "00000000-0000-0000-0000-00000000000a",
+          "workspaceId": "00000000-0000-0000-0000-000000000000",
+          "parameters": {
+            "path": {
+              "value": "",
+              "type": "string"
+            }
+          }
+        },
+        "policy": {
+          "timeout": "0.12:00:00",
+          "retry": 0,
+          "retryIntervalInSeconds": 30,
+          "secureInput": false,
+          "secureOutput": false
+        },
+        "name": "Extract",
+        "dependsOn": []
+      },
+      {
+        "type": "TridentNotebook",
+        "typeProperties": {
+          "notebookId": "00000000-0000-0000-0000-00000000000b",
+          "workspaceId": "00000000-0000-0000-0000-000000000000"
+        },
+        "policy": {
+          "timeout": "0.12:00:00",
+          "retry": 0,
+          "retryIntervalInSeconds": 30,
+          "secureInput": false,
+          "secureOutput": false
+        },
+        "name": "Transform",
+        "dependsOn": [
+          {
+            "activity": "Extract",
+            "dependencyConditions": [
+              "Succeeded"
+            ]
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/tests/items/test_datapipeline.py
+++ b/tests/items/test_datapipeline.py
@@ -1,0 +1,225 @@
+"""Tests for :mod:`pyfabric.items.datapipeline` (DataPipelineBuilder).
+
+The correctness bar is **byte-equality with Fabric's canonical
+``pipeline-content.json``**. Fabric re-serializes the pipeline on first
+git-sync to a fixed shape — git logicalId for ``notebookId``, zeroed
+``workspaceId``, and a specific activity/policy key order — so a builder that
+gets any of that wrong produces a file that flaps on every sync.
+
+All ids in the fixtures are synthetic (``00000000-...``) — no client
+identifiers leak in.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from pyfabric.items.datapipeline import (
+    DataPipelineBuilder,
+    notebook_logical_id,
+)
+from pyfabric.items.normalize import canonical_bytes
+from pyfabric.items.types import parse_platform
+
+FIXTURES = Path(__file__).parent.parent / "fixtures" / "datapipelines"
+_PIPELINE_REL = "pl.DataPipeline/pipeline-content.json"
+
+_NB_A = "00000000-0000-0000-0000-00000000000a"
+_NB_B = "00000000-0000-0000-0000-00000000000b"
+_ZERO_WS = "00000000-0000-0000-0000-000000000000"
+
+
+def _build_sample() -> DataPipelineBuilder:
+    b = DataPipelineBuilder(description="Example two-step pipeline.")
+    b.add_notebook_activity("Extract", _NB_A, parameters={"path": ""})
+    b.add_notebook_activity("Transform", _NB_B, depends_on=["Extract"])
+    return b
+
+
+def _make_notebook_dir(tmp_path: Path, name: str, logical_id: str) -> Path:
+    nb = tmp_path / f"{name}.Notebook"
+    nb.mkdir()
+    (nb / ".platform").write_text(
+        json.dumps(
+            {
+                "$schema": "https://example/schema.json",
+                "metadata": {"type": "Notebook", "displayName": name},
+                "config": {"version": "2.0", "logicalId": logical_id},
+            }
+        ),
+        encoding="utf-8",
+    )
+    return nb
+
+
+# ── Byte-equality with Fabric's canonical form ───────────────────────────────
+
+
+class TestByteEquality:
+    def test_matches_fabric_canonical_fixture(self, tmp_path: Path):
+        out = _build_sample().save_to_disk(tmp_path, display_name="pl_sample")
+        got = (out / "pipeline-content.json").read_bytes()
+        # Normalize the fixture the same way (strips any trailing newline an
+        # editor added) so the comparison is about content, not the fixture's
+        # on-disk trailing byte.
+        expected = canonical_bytes(
+            _PIPELINE_REL,
+            (
+                FIXTURES / "pl_sample.DataPipeline" / "pipeline-content.json"
+            ).read_bytes(),
+        )
+        assert got == expected
+
+    def test_bytes_are_lf_no_trailing_no_bom(self, tmp_path: Path):
+        out = _build_sample().save_to_disk(tmp_path, display_name="pl_sample")
+        raw = (out / "pipeline-content.json").read_bytes()
+        assert b"\r\n" not in raw
+        assert not raw.endswith(b"\n")
+        assert not raw.startswith(b"\xef\xbb\xbf")
+
+
+# ── Canonical conventions ────────────────────────────────────────────────────
+
+
+class TestConventions:
+    def test_notebookid_resolves_to_logicalid_from_platform(self, tmp_path: Path):
+        nb = _make_notebook_dir(
+            tmp_path, "nb_x", "11111111-1111-1111-1111-111111111111"
+        )
+        b = DataPipelineBuilder()
+        b.add_notebook_activity("A", nb)
+        act = json.loads(b.to_pipeline_content())["properties"]["activities"][0]
+        assert (
+            act["typeProperties"]["notebookId"]
+            == "11111111-1111-1111-1111-111111111111"
+        )
+
+    def test_notebook_logical_id_helper_accepts_dir_file_or_guid(self, tmp_path: Path):
+        nb = _make_notebook_dir(
+            tmp_path, "nb_y", "22222222-2222-2222-2222-222222222222"
+        )
+        assert notebook_logical_id(nb) == "22222222-2222-2222-2222-222222222222"
+        assert (
+            notebook_logical_id(nb / ".platform")
+            == "22222222-2222-2222-2222-222222222222"
+        )
+        assert notebook_logical_id(_NB_A) == _NB_A  # bare GUID passes through
+
+    def test_workspaceid_zeroed_by_default(self):
+        b = DataPipelineBuilder()
+        b.add_notebook_activity("A", _NB_A)
+        act = json.loads(b.to_pipeline_content())["properties"]["activities"][0]
+        assert act["typeProperties"]["workspaceId"] == _ZERO_WS
+
+    def test_activity_key_order(self):
+        b = DataPipelineBuilder()
+        b.add_notebook_activity("A", _NB_A)
+        act = json.loads(b.to_pipeline_content())["properties"]["activities"][0]
+        assert list(act.keys()) == [
+            "type",
+            "typeProperties",
+            "policy",
+            "name",
+            "dependsOn",
+        ]
+        assert list(act["policy"].keys()) == [
+            "timeout",
+            "retry",
+            "retryIntervalInSeconds",
+            "secureInput",
+            "secureOutput",
+        ]
+
+    def test_depends_on_emits_succeeded_chain(self):
+        b = _build_sample()
+        acts = json.loads(b.to_pipeline_content())["properties"]["activities"]
+        assert acts[0]["dependsOn"] == []
+        assert acts[1]["dependsOn"] == [
+            {"activity": "Extract", "dependencyConditions": ["Succeeded"]}
+        ]
+
+    def test_unknown_dependency_raises(self):
+        b = DataPipelineBuilder()
+        with pytest.raises(ValueError, match="unknown activity"):
+            b.add_notebook_activity("A", _NB_A, depends_on=["Nope"])
+
+    def test_duplicate_name_raises(self):
+        b = DataPipelineBuilder()
+        b.add_notebook_activity("A", _NB_A)
+        with pytest.raises(ValueError, match="duplicate activity name"):
+            b.add_notebook_activity("A", _NB_B)
+
+    @pytest.mark.parametrize(
+        "bad_name", ["Extract (Bronze)", "a/b", "a.b", "x@y", "a,b"]
+    )
+    def test_invalid_activity_name_raises(self, bad_name):
+        # Fabric rejects names with anything outside [A-Za-z0-9_- ].
+        b = DataPipelineBuilder()
+        with pytest.raises(ValueError, match="invalid activity name"):
+            b.add_notebook_activity(bad_name, _NB_A)
+
+    @pytest.mark.parametrize(
+        "ok_name",
+        ["Extract Projections Bronze", "bronze_to_silver", "Silver-to-Gold", "Step 1"],
+    )
+    def test_valid_activity_names_accepted(self, ok_name):
+        b = DataPipelineBuilder()
+        b.add_notebook_activity(ok_name, _NB_A)  # no raise
+
+    def test_parameter_type_inference(self):
+        b = DataPipelineBuilder()
+        b.add_notebook_activity(
+            "A", _NB_A, parameters={"s": "x", "n": 3, "f": 1.5, "flag": True}
+        )
+        params = json.loads(b.to_pipeline_content())["properties"]["activities"][0][
+            "typeProperties"
+        ]["parameters"]
+        assert params["s"] == {"value": "x", "type": "string"}
+        assert params["n"] == {"value": 3, "type": "int"}
+        assert params["f"] == {"value": 1.5, "type": "float"}
+        # bool before int — order matters in _param_type
+        assert params["flag"] == {"value": True, "type": "bool"}
+
+
+# ── Semantic model refresh ───────────────────────────────────────────────────
+
+
+class TestSemanticModelRefresh:
+    def test_includes_connection_and_dataset(self):
+        b = DataPipelineBuilder()
+        b.add_notebook_activity("Gold", _NB_A)
+        b.add_semantic_model_refresh(
+            "Refresh",
+            dataset_id="33333333-3333-3333-3333-333333333333",
+            connection="44444444-4444-4444-4444-444444444444",
+            depends_on=["Gold"],
+        )
+        act = json.loads(b.to_pipeline_content())["properties"]["activities"][1]
+        assert act["type"] == "PBISemanticModelRefresh"
+        assert (
+            act["typeProperties"]["datasetId"] == "33333333-3333-3333-3333-333333333333"
+        )
+        assert act["externalReferences"] == {
+            "connection": "44444444-4444-4444-4444-444444444444"
+        }
+        assert act["dependsOn"][0]["activity"] == "Gold"
+
+
+# ── save_to_disk / .platform ─────────────────────────────────────────────────
+
+
+class TestSaveToDisk:
+    def test_platform_declares_datapipeline(self, tmp_path: Path):
+        out = _build_sample().save_to_disk(
+            tmp_path,
+            display_name="pl_sample",
+            logical_id="55555555-5555-5555-5555-555555555555",
+        )
+        assert out.name == "pl_sample.DataPipeline"
+        pf = parse_platform((out / ".platform").read_text(encoding="utf-8"))
+        assert pf.metadata.type == "DataPipeline"
+        assert pf.metadata.display_name == "pl_sample"
+        assert pf.config.logical_id == "55555555-5555-5555-5555-555555555555"

--- a/tests/items/test_normalize.py
+++ b/tests/items/test_normalize.py
@@ -34,6 +34,9 @@ class TestRuleFor:
             ("sm.SemanticModel/definition/model.tmdl", "\n", False),
             ("sm.SemanticModel/definition/tables/dim_x.tmdl", "\n", False),
             ("rpt.Report/report.json", "\n", False),
+            # DataPipeline — LF, no trailing newline
+            ("pl.DataPipeline/pipeline-content.json", "\n", False),
+            ("pl.DataPipeline/.platform", "\n", False),
             ("any/random/file.txt", "\n", False),
         ],
     )
@@ -189,3 +192,22 @@ class TestNormalizeTree:
         result = normalize_tree(tmp_path, extra_globs=["custom.dir/*.txt"])
         assert custom in result.changed
         assert custom.read_bytes() == b"hello"
+
+    def test_covers_datapipeline(self, tmp_path: Path):
+        # DataPipeline artifacts must be picked up by ARTIFACT_GLOBS and
+        # normalized to LF + no trailing newline (CRLF and a trailing newline
+        # both get fixed). Without the *.DataPipeline globs the pipeline flaps
+        # on every git-sync.
+        pl = tmp_path / "pl.DataPipeline"
+        pl.mkdir()
+        (pl / ".platform").write_bytes(b'{"k": "v"}\r\n')
+        (pl / "pipeline-content.json").write_bytes(
+            b'{\r\n  "properties": {\r\n    "activities": []\r\n  }\r\n}\r\n'
+        )
+        result = normalize_tree(tmp_path)
+        assert (pl / ".platform") in result.changed
+        assert (pl / "pipeline-content.json") in result.changed
+        assert (pl / ".platform").read_bytes() == b'{"k": "v"}'
+        assert (pl / "pipeline-content.json").read_bytes() == (
+            b'{\n  "properties": {\n    "activities": []\n  }\n}'
+        )

--- a/tests/items/test_normalize.py
+++ b/tests/items/test_normalize.py
@@ -31,8 +31,7 @@ class TestRuleFor:
             # LF + no trailing — defaults
             ("sm.SemanticModel/.platform", "\n", False),
             ("sm.SemanticModel/definition.pbism", "\n", False),
-            ("sm.SemanticModel/definition/model.tmdl", "\n", False),
-            ("sm.SemanticModel/definition/tables/dim_x.tmdl", "\n", False),
+            ("sm.SemanticModel/definition/diagramLayout.json", "\n", False),
             ("rpt.Report/report.json", "\n", False),
             # DataPipeline — LF, no trailing newline
             ("pl.DataPipeline/pipeline-content.json", "\n", False),
@@ -44,6 +43,24 @@ class TestRuleFor:
         rule = rule_for(rel_path)
         assert rule.line_ending == expected_eol
         assert rule.trailing_newline is expected_trailing
+        assert rule.trailing_blank_line is False
+
+    @pytest.mark.parametrize(
+        "rel_path",
+        [
+            # fnmatch's bare ``*`` spans ``/``, so the one glob covers TMDL at the
+            # top of ``definition/`` AND nested under ``tables/``.
+            "sm.SemanticModel/definition/model.tmdl",
+            "sm.SemanticModel/definition/database.tmdl",
+            "sm.SemanticModel/definition/tables/dim_x.tmdl",
+            "sm.SemanticModel/definition/cultures/en-US.tmdl",
+        ],
+    )
+    def test_tmdl_is_lf_trailing_blank_line(self, rel_path):
+        # Fabric ends every SemanticModel TMDL with a trailing blank line.
+        rule = rule_for(rel_path)
+        assert rule.line_ending == "\n"
+        assert rule.trailing_blank_line is True
 
 
 # ── canonical_bytes ─────────────────────────────────────────────────────────
@@ -51,10 +68,36 @@ class TestRuleFor:
 
 class TestCanonicalBytes:
     def test_lf_no_trailing_default(self):
-        # A SemanticModel TMDL with CRLF + trailing LF should drop both.
+        # A default-rule artifact (here a .pbism) with CRLF + trailing LF should
+        # drop both — LF, no trailing newline.
+        raw = b"model Model\r\n\tculture: en-US\r\n"
+        out = canonical_bytes("sm.SemanticModel/definition.pbism", raw)
+        assert out == b"model Model\n\tculture: en-US"
+
+    def test_tmdl_ends_with_trailing_blank_line(self):
+        # Fabric writes SemanticModel TMDL ending in a blank line ("\n\n").
         raw = b"model Model\r\n\tculture: en-US\r\n"
         out = canonical_bytes("sm.SemanticModel/definition/model.tmdl", raw)
-        assert out == b"model Model\n\tculture: en-US"
+        assert out == b"model Model\n\tculture: en-US\n\n"
+
+    def test_tmdl_fabric_output_is_fixed_point(self):
+        # The anti-flap guarantee: Fabric's own output must normalize to itself,
+        # otherwise the file flaps on every git-sync cycle.
+        raw = b"model Model\n\tculture: en-US\n\n"
+        assert canonical_bytes("sm.SemanticModel/definition/model.tmdl", raw) == raw
+
+    def test_tmdl_single_newline_gets_blank_line(self):
+        # A one-trailing-newline TMDL (e.g. a hand-assembled or tool-written file)
+        # is drifted and must gain the second newline.
+        raw = b"table t\n"
+        out = canonical_bytes("sm.SemanticModel/definition/tables/t.tmdl", raw)
+        assert out == b"table t\n\n"
+
+    def test_tmdl_nested_path_gets_blank_line(self):
+        # fnmatch ``*`` spans ``/`` so nested tables/ files match the TMDL rule.
+        raw = b"table dim_x"
+        out = canonical_bytes("sm.SemanticModel/definition/tables/dim_x.tmdl", raw)
+        assert out == b"table dim_x\n\n"
 
     def test_notebook_lf_with_trailing(self):
         raw = b"# cell 1\r\nprint('hi')"  # missing trailing newline + CRLF
@@ -91,9 +134,9 @@ class TestCanonicalBytes:
         assert out == raw
 
     def test_handles_mixed_line_endings(self):
-        # \r\n and \n in the same file
+        # \r\n and \n in the same file — default rule (.pbism): LF, no trailing.
         raw = b"a\r\nb\nc\r\n"
-        out = canonical_bytes("sm.SemanticModel/definition/model.tmdl", raw)
+        out = canonical_bytes("sm.SemanticModel/definition.pbism", raw)
         assert out == b"a\nb\nc"
 
 
@@ -111,8 +154,9 @@ class TestWriteArtifactFile:
     def test_writes_without_workspace_root_uses_ancestor(self, tmp_path: Path):
         sm = tmp_path / "sm.SemanticModel" / "definition" / "model.tmdl"
         write_artifact_file(sm, "model M\r\n\tculture: en-US\r\n")
-        # LF, no trailing newline
-        assert sm.read_bytes() == b"model M\n\tculture: en-US"
+        # Ancestor resolution finds the .SemanticModel folder, so the TMDL rule
+        # fires: LF + trailing blank line.
+        assert sm.read_bytes() == b"model M\n\tculture: en-US\n\n"
 
     def test_creates_parent_dirs(self, tmp_path: Path):
         deep = tmp_path / "sm.SemanticModel" / "definition" / "tables" / "x.tmdl"
@@ -123,7 +167,7 @@ class TestWriteArtifactFile:
     def test_accepts_bytes(self, tmp_path: Path):
         f = tmp_path / "sm.SemanticModel" / "definition" / "model.tmdl"
         write_artifact_file(f, b"model M\r\n")
-        assert f.read_bytes() == b"model M"
+        assert f.read_bytes() == b"model M\n\n"
 
 
 # ── is_canonical ────────────────────────────────────────────────────────────
@@ -156,7 +200,7 @@ class TestNormalizeTree:
         result = normalize_tree(tmp_path)
         assert len(result.changed) == 2
         assert (sm / ".platform").read_bytes() == b'{"k": "v"}'
-        assert (sm / "definition" / "model.tmdl").read_bytes() == b"model M"
+        assert (sm / "definition" / "model.tmdl").read_bytes() == b"model M\n\n"
 
     def test_dry_run_does_not_write(self, tmp_path: Path):
         sm = tmp_path / "sm.SemanticModel" / "definition"

--- a/tests/items/test_semantic_model.py
+++ b/tests/items/test_semantic_model.py
@@ -320,20 +320,27 @@ class TestSaveToDisk:
         assert "fromColumn: fact_status.section_key" in text
         assert "toColumn: dim_section.section_key" in text
 
-    def test_files_use_lf_no_trailing_newline(
+    def test_files_use_fabric_byte_conventions(
         self, minimal_model: SemanticModel, tmp_path: Path
     ) -> None:
-        # All TMDL/JSON in a SemanticModel: LF, no trailing newline.
+        # LF everywhere; .platform/.pbism have no trailing newline, but TMDL
+        # ends with a trailing BLANK line ("\n\n") to match Fabric git-sync.
         item_dir = minimal_model.save_to_disk(tmp_path)
         for p in [
             item_dir / ".platform",
             item_dir / "definition.pbism",
+        ]:
+            raw = p.read_bytes()
+            assert b"\r\n" not in raw, f"{p.name} contains CRLF"
+            assert not raw.endswith(b"\n"), f"{p.name} has trailing newline"
+        for p in [
             item_dir / "definition" / "model.tmdl",
             item_dir / "definition" / "tables" / "fact_status.tmdl",
         ]:
             raw = p.read_bytes()
             assert b"\r\n" not in raw, f"{p.name} contains CRLF"
-            assert not raw.endswith(b"\n"), f"{p.name} has trailing newline"
+            assert raw.endswith(b"\n\n"), f"{p.name} missing trailing blank line"
+            assert not raw.endswith(b"\n\n\n"), f"{p.name} has extra blank lines"
 
     def test_lineage_tags_deterministic(
         self, minimal_model: SemanticModel, tmp_path: Path


### PR DESCRIPTION
## What

- **`DataPipelineBuilder`** (`src/pyfabric/items/datapipeline.py`) â€” a chainable
  builder for Fabric Data Pipeline artifacts that emits **Fabric's canonical
  `pipeline-content.json`**, so it round-trips cleanly through git-sync the first
  time. Hand-authored pipelines flap because Fabric re-serializes to a form that
  isn't obvious: `typeProperties.notebookId` is the referenced notebook's git
  **logicalId** (resolved from its `.platform`, not the workspace object id),
  `workspaceId` is zeroed, and activity/policy keys follow a fixed order.
  - `add_notebook_activity` / `add_semantic_model_refresh` / generic `add_activity`,
    `depends_on` success chains, parameter type inference, `to_pipeline_content` /
    `to_bundle` / `save_to_disk` (via `write_artifact_file`).
  - Validates activity names to Fabric's allowed charset (letters, numbers, `-`,
    `_`, space) â€” anything else raises before the pipeline reaches the portal.
  - `notebook_logical_id(notebook)` helper resolves a logicalId from a
    `.Notebook` dir / `.platform` / bare GUID.
- **normalize coverage for DataPipeline** â€” `ARTIFACT_GLOBS` gains
  `*.DataPipeline/.platform` + `pipeline-content.json`, `_ITEM_TYPES` gains
  `DataPipeline`. The catch-all `(LF, no trailing newline)` rule is already
  correct for both. Without these globs, `normalize_tree`/`lint_tree` skipped
  DataPipeline artifacts, so they flapped on every sync.
- Tests: a byte-equality test against a client-neutral canonical fixture (the
  real anti-flap guarantee), convention/validation tests, and normalize
  coverage for DataPipeline. Docs: `DataPipelineBuilder` added to `api.md`.

## Issues

- Closes #100 (DataPipeline builder).
- Addresses the **DataPipeline-globs** part of #99.
- The **TMDL trailing-newline** part of #99 is intentionally NOT here: evidence
  indicates the existing `(LF, no-trailing)` TMDL rule is **correct** (a
  Fabric-authored commit left no-trailing TMDL untouched; the trailing newline
  seen via `getItemDefinition` looks like an API artifact). Pending one more
  verification against a Fabric-authored `.tmdl` commit before deciding; the
  TMDL portion of #99 may be closed as invalid.

## Notes

- All ids in code/tests/fixtures are synthetic placeholders â€” no client
  identifiers.
- Pre-push hook green (ruff, ruff format, mypy, codespell, markdownlint, pytest).
- `pip-audit` flags `idna 3.11` (CVE-2026-45409, fix 3.15) â€” a **pre-existing
  transitive** dependency, not introduced by this change (it adds no deps).
  Worth a separate bump.

ðŸ¤– Generated with [Claude Code](https://claude.com/claude-code)

---

## Update: TMDL trailing blank-line fix (resolves the rest of #99)

Added the SemanticModel TMDL rule that was the other half of #99. Fabric
serializes every `*.SemanticModel/*.tmdl` ending in a trailing **blank line**
(`â€¦content\n\n`) â€” verified across two independent Fabric workspaces (26+
Fabric-authored `.tmdl` files; a description-only portal edit appends a lone
blank line to single-`\n` files). Previously TMDL fell to the catch-all
(LF, no trailing) and drifted from Fabric.

- `FileRule` gains an additive `trailing_blank_line: bool = False`
  (backward-compatible; supersedes `trailing_newline` when set).
- New `_RULES` entry `("*.SemanticModel/*.tmdl", "\n", False, True)` before the
  catch-all. (`fnmatch`'s bare `*` spans `/`, so one glob covers both
  `definition/model.tmdl` and `definition/tables/*.tmdl`; `**` does NOT work
  under fnmatch.)
- `canonical_bytes` collapses trailing blank lines before re-appending one, so
  Fabric's `\n\n` output is a fixed point.
- Tests: dedicated TMDL blank-line + fixed-point cases; generic default-rule
  tests moved off `.tmdl` onto `.pbism`; the SemanticModel builder byte test now
  asserts TMDL ends `\n\n` while `.platform`/`.pbism` stay no-trailing.

Closes #99.



> **Note on "tolerate":** a single-`
` TMDL has been *observed* sitting un-flagged in a workspace's git, but that's also consistent with Fabric not having re-serialized the model yet (lazy until a portal edit) — whether Fabric actively normalizes trailing newlines when diffing is **unconfirmed**. Only the emit side (`

`) is verified; matching it is correct regardless.