### PR TITLE
feat(items): SQL analytics endpoint metadata-refresh helpers

### DIFF
--- a/src/pyfabric/items/refresh.py
+++ b/src/pyfabric/items/refresh.py
@@ -36,6 +36,7 @@ import requests
 import structlog
 
 from pyfabric.client.auth import PBI_RESOURCE, FabricCredential
+from pyfabric.client.http import FabricClient, FabricError
 
 log = structlog.get_logger()
 
@@ -120,3 +121,104 @@ def refresh_semantic_model(
                 f"semantic-model refresh did not finish within {timeout}s "
                 f"(last status {status!r})"
             )
+
+
+# ── SQL analytics endpoint metadata refresh (Fabric API) ─────────────────────
+
+_SQL_SYNC_DONE = ("Succeeded", "Completed")
+_SQL_SYNC_FAILED = ("Failed", "Cancelled")
+
+
+def refresh_sql_endpoint_metadata(
+    client: FabricClient,
+    workspace_id: str,
+    sql_endpoint_id: str,
+    *,
+    wait: bool = True,
+    poll_interval: int = 15,
+    timeout: int = 600,
+    on_progress: OnProgress = None,
+) -> dict[str, Any]:
+    """Sync a lakehouse/warehouse SQL analytics endpoint's metadata to Delta.
+
+    The SQL analytics endpoint mirrors the lakehouse Delta tables, but its
+    metadata syncs with a lag. After a Spark/notebook write changes a table's
+    **schema** (e.g. adds a column), a downstream Import semantic model — which
+    reads schema *through this endpoint* (``Lakehouse.Contents``) — will fail to
+    refresh ("column does not exist in the rowset") until the endpoint catches
+    up. Call this between the write and the model refresh to force the sync.
+
+    Unlike :func:`refresh_semantic_model` (Power BI API), this is a Fabric API
+    call, so it takes a :class:`FabricClient`. Returns the per-table sync result
+    set. Raises :class:`RuntimeError` on a failed sync, :class:`TimeoutError` if
+    it doesn't finish within ``timeout``.
+    """
+    url = client._build_url(
+        f"workspaces/{workspace_id}/sqlEndpoints/{sql_endpoint_id}/refreshMetadata"
+    )
+    resp = client.raw_request("POST", url, {"preview": True})
+
+    if resp.status_code in (200, 201):
+        if on_progress:
+            on_progress("Completed")
+        return resp.json() if resp.text else {}
+
+    if resp.status_code != 202:
+        raise FabricError(resp.status_code, resp.text, url)
+
+    location = resp.headers.get("Location")
+    if not location:
+        raise RuntimeError(f"202 from {url} has no Location header")
+    retry_after = int(resp.headers.get("Retry-After", poll_interval))
+    if not wait:
+        return {"status": "Accepted", "location": location}
+
+    deadline = time.monotonic() + timeout
+    while True:
+        time.sleep(retry_after)
+        poll = client.raw_request("GET", location)
+        body = poll.json() if poll.text else {}
+        status = body.get("status", "Unknown")
+        if on_progress:
+            on_progress(status)
+        log.debug("sql_metadata_sync", sql_endpoint_id=sql_endpoint_id, status=status)
+
+        if status in _SQL_SYNC_DONE:
+            return body
+        if status in _SQL_SYNC_FAILED:
+            raise RuntimeError(
+                f"SQL endpoint metadata refresh {status}: {body.get('error', body)}"
+            )
+        if time.monotonic() > deadline:
+            raise TimeoutError(
+                f"SQL endpoint metadata refresh did not finish within {timeout}s "
+                f"(last status {status!r})"
+            )
+        retry_after = min(retry_after, poll_interval)
+
+
+def refresh_lakehouse_sql_metadata(
+    client: FabricClient,
+    workspace_id: str,
+    lakehouse_id: str,
+    **kwargs: Any,
+) -> dict[str, Any]:
+    """Resolve a lakehouse's SQL analytics endpoint id, then refresh its metadata.
+
+    Convenience over :func:`refresh_sql_endpoint_metadata` that reads the
+    endpoint id from the lakehouse's ``properties.sqlEndpointProperties.id``.
+    Extra keyword args (``wait``, ``poll_interval``, ``timeout``, ``on_progress``)
+    pass through.
+    """
+    lh = client.get(f"workspaces/{workspace_id}/lakehouses/{lakehouse_id}")
+    sql_endpoint_id = (
+        (lh.get("properties") or {}).get("sqlEndpointProperties") or {}
+    ).get("id")
+    if not sql_endpoint_id:
+        raise RuntimeError(
+            f"lakehouse {lakehouse_id} has no SQL endpoint id "
+            "(properties.sqlEndpointProperties.id)"
+        )
+    return refresh_sql_endpoint_metadata(
+        client, workspace_id, sql_endpoint_id, **kwargs
+    )

--- a/tests/items/test_refresh.py
+++ b/tests/items/test_refresh.py
@@ -6,7 +6,12 @@ from unittest.mock import MagicMock
 
 import pytest
 
-from pyfabric.items.refresh import refresh_semantic_model
+from pyfabric.client.http import FabricError
+from pyfabric.items.refresh import (
+    refresh_lakehouse_sql_metadata,
+    refresh_semantic_model,
+    refresh_sql_endpoint_metadata,
+)
 
 
 def _session(post_resp, get_responses) -> MagicMock:
