### PR TITLE
fix(deps): floor pyjwt>=2.13.0 to resolve PYSEC-2026-175/177/178/179

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,12 @@ pyfabric = "pyfabric.testing.plugin"
 azure = [
     "azure-identity>=1.17",
     "requests>=2.32",
+    # pyjwt is pulled in transitively via azure-identity -> msal. msal's
+    # own constraint (PyJWT[crypto]>=1.0.0,<3) allows versions affected by
+    # PYSEC-2026-175/177/178/179 (algorithm-confusion / unbounded JWKS
+    # fetch; fixed in 2.13.0). Floor it here so a fresh install resolves a
+    # patched pyjwt rather than the highest msal-permitted release.
+    "pyjwt>=2.13.0",
 ]
 data = [
     "pyodbc>=5.1",


### PR DESCRIPTION
## Summary

`pip-audit` flags **pyjwt 2.12.1** for four advisories — PYSEC-2026-175 / 177 / 178 / 179 (algorithm-confusion bypass and unbounded JWKS-endpoint fetch), all fixed in **2.13.0**.

pyjwt is not a direct dependency; it arrives transitively via `azure-identity → msal`. msal's own constraint (`PyJWT[crypto]>=1.0.0,<3`) permits the affected versions — even the latest msal does not force a patched pyjwt — so a fresh install of the `azure` extra resolved 2.12.1.

## Change

Add an explicit `pyjwt>=2.13.0` floor to the `azure` optional-dependency group (where `azure-identity` already lives), so installs resolve a patched release. Minimal, version-floor only — consistent with the repo's supply-chain stance.

## Verification (`.venv`)

- `pip install -e .[dev]` → upgraded pyjwt 2.12.1 → 2.13.0
- `pip-audit` → no pyjwt advisories remain (pre-existing `idna` / `pip` findings are unrelated to this change and not pyfabric deps)
- `ruff check` ✅ · `ruff format --check` ✅ · `mypy src/pyfabric` ✅ (no issues, 51 files) · `pytest` ✅ (846 passed, 4 skipped)

Closes #N/A — supply-chain maintenance.