### PR TITLE
feat(items): run_notebook (jobs) + refresh_semantic_model helpers

### DIFF
--- a/src/pyfabric/client/auth.py
+++ b/src/pyfabric/client/auth.py
@@ -36,6 +36,9 @@ log = structlog.get_logger()
 FABRIC_RESOURCE = "https://api.fabric.microsoft.com"
 STORAGE_RESOURCE = "https://storage.azure.com"
 SQL_RESOURCE = "https://database.windows.net"
+# Power BI REST (semantic-model refresh and other dataset operations live on the
+# Power BI host with its own audience, distinct from the Fabric API).
+PBI_RESOURCE = "https://analysis.windows.net/powerbi/api"
 
 # Token refresh before expiry (seconds)
 _REFRESH_MARGIN = 300  # 5 minutes before expiry
@@ -216,6 +219,11 @@ class FabricCredential:
     def sql_token(self) -> str:
         """Token for SQL analytics endpoint (database.windows.net)."""
         return self.get_token(SQL_RESOURCE)
+
+    @property
+    def powerbi_token(self) -> str:
+        """Token for the Power BI REST API (semantic-model refresh, etc.)."""
+        return self.get_token(PBI_RESOURCE)
 
     def account_info(self) -> dict:
         """Return current az account info, or {} if unavailable."""

--- a/src/pyfabric/items/jobs.py
+++ b/src/pyfabric/items/jobs.py
@@ -1,0 +1,155 @@
+"""Run an item's on-demand job via the Fabric Jobs API.
+
+Triggers a job for a workspace item — a notebook today (``jobType=RunNotebook``),
+any item via :func:`run_on_demand` — and, by default, polls to completion.
+
+The Jobs API LRO reports terminal status as ``"Completed"`` / ``"Failed"`` /
+``"Cancelled"`` (with a ``failureReason`` payload), not the standard
+``"Succeeded"``. So, like :meth:`pyfabric.client.graph.GraphClient.refresh`, we
+submit with :meth:`FabricClient.raw_request` and poll the job instance manually
+rather than relying on ``post()`` / ``_poll_lro``. Pass ``on_progress`` to surface
+live status during long runs.
+
+Usage::
+
+    from pyfabric.client.http import FabricClient
+    from pyfabric.items.jobs import run_notebook
+
+    client = FabricClient()
+    run_notebook(
+        client,
+        ws_id,
+        notebook_id,
+        parameters={"folder": "2026-06"},
+        on_progress=lambda s: print("status:", s),
+    )
+"""
+
+from __future__ import annotations
+
+import time
+from collections.abc import Callable, Mapping
+from typing import Any
+
+import structlog
+
+from pyfabric.client.http import FabricClient, FabricError
+
+log = structlog.get_logger()
+
+OnProgress = Callable[[str], None] | None
+
+_TERMINAL = ("Completed", "Failed", "Cancelled")
+
+
+def run_on_demand(
+    client: FabricClient,
+    workspace_id: str,
+    item_id: str,
+    job_type: str,
+    *,
+    execution_data: dict[str, Any] | None = None,
+    wait: bool = True,
+    poll_interval: int = 15,
+    on_progress: OnProgress = None,
+) -> dict[str, Any]:
+    """Trigger an on-demand job for an item; wait for it unless ``wait=False``.
+
+    Args:
+        job_type:        Fabric job type, e.g. ``"RunNotebook"``.
+        execution_data:  Optional body for the job (``executionData``), e.g.
+                         notebook parameters. Sent as ``{"executionData": ...}``.
+        wait:            Poll to completion (default). When ``False``, returns
+                         immediately with ``{"status": "Accepted", "location": ...}``.
+        poll_interval:   Seconds between polls (clamped against the server's
+                         ``Retry-After``).
+        on_progress:     Optional ``callback(status)`` invoked on each poll.
+
+    Returns the final job-instance body. Raises :class:`RuntimeError` on a
+    ``Failed`` / ``Cancelled`` outcome (message taken from ``failureReason``).
+    """
+    url = client._build_url(
+        f"workspaces/{workspace_id}/items/{item_id}/jobs/instances",
+        params={"jobType": job_type},
+    )
+    body = {"executionData": execution_data} if execution_data else None
+    resp = client.raw_request("POST", url, body)
+
+    if resp.status_code in (200, 201):
+        if on_progress:
+            on_progress("Completed")
+        return resp.json() if resp.text else {"status": "Completed"}
+
+    if resp.status_code != 202:
+        raise FabricError(resp.status_code, resp.text, url)
+
+    location = resp.headers.get("Location")
+    if not location:
+        raise RuntimeError(f"202 from {url} has no Location header")
+    retry_after = int(resp.headers.get("Retry-After", poll_interval))
+    if not wait:
+        return {"status": "Accepted", "location": location}
+
+    while True:
+        time.sleep(retry_after)
+        poll = client.raw_request("GET", location)
+        instance = poll.json() if poll.text else {}
+        status = instance.get("status", "Unknown")
+        if on_progress:
+            on_progress(status)
+        log.debug("job_status", item_id=item_id, job_type=job_type, status=status)
+
+        if status in _TERMINAL:
+            if status == "Completed" and not instance.get("failureReason"):
+                return instance
+            reason = instance.get("failureReason") or {}
+            msg = reason.get("message") or str(reason) if reason else status
+            raise RuntimeError(f"Job {status}: {msg}")
+        retry_after = min(retry_after, poll_interval)
+
+
+def _param_type(value: Any) -> str:
+    if isinstance(value, bool):
+        return "bool"
+    if isinstance(value, int):
+        return "int"
+    if isinstance(value, float):
+        return "float"
+    return "string"
+
+
+def run_notebook(
+    client: FabricClient,
+    workspace_id: str,
+    notebook_id: str,
+    *,
+    parameters: Mapping[str, Any] | None = None,
+    wait: bool = True,
+    poll_interval: int = 15,
+    on_progress: OnProgress = None,
+) -> dict[str, Any]:
+    """Trigger an on-demand notebook run (``jobType=RunNotebook``).
+
+    ``parameters`` (``{name: value}``) are injected into the notebook's
+    parameters cell via the Jobs API ``executionData.parameters`` — the
+    injection target ``NotebookBuilder.add_parameters_cell`` emits a cell for.
+    Each value's Fabric param ``type`` is inferred (bool/int/float/string).
+    """
+    execution_data: dict[str, Any] | None = None
+    if parameters:
+        execution_data = {
+            "parameters": {
+                name: {"value": value, "type": _param_type(value)}
+                for name, value in parameters.items()
+            }
+        }
+    return run_on_demand(
+        client,
+        workspace_id,
+        notebook_id,
+        "RunNotebook",
+        execution_data=execution_data,
+        wait=wait,
+        poll_interval=poll_interval,
+        on_progress=on_progress,
+    )