@@ -87,3 +92,87 @@ class TestRefreshSemanticModel:
         # Authorization header set from the credential's Power BI token
         auth = session.headers.update.call_args[0][0]["Authorization"]
         assert auth.startswith("Bearer ")
+
+
+def _sql_client(raw_responses=None, get_return=None) -> MagicMock:
+    """A FabricClient mock for the SQL-endpoint metadata helpers."""
+    c = MagicMock()
+    c._build_url = lambda path, params=None: (
+        f"https://api.fabric.microsoft.com/v1/{path}"
+    )
+    if raw_responses is not None:
+        c.raw_request.side_effect = raw_responses
+    if get_return is not None:
+        c.get.return_value = get_return
+    return c
+
+
+class TestRefreshSqlEndpointMetadata:
+    def test_sync_200_returns_results(self, mock_http_response):
+        mk = mock_http_response
+        c = _sql_client(
+            [mk(200, {"value": [{"tableName": "dbo.t", "status": "Success"}]})]
+        )
+        seen: list[str] = []
+        out = refresh_sql_endpoint_metadata(c, "WS", "EP", on_progress=seen.append)
+        assert out["value"][0]["status"] == "Success"
+        assert seen == ["Completed"]
+        method, url, _body = c.raw_request.call_args[0]
+        assert method == "POST"
+        assert "sqlEndpoints/EP/refreshMetadata" in url
+
+    def test_202_polls_to_succeeded(self, mock_http_response):
+        mk = mock_http_response
+        c = _sql_client(
+            [
+                mk(202, headers={"Location": "https://poll/op", "Retry-After": "0"}),
+                mk(200, {"status": "Running"}),
+                mk(200, {"status": "Succeeded", "value": []}),
+            ]
+        )
+        seen: list[str] = []
+        out = refresh_sql_endpoint_metadata(
+            c, "WS", "EP", poll_interval=0, on_progress=seen.append
+        )
+        assert out["status"] == "Succeeded"
+        assert seen == ["Running", "Succeeded"]
+
+    def test_no_wait_returns_location(self, mock_http_response):
+        c = _sql_client(
+            [mock_http_response(202, headers={"Location": "https://poll/op"})]
+        )
+        out = refresh_sql_endpoint_metadata(c, "WS", "EP", wait=False)
+        assert out == {"status": "Accepted", "location": "https://poll/op"}
+
+    def test_failed_status_raises(self, mock_http_response):
+        mk = mock_http_response
+        c = _sql_client(
+            [
+                mk(202, headers={"Location": "https://poll/op", "Retry-After": "0"}),
+                mk(200, {"status": "Failed", "error": "boom"}),
+            ]
+        )
+        with pytest.raises(RuntimeError, match="Failed"):
+            refresh_sql_endpoint_metadata(c, "WS", "EP", poll_interval=0)
+
+    def test_unexpected_status_raises_fabric_error(self, mock_http_response):
+        c = _sql_client([mock_http_response(400, {"error": "bad"})])
+        with pytest.raises(FabricError):
+            refresh_sql_endpoint_metadata(c, "WS", "EP")
+
+
+class TestRefreshLakehouseSqlMetadata:
+    def test_resolves_endpoint_then_refreshes(self, mock_http_response):
+        c = _sql_client(
+            [mock_http_response(200, {"value": []})],
+            get_return={"properties": {"sqlEndpointProperties": {"id": "EPID"}}},
+        )
+        refresh_lakehouse_sql_metadata(c, "WS", "LH")
+        _method, url, _body = c.raw_request.call_args[0]
+        assert "sqlEndpoints/EPID/refreshMetadata" in url
+
+    def test_missing_endpoint_id_raises(self):
+        c = MagicMock()
+        c.get.return_value = {"properties": {}}
+        with pytest.raises(RuntimeError, match="no SQL endpoint"):
+            refresh_lakehouse_sql_metadata(c, "WS", "LH")


### PR DESCRIPTION
## What

Adds two Fabric-API helpers in `pyfabric.items.refresh`:

- `refresh_sql_endpoint_metadata(client, workspace_id, sql_endpoint_id, ...)` — POSTs the SQL analytics endpoint `refreshMetadata` action; returns the per-table sync result on a 200, or polls the LRO to completion on a 202. Same `wait`/`poll_interval`/`timeout`/`on_progress` ergonomics as `refresh_semantic_model`.
- `refresh_lakehouse_sql_metadata(client, workspace_id, lakehouse_id, ...)` — convenience that resolves the endpoint id from `properties.sqlEndpointProperties.id` then delegates.

## Why

The SQL analytics endpoint's metadata lags behind Delta. After a Spark/notebook write changes a table **schema** (e.g. adds a column), an Import semantic model that reads schema *through the endpoint* fails to refresh with "column does not exist in the rowset" until the endpoint syncs. This was a real, repeated failure. The helper makes the sync an explicit, awaitable deploy step, completing the chain: run notebook → **refresh SQL metadata** → refresh semantic model.

## Tests

7 new tests (200-sync, 202-poll-to-success, no-wait, failed-status, error, endpoint-id resolution, missing-id). Full suite: 853 passed, 4 skipped. ruff / ruff format / mypy / pip-audit clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)