### PR TITLE
fix(logging): interpolate %-style positional args (#103)

### DIFF
--- a/src/pyfabric/logging.py
+++ b/src/pyfabric/logging.py
@@ -163,6 +163,13 @@ def setup_logging(
             structlog.contextvars.merge_contextvars,
             structlog.stdlib.add_log_level,
             structlog.stdlib.add_logger_name,
+            # Apply %-style positional args to the event message. Without this,
+            # `log.info("Target: %s/%s.%s", lh, schema, table)` is NOT interpolated:
+            # structlog leaves the format string verbatim and stashes the values in
+            # a `positional_args` field, so logs read "Target: %s/%s.%s" with the
+            # real values hidden. Must run before any processor that consumes the
+            # rendered message. (#103)
+            structlog.stdlib.PositionalArgumentsFormatter(),
             structlog.processors.TimeStamper(fmt="iso"),
             mask_tokens_processor,
             structlog.processors.StackInfoRenderer(),

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -118,3 +118,53 @@ class TestGetLogPath:
         path = get_log_path("my_script")
         assert "my_script" in path.name
         assert path.suffix == ".jsonl"
+
+
+class TestPositionalArgsInterpolation:
+    """#103: %-style positional args must be interpolated into the event message,
+    not left verbatim with the values stranded in a `positional_args` field."""
+
+    def test_percent_args_interpolated_not_stranded(self, tmp_path, monkeypatch):
+        import structlog
+
+        import pyfabric.logging as plog
+
+        monkeypatch.setattr(plog, "LOGS_DIR", tmp_path)
+        log_path = plog.setup_logging("posargs_test")
+        try:
+            # A library-style %-format call, exactly like data/lakehouse.py uses.
+            structlog.get_logger("test.posargs").info(
+                "Target: %s/%s.%s (%d rows, %d cols)", "lh", "dbo", "tbl", 5, 3
+            )
+            for h in logging.getLogger().handlers:
+                h.flush()
+            content = log_path.read_text(encoding="utf-8")
+        finally:
+            # Release the file handle so tmp_path can be cleaned on Windows.
+            root = logging.getLogger()
+            for h in list(root.handlers):
+                h.close()
+                root.removeHandler(h)
+
+        assert "Target: lh/dbo.tbl (5 rows, 3 cols)" in content
+        assert "positional_args" not in content
+        assert "%s" not in content
+
+    def test_formatter_is_in_configured_chain(self, tmp_path, monkeypatch):
+        import structlog
+
+        import pyfabric.logging as plog
+
+        monkeypatch.setattr(plog, "LOGS_DIR", tmp_path)
+        plog.setup_logging("posargs_chain")
+        try:
+            processors = structlog.get_config()["processors"]
+            assert any(
+                isinstance(p, structlog.stdlib.PositionalArgumentsFormatter)
+                for p in processors
+            ), "PositionalArgumentsFormatter missing from the processor chain (#103)"
+        finally:
+            root = logging.getLogger()
+            for h in list(root.handlers):
+                h.close()
+                root.removeHandler(h)


### PR DESCRIPTION
Closes #103.

## Problem

`setup_logging`'s structlog processor chain had no `PositionalArgumentsFormatter`, so a stdlib-style call such as:

```python
log.info("Target: %s/%s.%s (%d rows, %d cols)", lh, schema, table, n_rows, n_cols)
```

was **never interpolated**. structlog left the format string verbatim and stranded the values in a `positional_args` field, so the rendered line read `Target: %s/%s.%s (%d rows, %d cols)` with the real values hidden in a side field — hard to read in console and file output alike.

## Fix

Add `structlog.stdlib.PositionalArgumentsFormatter()` to the processor chain (before the processors that consume the rendered message). One line fixes **every** `%`-style call site across the library (~55 of them) at once, with no per-call changes — the approach recommended in the issue.

## Tests

- End-to-end: configure logging, emit a `%`-format call, assert the output contains the interpolated text and **no** `positional_args` / `%s` leakage.
- Chain-presence guard: assert `PositionalArgumentsFormatter` is in the configured processors.

## Pre-checkin

`ruff check` / `ruff format --check` / `mypy` clean; `pytest` 831 passed, 4 skipped (live-workspace e2e).

> Note: `pip-audit` reports 5 **pre-existing** transitive-dependency advisories (`idna 3.11` → CVE-2026-45409; `pyjwt 2.12.1` → 4 PYSECs) unrelated to this change — this PR touches no dependencies. They warrant a separate hash-pinned dep-bump PR.