--- a/src/pyfabric/items/refresh.py
+++ b/src/pyfabric/items/refresh.py
@@ -1,0 +1,122 @@
+"""Refresh a semantic model via the Power BI enhanced-refresh REST API.
+
+Semantic-model refresh does not live on the Fabric API — it's the Power BI host
+(``api.powerbi.com``) with a Power-BI-scoped token (:data:`PBI_RESOURCE`),
+distinct from the Fabric token :class:`FabricClient` uses. So this takes a
+:class:`FabricCredential` directly and issues its own requests, polling the
+refresh status (``"Completed"`` / ``"Failed"`` / …) much like
+:meth:`pyfabric.client.graph.GraphClient.refresh`.
+
+In a Fabric workspace the workspace id doubles as the Power BI *group* id and the
+semantic-model item id doubles as the *dataset* id.
+
+Usage::
+
+    from pyfabric.client.auth import FabricCredential
+    from pyfabric.items.refresh import refresh_semantic_model
+
+    refresh_semantic_model(
+        FabricCredential(),
+        ws_id,
+        dataset_id,
+        on_progress=lambda s: print("refresh:", s),
+    )
+
+The model's datasource credentials must be bound once in the portal before the
+first refresh (the standard Lakehouse/SQL credential-binding step).
+"""
+
+from __future__ import annotations
+
+import time
+from collections.abc import Callable
+from typing import Any
+
+import requests
+import structlog
+
+from pyfabric.client.auth import PBI_RESOURCE, FabricCredential
+
+log = structlog.get_logger()
+
+OnProgress = Callable[[str], None] | None
+
+_PBI_BASE = "https://api.powerbi.com/v1.0/myorg"
+_IN_PROGRESS = ("Unknown", "NotStarted", "InProgress")
+_FAILED = ("Failed", "Disabled", "Cancelled")
+
+
+def refresh_semantic_model(
+    credential: FabricCredential,
+    workspace_id: str,
+    dataset_id: str,
+    *,
+    refresh_type: str = "full",
+    wait: bool = True,
+    poll_interval: int = 15,
+    timeout: int = 1800,
+    on_progress: OnProgress = None,
+) -> dict[str, Any]:
+    """Trigger an enhanced refresh of a semantic model; wait unless ``wait=False``.
+
+    Args:
+        workspace_id:   Workspace id (= Power BI group id).
+        dataset_id:     Semantic-model item id (= Power BI dataset id).
+        refresh_type:   Power BI refresh type (``"full"``, ``"automatic"``, ...).
+        wait:           Poll to completion (default). ``False`` returns
+                        ``{"status": "Accepted", "requestId": ...}`` immediately.
+        poll_interval:  Seconds between status polls.
+        timeout:        Max seconds to wait before raising :class:`TimeoutError`.
+        on_progress:    Optional ``callback(status)`` invoked on each poll.
+
+    Returns the final refresh record. Raises :class:`RuntimeError` on a failed
+    refresh and :class:`TimeoutError` if it doesn't finish within ``timeout``.
+    """
+    token = credential.get_token(PBI_RESOURCE)
+    base = f"{_PBI_BASE}/groups/{workspace_id}/datasets/{dataset_id}/refreshes"
+    session = requests.Session()
+    session.headers.update(
+        {"Authorization": f"Bearer {token}", "Content-Type": "application/json"}
+    )
+
+    # A request body makes this an *enhanced* (async, trackable) refresh.
+    resp = session.post(base, json={"type": refresh_type})
+    if resp.status_code not in (200, 202):
+        raise RuntimeError(
+            f"semantic-model refresh POST failed: {resp.status_code} {resp.text}"
+        )
+
+    location = resp.headers.get("Location", "")
+    request_id = resp.headers.get("RequestId") or (
+        location.rstrip("/").rsplit("/", 1)[-1] if location else None
+    )
+    if not wait:
+        return {"status": "Accepted", "requestId": request_id}
+
+    deadline = time.monotonic() + timeout
+    while True:
+        time.sleep(poll_interval)
+        if request_id:
+            r = session.get(f"{base}/{request_id}")
+            record = r.json() if r.text else {}
+        else:
+            r = session.get(base, params={"$top": 1})
+            values = (r.json() if r.text else {}).get("value", [])
+            record = values[0] if values else {}
+        status = record.get("status", "Unknown")
+        if on_progress:
+            on_progress(status)
+        log.debug("refresh_status", dataset_id=dataset_id, status=status)
+
+        if status == "Completed":
+            return record
+        if status in _FAILED:
+            detail = record.get("serviceExceptionJson") or record.get("error") or status
+            raise RuntimeError(f"semantic-model refresh {status}: {detail}")
+        if status not in _IN_PROGRESS:
+            log.debug("refresh_status_unrecognized", status=status)
+        if time.monotonic() > deadline:
+            raise TimeoutError(
+                f"semantic-model refresh did not finish within {timeout}s "
+                f"(last status {status!r})"
+            )

