### PR TITLE
fix(report): emit Fabric-canonical report.json/.platform (no git-sync flap)

### DIFF
--- a/src/pyfabric/items/report.py
+++ b/src/pyfabric/items/report.py
@@ -80,6 +80,7 @@ Usage::
 """
 
 import json
+import re
 import uuid
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -90,6 +91,44 @@ import structlog
 from pyfabric.items.normalize import write_artifact_file
 
 log = structlog.get_logger()
+
+
+# ── Internal: 2-decimal float serialization ────────────────────────────────
+#
+# Fabric writes the *structured top-level* layout fields of a section /
+# visualContainer (``width`` / ``height`` / ``x`` / ``y`` / ``z``) as
+# 2-decimal floats — ``720.00``, ``16.00``, ``0.00`` — not ``720`` or
+# ``0.0``. ``json.dumps(720.0)`` yields ``720.0``, so we can't get there
+# with the stdlib encoder directly. The numbers embedded inside the
+# escaped ``config`` string must stay exactly as the builder writes them,
+# so a blanket regex over the whole document is unsafe.
+#
+# Approach: wrap only those five values in ``_Float2``; a custom encoder
+# emits a unique quoted token for each; a single post-pass unquotes the
+# tokens. The token only ever appears for wrapped values, so the config
+# string is never touched.
+
+
+@dataclass(frozen=True)
+class _Float2:
+    """Marker for a layout number that must serialize as ``N.00``."""
+
+    value: float
+
+
+_F2_TOKEN = re.compile(r'"@@F2:(-?\d+\.\d{2})@@"')
+
+
+class _Float2Encoder(json.JSONEncoder):
+    def default(self, o: Any) -> Any:
+        if isinstance(o, _Float2):
+            return f"@@F2:{o.value:.2f}@@"
+        return super().default(o)
+
+
+def _dumps_with_float2(payload: dict[str, Any]) -> str:
+    text = json.dumps(payload, indent=2, cls=_Float2Encoder)
+    return _F2_TOKEN.sub(r"\1", text)
 
 
 # ── Public types ────────────────────────────────────────────────────────────
@@ -465,13 +504,18 @@ class Report:
     # ── File emitters ──────────────────────────────────────────────────────
 
     def _emit_platform(self) -> str:
+        # NB: no ``description`` for a Report ``.platform``. Fabric strips
+        # it on first git-sync (observed even for a short ~68-char one),
+        # which causes a no-op byte-flap commit. The ``Report.description``
+        # field and ``strict_descriptions`` validation are kept — the
+        # description still surfaces to authors at build time — it just
+        # isn't emitted into the (non-retaining) Report .platform.
         return json.dumps(
             {
                 "$schema": "https://developer.microsoft.com/json-schemas/fabric/gitIntegration/platformProperties/2.0.0/schema.json",
                 "metadata": {
                     "type": "Report",
                     "displayName": self.name,
-                    **({"description": self.description} if self.description else {}),
                 },
                 "config": {"version": "2.0", "logicalId": self.logical_id},
             },
@@ -527,14 +571,12 @@ class Report:
                     },
                 }
             }
-        payload: dict[str, Any] = {
-            "config": json.dumps(report_config),
-            "layoutOptimization": 0,
-            "pods": [_emit_pod(p, i) for i, p in enumerate(self.pages)],
-            "sections": [_emit_section(p) for p in self.pages],
-        }
+        # ``resourcePackages`` is always present (Fabric adds a top-level
+        # ``"resourcePackages": []`` even when there's no theme) and sits
+        # between ``pods`` and ``sections`` in Fabric's canonical key order.
+        resource_packages: list[dict[str, Any]] = []
         if self.theme is not None:
-            payload["resourcePackages"] = [
+            resource_packages = [
                 {
                     "resourcePackage": {
                         "disabled": False,
@@ -550,7 +592,14 @@ class Report:
                     }
                 }
             ]
-        return json.dumps(payload, indent=2)
+        payload: dict[str, Any] = {
+            "config": json.dumps(report_config),
+            "layoutOptimization": 0,
+            "pods": [_emit_pod(p, i) for i, p in enumerate(self.pages)],
+            "resourcePackages": resource_packages,
+            "sections": [_emit_section(p) for p in self.pages],
+        }
+        return _dumps_with_float2(payload)
 
 
 # ── Internal: id helpers ───────────────────────────────────────────────────
@@ -591,16 +640,26 @@ def _emit_pod(page: Page, index: int) -> dict[str, Any]:
 
 
 def _emit_section(page: Page) -> dict[str, Any]:
-    """A PBIR-Legacy section (the JSON for one page)."""
+    """A PBIR-Legacy section (the JSON for one page).
+
+    ``visualContainers`` are sorted by the visual's ``name`` — Fabric
+    reorders them alphabetically on sync, so emitting them in insertion
+    order causes a byte-flap. The container dict has no top-level ``name``
+    (it lives inside the escaped ``config``), so we sort the source
+    visuals (whose names are assigned before emit) instead.
+    """
     return {
         "config": "{}",
         "displayName": page.display_name,
         "displayOption": 1,
         "filters": "[]",
-        "height": page.height,
+        "height": _Float2(page.height),
         "name": page.name,
-        "visualContainers": [_emit_visual_container(v) for v in page.visuals],
-        "width": page.width,
+        "visualContainers": [
+            _emit_visual_container(v)
+            for v in sorted(page.visuals, key=lambda v: v.name)
+        ],
+        "width": _Float2(page.width),
     }
 
 
@@ -609,11 +668,11 @@ def _emit_visual_container(v: Visual) -> dict[str, Any]:
     return {
         "config": json.dumps(_emit_visual_config(v)),
         "filters": "[]",
-        "height": v.position.height,
-        "width": v.position.width,
-        "x": v.position.x,
-        "y": v.position.y,
-        "z": v.position.z,
+        "height": _Float2(v.position.height),
+        "width": _Float2(v.position.width),
+        "x": _Float2(v.position.x),
+        "y": _Float2(v.position.y),
+        "z": _Float2(v.position.z),
     }
 
 

--- a/tests/items/test_report.py
+++ b/tests/items/test_report.py
@@ -559,7 +559,9 @@ class TestTheme:
             "rpt", "../x.SemanticModel", [page], strict_descriptions=False
         ).save_to_disk(tmp_path)
         rj = _load_report_json(tmp_path / "rpt.Report")
-        assert "resourcePackages" not in rj
+        # ``resourcePackages`` is always present (Fabric emits ``[]`` even
+        # without a theme — see issue #106); with no theme it's empty.
+        assert rj["resourcePackages"] == []
         config = json.loads(rj["config"])
         assert "themeCollection" not in config
 
@@ -783,3 +785,176 @@ class TestStrictDescriptions:
                 pages=[basic_page],
                 description="   ",
             ).save_to_disk(tmp_path)
+
+
+# ── Canonical-bytes (no git-sync flap) — issue #106 ────────────────────────
+
+
+class TestCanonicalBytes:
+    """The four byte-canonicalisation fixes from issue #106.
+
+    Fabric rewrites a freshly-built report.json/.platform on first
+    git-sync unless the builder emits its canonical bytes up front:
+    Report .platform drops its description; report.json carries a
+    top-level ``resourcePackages``; layout numbers serialize as
+    2-decimal floats; visualContainers are sorted by name.
+    """
+
+    def test_platform_has_no_description(
+        self, report_minimal: Report, tmp_path: Path
+    ) -> None:
+        # Report fixture HAS a description (it's validated/required), but
+        # Fabric strips it from the Report .platform — so the builder must
+        # not emit it. The Report.description field itself stays set.
+        assert report_minimal.description
+        item_dir = report_minimal.save_to_disk(tmp_path)
+        platform = json.loads((item_dir / ".platform").read_text("utf-8"))
+        assert "description" not in platform["metadata"]
+        # Other metadata is unaffected.
+        assert platform["metadata"]["displayName"] == "rpt_test"
+
+    def test_report_json_always_has_resource_packages(
+        self, report_minimal: Report, tmp_path: Path
+    ) -> None:
+        # Present even with no theme (Fabric writes ``"resourcePackages": []``).
+        item_dir = report_minimal.save_to_disk(tmp_path)
+        rj = _load_report_json(item_dir)
+        assert rj["resourcePackages"] == []
+        # ...and ordered between ``pods`` and ``sections``.
+        keys = list(rj.keys())
+        assert keys.index("pods") < keys.index("resourcePackages")
+        assert keys.index("resourcePackages") < keys.index("sections")
+
+    def test_resource_packages_populated_when_theme_present(
+        self, tmp_path: Path
+    ) -> None:
+        theme = Theme(name="MyTheme", content={"name": "MyTheme", "dataColors": []})
+        page = Page(
+            display_name="P",
+            visuals=[
+                Card(
+                    position=Position(x=0, y=0, width=200, height=120),
+                    measure=Measure("fact_x", "M"),
+                ),
+            ],
+        )
+        Report(
+            "rpt", "../x.SemanticModel", [page], theme=theme, strict_descriptions=False
+        ).save_to_disk(tmp_path)
+        rj = _load_report_json(tmp_path / "rpt.Report")
+        assert (
+            rj["resourcePackages"][0]["resourcePackage"]["items"][0]["name"]
+            == "MyTheme"
+        )
+
+    def test_layout_numbers_render_as_two_decimal_floats(self, tmp_path: Path) -> None:
+        page = Page(
+            display_name="P",
+            width=1280,
+            height=720,
+            visuals=[
+                Card(
+                    position=Position(x=16, y=110, width=720, height=120),
+                    measure=Measure("fact_x", "M"),
+                    name="card_a",
+                ),
+            ],
+        )
+        Report(
+            "rpt", "../x.SemanticModel", [page], strict_descriptions=False
+        ).save_to_disk(tmp_path)
+        # Assert on the RAW serialized text — parsed JSON gives 720.0 == 720
+        # which would not catch int-vs-N.00.
+        raw = (tmp_path / "rpt.Report" / "report.json").read_text("utf-8")
+        # Section dimensions.
+        assert '"height": 720.00,' in raw
+        assert '"width": 1280.00' in raw
+        # VisualContainer position fields.
+        assert '"height": 120.00,' in raw
+        assert '"width": 720.00,' in raw
+        assert '"x": 16.00,' in raw
+        assert '"y": 110.00,' in raw
+        assert '"z": 0.00' in raw
+        # No bare ints / single-decimal for these structured fields.
+        assert '"height": 720,' not in raw
+        assert '"x": 16,' not in raw
+        assert '"z": 0.0,' not in raw and '"z": 0,' not in raw
+
+    def test_config_string_numbers_not_floated(self, tmp_path: Path) -> None:
+        # The SAME layout numbers live inside the escaped ``config`` string
+        # (the visual's ``layouts`` block). Those must stay exactly as the
+        # builder writes them (ints / 0.0), NOT floated to N.00 — proving
+        # the float pass never reaches into the config string.
+        page = Page(
+            display_name="P",
+            visuals=[
+                Card(
+                    position=Position(x=16, y=110, width=720, height=120),
+                    measure=Measure("fact_x", "M"),
+                    name="card_a",
+                ),
+            ],
+        )
+        Report(
+            "rpt", "../x.SemanticModel", [page], strict_descriptions=False
+        ).save_to_disk(tmp_path)
+        raw = (tmp_path / "rpt.Report" / "report.json").read_text("utf-8")
+        # Escaped (inside config string) x/width must NOT be floated.
+        assert '\\"x\\": 16,' in raw
+        assert '\\"width\\": 720,' in raw
+        assert '\\"x\\": 16.00' not in raw
+        # The inner layout dict itself round-trips with the original numbers.
+        cfg = _visual_configs(_load_report_json(tmp_path / "rpt.Report"))[0]
+        pos = cfg["layouts"][0]["position"]
+        assert pos["x"] == 16
+        assert pos["width"] == 720
+
+    def test_non_layout_ints_stay_ints(self, tmp_path: Path) -> None:
+        # Guard against a "float everything numeric" over-reach: structural
+        # ints must remain ints in the serialized text.
+        page = Page(
+            display_name="P",
+            visuals=[
+                Card(
+                    position=Position(x=0, y=0, width=200, height=120),
+                    measure=Measure("fact_x", "M"),
+                    name="card_a",
+                ),
+            ],
+        )
+        Report(
+            "rpt", "../x.SemanticModel", [page], strict_descriptions=False
+        ).save_to_disk(tmp_path)
+        raw = (tmp_path / "rpt.Report" / "report.json").read_text("utf-8")
+        assert '"layoutOptimization": 0' in raw
+        assert '"displayOption": 1' in raw
+
+    def test_visual_containers_sorted_by_name(self, tmp_path: Path) -> None:
+        # Insertion order is slicer-then-card, but the slicer's name sorts
+        # AFTER the card's — Fabric reorders alphabetically by visual name,
+        # so the emitter must too.
+        page = Page(
+            display_name="P",
+            visuals=[
+                Slicer(
+                    position=Position(x=0, y=0, width=200, height=80),
+                    field=Column("dim", "region"),
+                    name="slicer_zzz",
+                ),
+                Card(
+                    position=Position(x=0, y=100, width=200, height=120),
+                    measure=Measure("fact_x", "M"),
+                    name="card_aaa",
+                ),
+            ],
+        )
+        Report(
+            "rpt", "../x.SemanticModel", [page], strict_descriptions=False
+        ).save_to_disk(tmp_path)
+        rj = _load_report_json(tmp_path / "rpt.Report")
+        names = [
+            json.loads(v["config"])["name"]
+            for v in rj["sections"][0]["visualContainers"]
+        ]
+        assert names == sorted(names)
+        assert names == ["card_aaa", "slicer_zzz"]


### PR DESCRIPTION
Closes #106.

## Summary

A report built by `Report.save_to_disk` was rewritten by Fabric on the first git-sync — a no-op byte-flap — because the builder emitted four fields differently from Fabric's canonical output. All four are fixed so a freshly built report matches what Fabric writes back.

## The four fixes

1. **`.platform` description dropped.** Fabric strips a Report `.platform` `description` on sync (even a short one). `_emit_platform` no longer emits it. The `Report.description` field and `strict_descriptions` validation are untouched — the description still surfaces to authors at build time; it just isn't written into the (non-retaining) Report `.platform`. (SemanticModel `.platform` descriptions are unaffected.)
2. **`resourcePackages` always present.** Fabric writes a top-level `"resourcePackages": []` even with no theme. Now always emitted (empty without a theme, populated when one is set), ordered between `pods` and `sections` per Fabric's key order.
3. **2-decimal float layout fields.** Every section / visualContainer `width`/`height`/`x`/`y`/`z` now serializes as `N.00` (`720.00`, `16.00`, `0.00`). Implemented with a `_Float2` marker wrapping only those five structured values + a custom `JSONEncoder` emitting a unique token + a single regex post-pass that unquotes the token. The same numbers embedded in the escaped `config` string are deliberately left exactly as the builder writes them.
4. **visualContainers sorted by name.** Fabric reorders the array alphabetically by each visual's `name`. The container dict has no top-level `name` (it lives in the escaped `config`), so source visuals are sorted by name before emit.

## Before / after (report.json + .platform)

`.platform` metadata:
```diff
   "metadata": {
     "type": "Report",
-    "displayName": "rpt_test",
-    "description": "Test report fixture."
+    "displayName": "rpt_test"
   },
```

report.json top-level + layout fields (structured fields only — config string untouched):
```diff
     ...
   ],
+  "resourcePackages": [],
   "sections": [
     {
       ...
-      "height": 720,
+      "height": 720.00,
       "visualContainers": [
         {
           ...
-          "height": 120,
-          "width": 720,
-          "x": 16,
-          "y": 110,
-          "z": 0.0
+          "height": 120.00,
+          "width": 720.00,
+          "x": 16.00,
+          "y": 110.00,
+          "z": 0.00
         }
       ],
-      "width": 1280
+      "width": 1280.00
```
The matching numbers inside the escaped `config` string stay as-is (verified by test): `\"x\": 16`, `\"width\": 720`.

visualContainers ordering: insertion order `slicer_zzz`, `card_aaa` → emitted `card_aaa`, `slicer_zzz`.

## Tests (`tests/items/test_report.py`)

New `TestCanonicalBytes` class asserts: `.platform` has no description; `resourcePackages` is always present and correctly ordered (and populated when a theme is set); layout fields render `N.00` in the **raw serialized text** (parsed JSON gives `720.0 == 720` and wouldn't catch it); config-string numbers stay un-floated; non-layout ints (`layoutOptimization`, `displayOption`) stay ints; visualContainers are name-sorted. Updated one existing test (`test_no_theme_omits_collection_and_resources`) to expect `resourcePackages == []` rather than absence.

## Pre-checkin (`.venv`)

`ruff check` ✅ · `ruff format --check` ✅ (121 files) · `mypy src/pyfabric` ✅ (no issues, 51 files) · `pytest` ✅ (853 passed, 4 skipped) · `pip-audit` — no findings introduced by this change (the pre-existing `idna` / `pip` advisories are unrelated and not pyfabric deps).