--- a/tests/items/test_jobs.py
+++ b/tests/items/test_jobs.py
@@ -1,0 +1,102 @@
+"""Tests for the Jobs API helpers (run_on_demand / run_notebook)."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from pyfabric.items.jobs import _param_type, run_notebook, run_on_demand
+
+
+def _client(responses: list) -> MagicMock:
+    """A mock FabricClient whose ``raw_request`` yields ``responses`` in order."""
+    c = MagicMock()
+    c._build_url = lambda path, params=None: f"https://api/{path}?{params}"
+    c.raw_request.side_effect = responses
+    return c
+
+
+class TestRunOnDemand:
+    def test_waits_for_completion_and_reports_progress(self, mock_http_response):
+        mk = mock_http_response
+        client = _client(
+            [
+                mk(
+                    202,
+                    headers={"Location": "https://api/inst/JID", "Retry-After": "0"},
+                ),
+                mk(200, {"status": "InProgress"}),
+                mk(200, {"status": "Completed", "id": "JID"}),
+            ]
+        )
+        seen: list[str] = []
+        result = run_on_demand(
+            client,
+            "WS",
+            "ITEM",
+            "RunNotebook",
+            poll_interval=0,
+            on_progress=seen.append,
+        )
+        assert result["status"] == "Completed"
+        assert seen == ["InProgress", "Completed"]
+
+    def test_sync_200_returns_immediately(self, mock_http_response):
+        client = _client([mock_http_response(200, {"status": "Completed"})])
+        assert (
+            run_on_demand(client, "WS", "ITEM", "RunNotebook")["status"] == "Completed"
+        )
+
+    def test_failed_raises_with_failure_reason(self, mock_http_response):
+        mk = mock_http_response
+        client = _client(
+            [
+                mk(202, headers={"Location": "L", "Retry-After": "0"}),
+                mk(200, {"status": "Failed", "failureReason": {"message": "boom"}}),
+            ]
+        )
+        with pytest.raises(RuntimeError, match="boom"):
+            run_on_demand(client, "WS", "ITEM", "RunNotebook", poll_interval=0)
+
+    def test_no_wait_returns_location(self, mock_http_response):
+        client = _client([mock_http_response(202, headers={"Location": "LOC"})])
+        out = run_on_demand(client, "WS", "ITEM", "RunNotebook", wait=False)
+        assert out == {"status": "Accepted", "location": "LOC"}
+
+    def test_202_without_location_raises(self, mock_http_response):
+        client = _client([mock_http_response(202, headers={})])
+        with pytest.raises(RuntimeError, match="no Location"):
+            run_on_demand(client, "WS", "ITEM", "RunNotebook")
+
+
+class TestRunNotebook:
+    def test_injects_typed_parameters(self, mock_http_response):
+        client = _client([mock_http_response(200, {"status": "Completed"})])
+        run_notebook(
+            client, "WS", "NB", parameters={"folder": "x", "n": 3, "flag": True}
+        )
+        method, _url, body = client.raw_request.call_args[0]
+        assert method == "POST"
+        params = body["executionData"]["parameters"]
+        assert params["folder"] == {"value": "x", "type": "string"}
+        assert params["n"] == {"value": 3, "type": "int"}
+        assert params["flag"] == {"value": True, "type": "bool"}
+
+    def test_no_parameters_sends_no_body(self, mock_http_response):
+        client = _client([mock_http_response(200, {"status": "Completed"})])
+        run_notebook(client, "WS", "NB")
+        assert client.raw_request.call_args[0][2] is None
+
+    def test_uses_run_notebook_job_type(self, mock_http_response):
+        client = _client([mock_http_response(200, {"status": "Completed"})])
+        run_notebook(client, "WS", "NB")
+        url = client.raw_request.call_args[0][1]
+        assert "RunNotebook" in url and "items/NB/jobs/instances" in url
+
+
+def test_param_type():
+    assert _param_type(True) == "bool"
+    assert _param_type(3) == "int"
+    assert _param_type(3.5) == "float"
+    assert _param_type("x") == "string"

--- a/tests/items/test_refresh.py
+++ b/tests/items/test_refresh.py
@@ -1,0 +1,89 @@
+"""Tests for refresh_semantic_model (Power BI enhanced refresh)."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from pyfabric.items.refresh import refresh_semantic_model
+
+
+def _session(post_resp, get_responses) -> MagicMock:
+    s = MagicMock()
+    s.post.return_value = post_resp
+    s.get.side_effect = get_responses
+    return s
+
+
+def _patch_session(monkeypatch, session: MagicMock) -> None:
+    monkeypatch.setattr("pyfabric.items.refresh.requests.Session", lambda: session)
+
+
+class TestRefreshSemanticModel:
+    def test_waits_for_completion_and_reports_progress(
+        self, monkeypatch, mock_credential, mock_http_response
+    ):
+        mk = mock_http_response
+        session = _session(
+            mk(202, headers={"RequestId": "RID"}),
+            [mk(200, {"status": "Unknown"}), mk(200, {"status": "Completed"})],
+        )
+        _patch_session(monkeypatch, session)
+        seen: list[str] = []
+        out = refresh_semantic_model(
+            mock_credential, "WS", "DS", poll_interval=0, on_progress=seen.append
+        )
+        assert out["status"] == "Completed"
+        assert seen == ["Unknown", "Completed"]
+        # polled the specific request id
+        assert "RID" in session.get.call_args[0][0]
+
+    def test_failed_raises(self, monkeypatch, mock_credential, mock_http_response):
+        mk = mock_http_response
+        session = _session(
+            mk(202, headers={"RequestId": "RID"}),
+            [mk(200, {"status": "Failed", "serviceExceptionJson": "err"})],
+        )
+        _patch_session(monkeypatch, session)
+        with pytest.raises(RuntimeError, match="Failed"):
+            refresh_semantic_model(mock_credential, "WS", "DS", poll_interval=0)
+
+    def test_no_wait_returns_request_id(
+        self, monkeypatch, mock_credential, mock_http_response
+    ):
+        session = _session(mock_http_response(202, headers={"RequestId": "RID"}), [])
+        _patch_session(monkeypatch, session)
+        out = refresh_semantic_model(mock_credential, "WS", "DS", wait=False)
+        assert out == {"status": "Accepted", "requestId": "RID"}
+
+    def test_post_failure_raises(
+        self, monkeypatch, mock_credential, mock_http_response
+    ):
+        session = _session(mock_http_response(400, text="bad request"), [])
+        _patch_session(monkeypatch, session)
+        with pytest.raises(RuntimeError, match="refresh POST failed"):
+            refresh_semantic_model(mock_credential, "WS", "DS")
+
+    def test_request_id_falls_back_to_location(
+        self, monkeypatch, mock_credential, mock_http_response
+    ):
+        mk = mock_http_response
+        session = _session(
+            mk(202, headers={"Location": "https://api/.../refreshes/FROMLOC"}),
+            [mk(200, {"status": "Completed"})],
+        )
+        _patch_session(monkeypatch, session)
+        refresh_semantic_model(mock_credential, "WS", "DS", poll_interval=0)
+        assert "FROMLOC" in session.get.call_args[0][0]
+
+    def test_uses_powerbi_token(self, monkeypatch, mock_credential, mock_http_response):
+        session = _session(
+            mock_http_response(202, headers={"RequestId": "RID"}),
+            [mock_http_response(200, {"status": "Completed"})],
+        )
+        _patch_session(monkeypatch, session)
+        refresh_semantic_model(mock_credential, "WS", "DS", poll_interval=0)
+        # Authorization header set from the credential's Power BI token
+        auth = session.headers.update.call_args[0][0]["Authorization"]
+        assert auth.startswith("Bearer ")


### PR DESCRIPTION
Closes #105.

Adds the two runtime helpers needed to orchestrate a **git-sync → run-notebook → refresh-model** deployment from Python, each with an optional `on_progress(status)` callback for live tracking. Composes with the existing `GitClient.sync_workspace` and `items.crud.list_items`.

### `items/jobs.py`
- `run_on_demand(client, ws, item_id, job_type, *, execution_data=None, wait=True, poll_interval=15, on_progress=None)` — submits a Fabric Jobs API on-demand job and polls the instance to completion. The Jobs LRO reports `"Completed"`/`"Failed"`/`"Cancelled"` (with `failureReason`), not `"Succeeded"`, so it uses `raw_request` + manual polling, mirroring `GraphClient.refresh`.
- `run_notebook(client, ws, notebook_id, *, parameters=None, ...)` — the `jobType=RunNotebook` convenience, mapping `parameters` to `executionData.parameters` (the injection target #78's `add_parameters_cell` emits a cell for; types inferred bool/int/float/string).
- Revisits #66: its `_poll_lro` `"Completed"` fix landed, but the helper itself never did.

### `items/refresh.py`
- `refresh_semantic_model(credential, ws, dataset_id, *, refresh_type="full", wait=True, poll_interval=15, timeout=1800, on_progress=None)` — Power BI enhanced refresh. Different host (`api.powerbi.com`) + a Power-BI-scoped token, so it takes a `FabricCredential` and runs its own polling.

### `client/auth.py`
- `PBI_RESOURCE` constant + `FabricCredential.powerbi_token` property.

### Tests / checks
- 15 unit tests (mocked transport): wait-to-completion + progress callback, sync-200, failure surfacing, no-wait, missing-Location, parameter typing/injection; refresh completion/failure/no-wait/post-failure/location-fallback/token.
- Full pre-checkin green locally: `ruff check`, `ruff format`, `mypy` (51 files), `pytest` (846 passed / 4 e2e skipped).

> Note (separate, pre-existing): `pip-audit` flags `pyjwt 2.12.1` (PYSEC-2026-175/177/178/179, fixed in 2.13.0) via `azure-identity → msal`. Not introduced here; worth a separate dependency bump.