### PR TITLE
feat(report): migrate Report builder to modern PBIR (drop legacy report.json)

### DIFF
--- a/src/pyfabric/items/report.py
+++ b/src/pyfabric/items/report.py
@@ -1,36 +1,45 @@
-"""Build Fabric Report items (PBIR-Legacy format) by hand.
+"""Build Fabric Report items (modern **PBIR** format) by hand.
 
-A Page-and-Visual builder for KPI strips, slicers, and detail tables
-linked to a SemanticModel via a relative byPath reference. Supports
-single-metric and multi-metric cards (with label typography + theme
-color styling), single-column and hierarchy slicers (with optional
-allow-list filter), tables with mixed Column/Measure/Aggregate fields
-and OrderBy on any of them, and an optional report-level theme bundled
-into ``StaticResources/SharedResources/BaseThemes/``.
+A Page-and-Visual builder for slicers and detail tables linked to a
+SemanticModel via a relative ``byPath`` reference. Emits the modern PBIR
+``definition/`` folder format — a separate ``page.json`` per page and a
+separate ``visual.json`` per visual — which is Microsoft's current
+diff-able report format and the one current Fabric opens reliably.
 
-Out of scope: tooltip pages (the wiring schema needs to be re-derived
-from working examples), bookmarks, drillthrough, page-level filters
-beyond a slicer's allow-list.
+Scope (what emits byte-confident PBIR today):
 
-Output format is **PBIR-Legacy** (single ``report.json``) — the format
-Fabric currently emits when a report is created via ``+ New item →
-Report`` in the workspace UI. The newer folder-per-page PBIR format is
-not emitted; if a tenant requires it, open the report in Desktop and
-re-save to convert.
+- **Slicer** → a ``listSlicer`` with one or more column projections
+  (the first ``active``). The ``listSlicer`` has a built-in search box;
+  there is no property to author for it.
+- **Table** → a ``tableEx`` with mixed :class:`Column` / :class:`Measure`
+  projections, an optional sort on a single column, and a per-projection
+  ``filterConfig`` (columns ``Categorical``, measures ``Advanced``).
+
+``Card`` and ``MultiCard`` remain in the public API for source
+compatibility but their PBIR emit is **not yet implemented** — it needs
+UI-captured reference bytes. Instantiating them on a saved page raises
+``NotImplementedError``.
+
+PBIR shapes that still need a UI capture (no attested reference bytes —
+would be guessed, so they are dropped-with-warning or raise rather than
+emit invented JSON): tooltip pages, bookmarks, drillthrough,
+hierarchy/expansion slicers, slicer ``mode`` variants (Dropdown/Between),
+``allow_values`` slicer filters, inline column aggregations,
+``format_string`` column properties, sort-by-measure, and the dynamic
+title (only the fully-styled form is attested; the minimal form emitted
+here is provisional). Each is handled at the point it would be emitted.
 
 Every write routes through
 :func:`pyfabric.items.normalize.write_artifact_file` so emitted bytes
-match Fabric's per-file-type byte convention and won't trigger sync flap.
+match Fabric's per-file-type byte convention (LF, no BOM, no trailing
+newline for report JSON) and won't trigger sync flap.
 
 Usage::
 
     from pathlib import Path
     from pyfabric.items.report import (
-        Aggregate,
-        Card,
         Column,
         Measure,
-        MultiCard,
         Page,
         Position,
         Report,
@@ -40,34 +49,21 @@ Usage::
     )
 
     page = Page(
-        display_name="QA Summary",
+        display_name="Page 1",
         width=1280,
         height=720,
         visuals=[
             Slicer(
-                position=Position(x=10, y=12, width=212, height=80),
-                field=Column("dim_projection", "region"),
-                mode="Dropdown",
-            ),
-            MultiCard(
-                position=Position(x=10, y=110, width=1260, height=120),
-                measures=[
-                    Measure("fact_x", "# PDFs Total", format_string="#,0"),
-                    Measure("fact_x", "# PDFs OK", format_string="#,0"),
-                ],
-                display_units="None",
+                position=Position(x=10, y=0, width=430, height=280),
+                field=Column("dim_x", "name"),
             ),
             Table(
-                position=Position(x=10, y=240, width=1260, height=460),
+                position=Position(x=460, y=0, width=780, height=270),
                 fields=[
-                    Column("dim_projection", "project_number"),
-                    Column("fact_x", "status"),
-                    Aggregate("fact_x", "missing_field_count", function="sum"),
+                    Column("dim_x", "name"),
+                    Column("dim_x", "city"),
                 ],
-                order_by=TableOrderBy(
-                    field=Aggregate("fact_x", "missing_field_count", function="sum"),
-                    direction="desc",
-                ),
+                order_by=TableOrderBy(field=Column("dim_x", "name")),
             ),
         ],
     )
@@ -76,6 +72,7 @@ Usage::
         name="rpt_my_report",
         semantic_model_path="../sm_my_model.SemanticModel",
         pages=[page],
+        description="An example report.",
     ).save_to_disk(Path("ws/"))
 """
 
@@ -105,36 +102,14 @@ LabelPosition = Literal["belowValue", "aboveValue"]
 # to setting fontSize directly because the role adapts on theme swap.
 LabelHeading = Literal["Heading1", "Heading2", "Heading3", "Body"]
 
-
-# ``valueDisplayUnits`` literal magnitudes used by Power BI cards.
-# 1D = "show actual" (None); 0D = Auto (the abbreviation default that
-# turns 1623 → "2K"); the rest are divisor magnitudes.
-_DISPLAY_UNITS_LITERAL: dict[DisplayUnits, str] = {
-    "Auto": "0D",
-    "None": "1D",
-    "Thousands": "1000D",
-    "Millions": "1000000D",
-    "Billions": "1000000000D",
-    "Trillions": "1000000000000D",
+# PBIR sort directions (the modern format uses spelled-out enum strings,
+# not the legacy integer codes).
+_SORT_DIRECTION: dict[SortDirection, str] = {
+    "asc": "Ascending",
+    "desc": "Descending",
 }
 
-# Aggregation function index in the PBIR ``Aggregation.Function`` enum.
-_AGG_FN_INDEX: dict[AggregationFunction, int] = {
-    "sum": 0,
-    "avg": 1,
-    "min": 2,
-    "max": 3,
-    "count": 4,
-    "distinctCount": 5,
-}
-
-# Sort direction index in the PBIR ``OrderBy.Direction`` enum.
-_SORT_DIR_INDEX: dict[SortDirection, int] = {
-    "asc": 1,
-    "desc": 2,
-}
-
-# Stable UUID namespace for deterministic visual / page / pod ids.
+# Stable UUID namespace for deterministic visual / page / filter ids.
 _REPORT_NS = uuid.UUID("c1d2e3f4-0001-4000-8000-000000000000")
 
 
@@ -145,11 +120,10 @@ _REPORT_NS = uuid.UUID("c1d2e3f4-0001-4000-8000-000000000000")
 class ThemeColor:
     """A reference to a color in the report's theme palette.
 
-    Use in place of hex literals so cards and other visuals adapt when
-    the theme is swapped. ``color_id`` indexes the theme's
-    ``dataColors`` list (0-based; theme conventions vary). ``percent``
-    tints the color (0.0 = full saturation, 0.6 = soft tint suitable
-    for backgrounds).
+    Use in place of hex literals so visuals adapt when the theme is
+    swapped. ``color_id`` indexes the theme's ``dataColors`` list
+    (0-based; theme conventions vary). ``percent`` tints the color
+    (0.0 = full saturation, 0.6 = soft tint suitable for backgrounds).
     """
 
     color_id: int
@@ -180,8 +154,9 @@ class Column:
     """A column reference in the SemanticModel, used inside a visual.
 
     ``entity`` is the SemanticModel table name; ``name`` is the column
-    name on that table. ``format_string`` overrides the column-property
-    formatter inside the visual (does not change the column's default).
+    name on that table. ``format_string`` is accepted for source
+    compatibility but is **not yet emitted** in PBIR (column-property
+    formatting needs UI-captured reference bytes).
     """
 
     entity: str
@@ -191,7 +166,11 @@ class Column:
 
 @dataclass(frozen=True)
 class Measure:
-    """A measure reference in the SemanticModel, used inside a visual."""
+    """A measure reference in the SemanticModel, used inside a visual.
+
+    ``format_string`` is accepted for source compatibility but is **not
+    yet emitted** in PBIR.
+    """
 
     entity: str
     name: str
@@ -202,9 +181,11 @@ class Measure:
 class Aggregate:
     """An inline aggregation of a column inside a visual.
 
-    Lets a Table or OrderBy reference ``Sum(table.col)`` without
-    requiring a model-level measure. Power BI emits this with an
-    ``Aggregation`` wrapper in the prototype query.
+    Retained for source compatibility. The modern PBIR projection shape
+    for an inline aggregation is **not attested** in the reference
+    reports (they project only columns and model measures), so a
+    :class:`Table` that references an ``Aggregate`` raises
+    :class:`NotImplementedError` on save until UI-captured bytes exist.
     """
 
     entity: str
@@ -222,14 +203,19 @@ FieldRef = Column | Measure | Aggregate
 
 @dataclass
 class Position:
-    """Visual placement on a Page (canvas coordinates in pixels)."""
+    """Visual placement on a Page (canvas coordinates in pixels).
+
+    Whole-number coordinates emit as JSON ints (``"y": 0``), matching
+    Fabric's output for non-dragged visuals; fractional values emit as
+    floats. ``tab_order`` defaults to ``z`` when left at 0.
+    """
 
     x: float
     y: float
     width: float
     height: float
     z: float = 0.0
-    tab_order: int = 0
+    tab_order: int | None = None
 
 
 # ── Visuals ─────────────────────────────────────────────────────────────────
@@ -245,19 +231,18 @@ class Visual:
 
 @dataclass
 class Slicer(Visual):
-    """A slicer visual.
+    """A slicer visual, emitted as a ``listSlicer``.
 
-    ``field`` accepts either a single :class:`Column` (the common case)
-    or a list of columns to render a **hierarchy slicer** with one
-    drill level per entry. Hierarchy slicers must use ``mode="Basic"``;
-    other modes are silently coerced. All hierarchy levels start
-    collapsed (no preselected expansion); customize in Desktop if you
-    need a specific drill path on first load.
+    ``field`` accepts a single :class:`Column` (the common case) or a
+    list of columns. The first projection is marked ``active``; the rest
+    inactive. The ``listSlicer`` has a built-in search box.
 
-    ``allow_values`` emits a hardcoded slicer-level filter that limits
-    the dropdown to those values — useful for scoping the report
-    (e.g. a status slicer showing only ``["INCOMPLETE", "NOT_DETECTED"]``).
-    The filter targets the **leaf** column when ``field`` is a hierarchy.
+    ``mode`` and ``allow_values`` are accepted for source compatibility
+    but are **not yet emitted** in PBIR — the modern bytes for non-list
+    slicer modes and for a hardcoded allow-list filter need a UI capture
+    (the only attested reference is a bare ``listSlicer``). A hierarchy
+    (multi-column ``field``) emits as additional inactive projections,
+    not as an ``expansionStates`` drill hierarchy (also un-attested).
     """
 
     field: Column | list[Column] = field(default_factory=lambda: Column("", ""))
@@ -283,9 +268,9 @@ class Slicer(Visual):
 class Card(Visual):
     """A single-metric KPI card.
 
-    ``display_units="None"`` (default) shows the actual integer; ``"Auto"``
-    triggers Power BI's "2K" abbreviation. Set ``title`` to override the
-    measure-name title; set to empty string to suppress.
+    Retained in the public API for source compatibility. **PBIR emit is
+    not yet implemented** — needs UI-captured reference bytes. Saving a
+    page that contains a ``Card`` raises :class:`NotImplementedError`.
     """
 
     measure: Measure = field(default_factory=lambda: Measure("", ""))
@@ -295,20 +280,11 @@ class Card(Visual):
 
 @dataclass
 class MultiCard(Visual):
-    """A multi-metric KPI strip (one cardVisual rendering several measures).
+    """A multi-metric KPI strip.
 
-    All measures share ``display_units``. ``arrangement`` controls
-    whether tiles flow in rows or columns. The polish flags
-    (``show_outline``, ``show_accent_bar``, ``show_shadow``) wire the
-    matching ``objects`` properties.
-
-    The label-styling props target the small text under each value:
-
-    - ``label_heading`` — Power BI typography role (``"Heading2"`` etc.).
-      Theme-driven font size + weight; preferable to setting a literal
-      font size because the role adapts on theme swap.
-    - ``label_position`` — ``"belowValue"`` (default) or ``"aboveValue"``.
-    - ``label_font_color`` — :class:`ThemeColor` reference for label text.
+    Retained in the public API for source compatibility. **PBIR emit is
+    not yet implemented** — needs UI-captured reference bytes. Saving a
+    page that contains a ``MultiCard`` raises :class:`NotImplementedError`.
     """
 
     measures: list[Measure] = field(default_factory=list)
@@ -324,7 +300,12 @@ class MultiCard(Visual):
 
 @dataclass
 class TableOrderBy:
-    """Sort spec for a Table visual."""
+    """Sort spec for a Table visual.
+
+    Only sort-by-:class:`Column` is byte-confident from the references.
+    Sorting by a :class:`Measure` or :class:`Aggregate` raises
+    :class:`NotImplementedError` on save (un-attested PBIR shape).
+    """
 
     field: FieldRef
     direction: SortDirection = "asc"
@@ -332,30 +313,45 @@ class TableOrderBy:
 
 @dataclass
 class Table(Visual):
-    """A table visual with one or more field/measure/aggregate columns.
+    """A table visual, emitted as a ``tableEx``.
 
-    ``order_by`` is optional; when omitted, Power BI uses its default
-    sort. Provide an :class:`Aggregate` reference there to sort by
-    something like ``Sum(missing_field_count)`` without defining a
-    model measure.
+    ``fields`` may mix :class:`Column` and :class:`Measure` projections.
+    ``order_by`` is optional and currently supports sort-by-column only.
+
+    ``title`` optionally binds a measure-driven dynamic title (the
+    ``visualContainerObjects.title`` shape). **Caveat:** only the
+    *fully-styled* title form is attested in the reference reports; the
+    minimal form emitted here (``show`` + ``text``) needs a UI capture to
+    certify its exact bytes. The hook is provided so callers can author
+    one, but treat its bytes as provisional.
     """
 
     fields: list[FieldRef] = field(default_factory=list)
     order_by: TableOrderBy | None = None
+    title: Measure | None = None
 
 
 # ── Page ────────────────────────────────────────────────────────────────────
 
 
+PageDisplayOption = Literal["FitToPage", "ActualSize", "FitToWidth"]
+
+
 @dataclass
 class Page:
-    """A single report page (called a "section" in PBIR-Legacy JSON)."""
+    """A single report page.
+
+    ``name`` is the page's id (also its folder name under
+    ``definition/pages/``). Leave blank to derive a deterministic id from
+    the report + display name; pin it for byte-stable output.
+    """
 
     display_name: str
     visuals: list[Visual] = field(default_factory=list)
     width: float = 1280.0
     height: float = 720.0
     name: str = ""  # auto-filled from display_name if blank
+    display_option: PageDisplayOption = "FitToPage"
 
 
 # ── Report ──────────────────────────────────────────────────────────────────
@@ -367,21 +363,24 @@ class ReportError(Exception):
 
 @dataclass
 class Report:
-    """A full Fabric Report item.
+    """A full Fabric Report item, emitted in modern PBIR format.
 
-    ``semantic_model_path`` is a relative path from the report folder
-    to a sibling ``*.SemanticModel`` folder (e.g. ``"../sm_x.SemanticModel"``).
-    Emitted as a PBIR-Legacy ``definition.pbir`` ``byPath`` reference.
+    ``semantic_model_path`` is a relative path from the report folder to
+    a sibling ``*.SemanticModel`` folder (e.g. ``"../sm_x.SemanticModel"``),
+    emitted as a ``definition.pbir`` ``byPath`` reference.
 
     ``theme``, when set, bundles a base theme JSON file at
-    ``StaticResources/SharedResources/BaseThemes/<theme.name>.json``
-    and registers it as the report's base theme. Without a theme,
-    Power BI applies its workspace default.
+    ``StaticResources/SharedResources/BaseThemes/<theme.name>.json`` and
+    registers it as the report's base theme. Without a theme, Power BI
+    applies its workspace default. pyfabric never bundles a default
+    theme — the caller supplies it.
 
-    **A non-empty description is required by default.** Reports show up
-    in the workspace listing and item-info pane; an empty description
-    is a poor consumer experience. Set ``strict_descriptions=False``
-    to opt out (a warning is logged).
+    **A non-empty description is required by default.** It is validated
+    and surfaced through the API, but — per Fabric's behavior — it is
+    **not written into ``.platform``** (Fabric strips report descriptions
+    there and would otherwise flap on sync). Set
+    ``strict_descriptions=False`` to skip the validation (a warning is
+    logged).
     """
 
     name: str
@@ -396,8 +395,8 @@ class Report:
         """Return a list of human-readable error messages.
 
         Empty list means the report passes pre-emit validation. Called
-        automatically from :meth:`save_to_disk`; expose it separately
-        so callers can lint without writing.
+        automatically from :meth:`save_to_disk`; expose it separately so
+        callers can lint without writing.
         """
         errors: list[str] = []
         if not (self.description or "").strip():
@@ -416,11 +415,12 @@ class Report:
         return errors
 
     def save_to_disk(self, output_dir: Path | str) -> Path:
-        """Emit the full ``<name>.Report`` folder.
+        """Emit the full ``<name>.Report`` folder in modern PBIR format.
 
         Returns the path to the created folder. Raises :class:`ReportError`
-        if pre-emit validation fails. All writes route through
-        :func:`pyfabric.items.normalize.write_artifact_file`.
+        if pre-emit validation fails, and :class:`NotImplementedError`
+        for visuals whose PBIR bytes are not yet implemented. All writes
+        route through :func:`pyfabric.items.normalize.write_artifact_file`.
         """
         errors = self.validate()
         if errors:
@@ -442,7 +442,24 @@ class Report:
 
         write_artifact_file(item_dir / ".platform", self._emit_platform())
         write_artifact_file(item_dir / "definition.pbir", self._emit_pbir())
-        write_artifact_file(item_dir / "report.json", self._emit_report_json())
+        write_artifact_file(
+            item_dir / "definition" / "version.json", self._emit_version()
+        )
+        write_artifact_file(
+            item_dir / "definition" / "report.json", self._emit_report_json()
+        )
+        write_artifact_file(
+            item_dir / "definition" / "pages" / "pages.json", self._emit_pages_json()
+        )
+        for page in self.pages:
+            page_dir = item_dir / "definition" / "pages" / page.name
+            write_artifact_file(page_dir / "page.json", _emit_page_json(page))
+            for visual in page.visuals:
+                visual_dir = page_dir / "visuals" / visual.name
+                write_artifact_file(
+                    visual_dir / "visual.json", _emit_visual_json(visual)
+                )
+
         if self.theme is not None:
             theme_path = (
                 item_dir
@@ -465,13 +482,14 @@ class Report:
     # ── File emitters ──────────────────────────────────────────────────────
 
     def _emit_platform(self) -> str:
+        # NOTE: no ``description`` key — Fabric strips report descriptions
+        # from .platform on sync, so emitting one causes a permanent flap.
         return json.dumps(
             {
                 "$schema": "https://developer.microsoft.com/json-schemas/fabric/gitIntegration/platformProperties/2.0.0/schema.json",
                 "metadata": {
                     "type": "Report",
                     "displayName": self.name,
-                    **({"description": self.description} if self.description else {}),
                 },
                 "config": {"version": "2.0", "logicalId": self.logical_id},
             },
@@ -488,69 +506,73 @@ class Report:
             indent=2,
         )
 
+    def _emit_version(self) -> str:
+        return json.dumps(
+            {
+                "$schema": "https://developer.microsoft.com/json-schemas/fabric/item/report/definition/versionMetadata/1.0.0/schema.json",
+                "version": "2.0.0",
+            },
+            indent=2,
+        )
+
     def _emit_report_json(self) -> str:
-        report_config: dict[str, Any] = {
-            "version": "5.72",
-            "activeSectionIndex": 0,
-            "defaultDrillFilterOtherVisuals": True,
-            "linguisticSchemaSyncVersion": 0,
-            "settings": {
-                "useNewFilterPaneExperience": True,
-                "allowChangeFilterTypes": True,
-                "useStylableVisualContainerHeader": True,
-                "queryLimitOption": 6,
-                "useEnhancedTooltips": True,
-                "exportDataMode": 1,
-                "useDefaultAggregateDisplayName": True,
-            },
-            "objects": {
-                "section": [
-                    {
-                        "properties": {
-                            "verticalAlignment": {
-                                "expr": {"Literal": {"Value": "'Top'"}}
-                            }
-                        }
-                    }
-                ]
-            },
+        payload: dict[str, Any] = {
+            "$schema": "https://developer.microsoft.com/json-schemas/fabric/item/report/definition/report/3.3.0/schema.json",
         }
         if self.theme is not None:
-            report_config["themeCollection"] = {
+            payload["themeCollection"] = {
                 "baseTheme": {
                     "name": self.theme.name,
-                    "type": 2,
-                    "version": {
-                        "visual": "2.8.0",
-                        "report": "3.2.0",
+                    "reportVersionAtImport": {
+                        "visual": "2.9.0",
+                        "report": "3.3.0",
                         "page": "2.3.1",
                     },
+                    "type": "SharedResources",
                 }
             }
-        payload: dict[str, Any] = {
-            "config": json.dumps(report_config),
-            "layoutOptimization": 0,
-            "pods": [_emit_pod(p, i) for i, p in enumerate(self.pages)],
-            "sections": [_emit_section(p) for p in self.pages],
+        payload["objects"] = {
+            "section": [
+                {
+                    "properties": {
+                        "verticalAlignment": {"expr": {"Literal": {"Value": "'Top'"}}}
+                    }
+                }
+            ]
         }
         if self.theme is not None:
             payload["resourcePackages"] = [
                 {
-                    "resourcePackage": {
-                        "disabled": False,
-                        "items": [
-                            {
-                                "name": self.theme.name,
-                                "path": f"BaseThemes/{self.theme.name}.json",
-                                "type": 202,
-                            }
-                        ],
-                        "name": "SharedResources",
-                        "type": 2,
-                    }
+                    "name": "SharedResources",
+                    "type": "SharedResources",
+                    "items": [
+                        {
+                            "name": self.theme.name,
+                            "path": f"BaseThemes/{self.theme.name}.json",
+                            "type": "BaseTheme",
+                        }
+                    ],
                 }
             ]
+        payload["settings"] = {
+            "useStylableVisualContainerHeader": True,
+            "exportDataMode": "AllowSummarized",
+            "defaultDrillFilterOtherVisuals": True,
+            "allowChangeFilterTypes": True,
+            "useEnhancedTooltips": True,
+            "useDefaultAggregateDisplayName": True,
+        }
         return json.dumps(payload, indent=2)
+
+    def _emit_pages_json(self) -> str:
+        return json.dumps(
+            {
+                "$schema": "https://developer.microsoft.com/json-schemas/fabric/item/report/definition/pagesMetadata/1.1.0/schema.json",
+                "pageOrder": [p.name for p in self.pages],
+                "activePageName": self.pages[0].name if self.pages else "",
+            },
+            indent=2,
+        )
 
 
 # ── Internal: id helpers ───────────────────────────────────────────────────
@@ -561,569 +583,235 @@ def _id20(*parts: str) -> str:
     return uuid.uuid5(_REPORT_NS, ".".join(parts)).hex[:20]
 
 
-def _theme_color_solid(c: ThemeColor) -> dict[str, Any]:
-    """The ``{solid: {color: {expr: {ThemeDataColor: ...}}}}`` wrapper Power BI uses for theme color refs."""
+def _num(value: float) -> float | int:
+    """Whole numbers emit as ints (``0`` not ``0.0``); fractions stay floats.
+
+    Matches Fabric's PBIR position output, where un-dragged coordinates
+    are JSON integers and drag values are floats.
+    """
+    if isinstance(value, float) and value.is_integer():
+        return int(value)
+    return value
+
+
+# ── Internal: page / visual emitters ───────────────────────────────────────
+
+
+def _emit_page_json(page: Page) -> str:
+    return json.dumps(
+        {
+            "$schema": "https://developer.microsoft.com/json-schemas/fabric/item/report/definition/page/2.1.0/schema.json",
+            "name": page.name,
+            "displayName": page.display_name,
+            "displayOption": page.display_option,
+            "height": _num(page.height),
+            "width": _num(page.width),
+        },
+        indent=2,
+    )
+
+
+def _emit_visual_json(v: Visual) -> str:
+    return json.dumps(
+        {
+            "$schema": "https://developer.microsoft.com/json-schemas/fabric/item/report/definition/visualContainer/2.10.0/schema.json",
+            "name": v.name,
+            "position": _emit_position(v.position),
+            "visual": _emit_visual_body(v),
+            "filterConfig": _emit_filter_config(v),
+        },
+        indent=2,
+    )
+
+
+def _emit_position(p: Position) -> dict[str, Any]:
+    tab_order = p.tab_order if p.tab_order is not None else int(p.z)
     return {
-        "solid": {
-            "color": {
-                "expr": {
-                    "ThemeDataColor": {
-                        "ColorId": c.color_id,
-                        "Percent": c.percent,
-                    }
-                }
+        "x": _num(p.x),
+        "y": _num(p.y),
+        "z": _num(p.z),
+        "height": _num(p.height),
+        "width": _num(p.width),
+        "tabOrder": tab_order,
+    }
+
+
+def _emit_visual_body(v: Visual) -> dict[str, Any]:
+    """Dispatch to the per-visual ``visual`` body emitter."""
+    if isinstance(v, Slicer):
+        return _emit_slicer_body(v)
+    if isinstance(v, Table):
+        return _emit_table_body(v)
+    if isinstance(v, (Card, MultiCard)):
+        raise NotImplementedError(
+            f"{type(v).__name__} PBIR emit not yet implemented — needs reference bytes"
+        )
+    raise TypeError(f"unsupported visual type: {type(v).__name__}")
+
+
+# ── Field-reference shapes (modern PBIR) ────────────────────────────────────
+
+
+def _field_ref(ref: Column | Measure) -> dict[str, Any]:
+    """The ``field.{Column|Measure}.Expression.SourceRef.Entity`` shape.
+
+    Modern PBIR references an entity directly — no From/Select alias
+    machinery (that was the legacy prototype-query form).
+    """
+    kind = "Measure" if isinstance(ref, Measure) else "Column"
+    return {
+        "field": {
+            kind: {
+                "Expression": {"SourceRef": {"Entity": ref.entity}},
+                "Property": ref.name,
             }
         }
     }
 
 
-# ── Internal: section / pod emitters ───────────────────────────────────────
+def _projection(ref: Column | Measure) -> dict[str, Any]:
+    """A ``query.queryState.Values.projections[]`` entry."""
+    proj = _field_ref(ref)
+    proj["queryRef"] = f"{ref.entity}.{ref.name}"
+    proj["nativeQueryRef"] = ref.name
+    return proj
 
 
-def _emit_pod(page: Page, index: int) -> dict[str, Any]:
-    """One ``pods[]`` entry binds a page to its rendering surface."""
-    return {
-        "boundSection": page.name,
-        "config": "{}",
-        "name": _id20("pod", page.name),
-        "referenceScope": 1,
-    }
-
-
-def _emit_section(page: Page) -> dict[str, Any]:
-    """A PBIR-Legacy section (the JSON for one page)."""
-    return {
-        "config": "{}",
-        "displayName": page.display_name,
-        "displayOption": 1,
-        "filters": "[]",
-        "height": page.height,
-        "name": page.name,
-        "visualContainers": [_emit_visual_container(v) for v in page.visuals],
-        "width": page.width,
-    }
-
-
-def _emit_visual_container(v: Visual) -> dict[str, Any]:
-    """The outer wrapper for a visual; the inner ``config`` is stringified JSON."""
-    return {
-        "config": json.dumps(_emit_visual_config(v)),
-        "filters": "[]",
-        "height": v.position.height,
-        "width": v.position.width,
-        "x": v.position.x,
-        "y": v.position.y,
-        "z": v.position.z,
-    }
-
-
-def _emit_visual_config(v: Visual) -> dict[str, Any]:
-    """Dispatch to the per-visual emitter."""
-    if isinstance(v, Slicer):
-        return _emit_slicer_config(v)
-    if isinstance(v, Card):
-        return _emit_card_config(v)
-    if isinstance(v, MultiCard):
-        return _emit_multicard_config(v)
-    if isinstance(v, Table):
-        return _emit_table_config(v)
-    raise TypeError(f"unsupported visual type: {type(v).__name__}")
-
-
-def _layout_block(v: Visual) -> list[dict[str, Any]]:
-    """Standard ``layouts`` block with the visual's position."""
-    return [
-        {
-            "id": 0,
-            "position": {
-                "x": v.position.x,
-                "y": v.position.y,
-                "z": v.position.z,
-                "width": v.position.width,
-                "height": v.position.height,
-                "tabOrder": v.position.tab_order or int(v.position.z),
-            },
-        }
-    ]
+def _projectable(ref: FieldRef) -> Column | Measure:
+    """Narrow a field ref to a projectable one, or raise for un-attested kinds."""
+    if isinstance(ref, Aggregate):
+        raise NotImplementedError(
+            "inline Aggregate projection has no attested PBIR shape — "
+            "use a model measure or capture reference bytes"
+        )
+    return ref
 
 
 # ── Slicer emitter ──────────────────────────────────────────────────────────
 
 
-def _emit_slicer_config(s: Slicer) -> dict[str, Any]:
+def _emit_slicer_body(s: Slicer) -> dict[str, Any]:
     levels = s.field_levels
-    leaf = s.leaf_field
-    # All slicer levels must come from the same entity (Power BI doesn't
-    # render cross-entity hierarchies in a single slicer). Validate up
-    # front rather than emit silently broken JSON.
     entities = {c.entity for c in levels}
     if len(entities) > 1:
         raise ValueError(
             f"Slicer hierarchy levels must share an entity; got {sorted(entities)}"
         )
-    src = leaf.entity[0] or "d"
-    # Hierarchy slicers only render correctly in Basic mode.
-    mode: SlicerMode = "Basic" if s.is_hierarchy else s.mode
-
-    objects: dict[str, Any] = {
-        "data": [
-            {"properties": {"mode": {"expr": {"Literal": {"Value": f"'{mode}'"}}}}}
-        ]
-    }
+    # These two knobs are accepted for source compatibility but have no
+    # attested modern-PBIR bytes yet, so they are dropped rather than
+    # guessed. Warn loudly — silently emitting a slicer that ignores a
+    # caller's scoping intent is exactly the failure class this migration
+    # set out to remove. See the module docstring's "PBIR shapes that
+    # still need a UI capture" note.
+    if s.mode != "Dropdown":
+        log.warning(
+            "Slicer mode ignored — listSlicer has no attested PBIR mode bytes; "
+            "emitting a plain listSlicer (needs UI capture to support modes)",
+            slicer=s.name,
+            requested_mode=s.mode,
+        )
     if s.allow_values:
-        objects["general"] = [
-            {
-                "properties": {
-                    "filter": {
-                        "filter": {
-                            "Version": 2,
-                            "From": [{"Name": src, "Entity": leaf.entity, "Type": 0}],
-                            "Where": [
-                                {
-                                    "Condition": {
-                                        "In": {
-                                            "Expressions": [
-                                                {
-                                                    "Column": {
-                                                        "Expression": {
-                                                            "SourceRef": {"Source": src}
-                                                        },
-                                                        "Property": leaf.name,
-                                                    }
-                                                }
-                                            ],
-                                            "Values": [
-                                                [{"Literal": {"Value": f"'{v}'"}}]
-                                                for v in s.allow_values
-                                            ],
-                                        }
-                                    }
-                                }
-                            ],
-                        }
-                    }
-                }
-            }
-        ]
-
-    inner: dict[str, Any] = {
-        "name": s.name,
-        "layouts": _layout_block(s),
-        "singleVisual": {
-            "visualType": "slicer",
-            "projections": {
-                "Values": [
-                    {"queryRef": f"{c.entity}.{c.name}", "active": True} for c in levels
-                ]
-            },
-            "prototypeQuery": {
-                "Version": 2,
-                "From": [{"Name": src, "Entity": leaf.entity, "Type": 0}],
-                "Select": [_select_column(c, src) for c in levels],
-            },
-            "drillFilterOtherVisuals": True,
-            "objects": objects,
-        },
-    }
-    if s.is_hierarchy:
-        # Default to all levels collapsed; users wanting a preselected
-        # expansion path should customize in Desktop after first save.
-        inner["singleVisual"]["expansionStates"] = [
-            {
-                "roles": ["Values"],
-                "levels": [
-                    {
-                        "queryRefs": [f"{c.entity}.{c.name}"],
-                        "isCollapsed": True,
-                    }
-                    for c in levels
-                ],
-                "root": {"identityValues": None, "children": []},
-            }
-        ]
-    return inner
-
-
-# ── Card (single-metric) emitter ───────────────────────────────────────────
-
-
-def _emit_card_config(c: Card) -> dict[str, Any]:
-    src = c.measure.entity[0] or "f"
-    full_name = f"{c.measure.entity}.{c.measure.name}"
-    objects: dict[str, Any] = {
-        "value": [
-            {
-                "properties": {
-                    "displayUnits": {
-                        "expr": {
-                            "Literal": {
-                                "Value": _DISPLAY_UNITS_LITERAL[c.display_units]
-                            }
-                        }
-                    }
-                },
-                "selector": {"id": "default"},
-            }
-        ]
-    }
-    column_properties: dict[str, Any] = {}
-    if c.measure.format_string:
-        column_properties[full_name] = {"formatString": c.measure.format_string}
-    inner: dict[str, Any] = {
-        "name": c.name,
-        "layouts": _layout_block(c),
-        "singleVisual": {
-            "visualType": "cardVisual",
-            "projections": {"Data": [{"queryRef": full_name}]},
-            "prototypeQuery": {
-                "Version": 2,
-                "From": [{"Name": src, "Entity": c.measure.entity, "Type": 0}],
-                "Select": [_select_measure(c.measure, src)],
-            },
-            "columnProperties": column_properties,
-            "drillFilterOtherVisuals": True,
-            "objects": objects,
-        },
-    }
-    if c.title is not None:
-        inner["singleVisual"]["vcObjects"] = {
-            "title": [
-                {
-                    "properties": {
-                        "show": {"expr": {"Literal": {"Value": "true"}}},
-                        "text": {"expr": {"Literal": {"Value": f"'{c.title}'"}}},
-                    }
-                }
-            ]
-            if c.title
-            else [{"properties": {"show": {"expr": {"Literal": {"Value": "false"}}}}}]
-        }
-    return inner
-
-
-# ── MultiCard emitter ──────────────────────────────────────────────────────
-
-
-def _emit_multicard_config(mc: MultiCard) -> dict[str, Any]:
-    if not mc.measures:
-        raise ValueError("MultiCard requires at least one measure")
-    src = mc.measures[0].entity[0] or "f"
-    entity = mc.measures[0].entity
-    if any(m.entity != entity for m in mc.measures):
-        raise ValueError("MultiCard measures must all live on the same entity (table)")
-
-    projections = [{"queryRef": f"{m.entity}.{m.name}"} for m in mc.measures]
-    select = [_select_measure(m, src) for m in mc.measures]
-    column_properties = {
-        f"{m.entity}.{m.name}": {"formatString": m.format_string}
-        for m in mc.measures
-        if m.format_string
-    }
-
-    # `referenceLabel` properties: one entry per measure with its
-    # measure-expression value. This is the per-tile binding the
-    # multi-card layout uses (in addition to `projections`).
-    reference_label = [
-        {
-            "properties": {
-                "value": {
-                    "expr": {
-                        "Measure": {
-                            "Expression": {"SourceRef": {"Entity": m.entity}},
-                            "Property": m.name,
-                        }
-                    }
-                }
-            },
-            "selector": {
-                "data": [{"dataViewWildcard": {"matchingOption": 0}}],
-                "metadata": f"{m.entity}.{m.name}",
-                "id": _id20("ref", mc.name, m.name),
-                "order": 0,
-            },
-        }
-        for m in mc.measures
-    ]
-    reference_label_value = [
-        {
-            "properties": {
-                "valueDisplayUnits": {
-                    "expr": {
-                        "Literal": {"Value": _DISPLAY_UNITS_LITERAL[mc.display_units]}
-                    }
-                }
-            },
-            "selector": {
-                "metadata": f"{m.entity}.{m.name}",
-                "id": _id20("ref", mc.name, m.name),
-            },
-        }
-        for m in mc.measures
-    ]
-    # Hide the auto-generated reference-label titles per measure so the
-    # tile shows the value cleanly.
-    reference_label_title = [
-        {
-            "properties": {"show": {"expr": {"Literal": {"Value": "false"}}}},
-            "selector": {"metadata": f"{m.entity}.{m.name}"},
-        }
-        for m in mc.measures
-    ]
-
-    objects: dict[str, Any] = {
-        "layout": [
-            {
-                "properties": {
-                    "style": {"expr": {"Literal": {"Value": "'Cards'"}}},
-                    "orientation": {"expr": {"Literal": {"Value": "2D"}}},
-                }
-            }
-        ],
-        "referenceLabel": reference_label,
-        "referenceLabelTitle": reference_label_title,
-        "referenceLabelValue": reference_label_value,
-        "referenceLabelLayout": [
-            {
-                "properties": {
-                    "horizontalAlignment": {"expr": {"Literal": {"Value": "'center'"}}},
-                    "verticalAlignment": {"expr": {"Literal": {"Value": "'middle'"}}},
-                    "arrangement": {
-                        "expr": {"Literal": {"Value": f"'{mc.arrangement}'"}}
-                    },
-                },
-                "selector": {"id": "default"},
-            }
-        ],
-    }
-    if mc.show_outline:
-        objects["outline"] = [
-            {
-                "properties": {"show": {"expr": {"Literal": {"Value": "true"}}}},
-                "selector": {"id": "default"},
-            }
-        ]
-    if mc.show_accent_bar:
-        objects["accentBar"] = [
-            {
-                "properties": {"show": {"expr": {"Literal": {"Value": "true"}}}},
-                "selector": {"id": "default"},
-            }
-        ]
-    if mc.show_shadow:
-        objects["shadowCustom"] = [
-            {
-                "properties": {"show": {"expr": {"Literal": {"Value": "true"}}}},
-                "selector": {"id": "default"},
-            }
-        ]
-
-    # Label styling for the per-tile measure-name text. Only emit when
-    # the user set at least one knob; otherwise leave Power BI defaults.
-    if any(
-        v is not None
-        for v in (mc.label_heading, mc.label_position, mc.label_font_color)
-    ):
-        label_props: dict[str, Any] = {"show": {"expr": {"Literal": {"Value": "true"}}}}
-        if mc.label_heading is not None:
-            label_props["heading"] = {
-                "expr": {"Literal": {"Value": f"'{mc.label_heading}'"}}
-            }
-        if mc.label_position is not None:
-            label_props["position"] = {
-                "expr": {"Literal": {"Value": f"'{mc.label_position}'"}}
-            }
-        if mc.label_font_color is not None:
-            label_props["fontColor"] = _theme_color_solid(mc.label_font_color)
-        objects["label"] = [{"properties": label_props, "selector": {"id": "default"}}]
-
+        log.warning(
+            "Slicer allow_values ignored — the hardcoded allow-list filter has "
+            "no attested PBIR bytes yet; the slicer will NOT be scoped to those "
+            "values (needs UI capture)",
+            slicer=s.name,
+            allow_values=s.allow_values,
+        )
+    projections = []
+    for i, col in enumerate(levels):
+        proj = _projection(col)
+        proj["active"] = i == 0
+        projections.append(proj)
     return {
-        "name": mc.name,
-        "layouts": _layout_block(mc),
-        "singleVisual": {
-            "visualType": "cardVisual",
-            "projections": {"Data": projections},
-            "prototypeQuery": {
-                "Version": 2,
-                "From": [{"Name": src, "Entity": entity, "Type": 0}],
-                "Select": select,
-            },
-            "columnProperties": column_properties,
-            "drillFilterOtherVisuals": True,
-            "objects": objects,
-            "vcObjects": {
-                "title": [
-                    {"properties": {"show": {"expr": {"Literal": {"Value": "false"}}}}}
-                ]
-            },
-        },
+        "visualType": "listSlicer",
+        "query": {"queryState": {"Values": {"projections": projections}}},
+        "drillFilterOtherVisuals": True,
     }
 
 
 # ── Table emitter ──────────────────────────────────────────────────────────
 
 
-def _emit_table_config(t: Table) -> dict[str, Any]:
+def _emit_table_body(t: Table) -> dict[str, Any]:
     if not t.fields:
         raise ValueError("Table requires at least one field")
+    projectables = [_projectable(f) for f in t.fields]
 
-    # Build From clause: one alias per distinct entity referenced.
-    entities: dict[str, str] = {}  # entity -> alias
-
-    def _alias(entity: str) -> str:
-        if entity not in entities:
-            entities[entity] = f"t{len(entities)}"
-        return entities[entity]
-
-    select_clauses = []
-    projections = []
-    column_properties: dict[str, Any] = {}
-    for f in t.fields:
-        if isinstance(f, Column):
-            alias = _alias(f.entity)
-            select_clauses.append(_select_column(f, alias))
-            projections.append({"queryRef": f"{f.entity}.{f.name}"})
-            if f.format_string:
-                column_properties[f"{f.entity}.{f.name}"] = {
-                    "formatString": f.format_string
-                }
-        elif isinstance(f, Measure):
-            alias = _alias(f.entity)
-            select_clauses.append(_select_measure(f, alias))
-            projections.append({"queryRef": f"{f.entity}.{f.name}"})
-            if f.format_string:
-                column_properties[f"{f.entity}.{f.name}"] = {
-                    "formatString": f.format_string
-                }
-        else:  # Aggregate
-            alias = _alias(f.entity)
-            select_clauses.append(_select_aggregate(f, alias))
-            ref_name = _aggregate_ref_name(f)
-            projections.append({"queryRef": ref_name})
-            if f.format_string:
-                column_properties[ref_name] = {"formatString": f.format_string}
-
-    from_clauses = [
-        {"Name": alias, "Entity": entity, "Type": 0}
-        for entity, alias in entities.items()
-    ]
-
-    prototype_query: dict[str, Any] = {
-        "Version": 2,
-        "From": from_clauses,
-        "Select": select_clauses,
+    query: dict[str, Any] = {
+        "queryState": {
+            "Values": {"projections": [_projection(f) for f in projectables]}
+        }
     }
     if t.order_by is not None:
-        prototype_query["OrderBy"] = [_order_by_clause(t.order_by, _alias)]
+        query["sortDefinition"] = {"sort": [_sort_entry(t.order_by)]}
 
-    return {
-        "name": t.name,
-        "layouts": _layout_block(t),
-        "singleVisual": {
-            "visualType": "tableEx",
-            "projections": {"Values": projections},
-            "prototypeQuery": prototype_query,
-            "columnProperties": column_properties,
-            "drillFilterOtherVisuals": True,
-        },
+    body: dict[str, Any] = {
+        "visualType": "tableEx",
+        "query": query,
     }
-
-
-# ── Internal: prototype-query Select / OrderBy clause builders ─────────────
-
-
-def _select_column(c: Column, alias: str) -> dict[str, Any]:
-    return {
-        "Column": {
-            "Expression": {"SourceRef": {"Source": alias}},
-            "Property": c.name,
-        },
-        "Name": f"{c.entity}.{c.name}",
-    }
-
-
-def _select_measure(m: Measure, alias: str) -> dict[str, Any]:
-    return {
-        "Measure": {
-            "Expression": {"SourceRef": {"Source": alias}},
-            "Property": m.name,
-        },
-        "Name": f"{m.entity}.{m.name}",
-        "NativeReferenceName": m.name,
-    }
-
-
-def _select_aggregate(a: Aggregate, alias: str) -> dict[str, Any]:
-    return {
-        "Aggregation": {
-            "Expression": {
-                "Column": {
-                    "Expression": {"SourceRef": {"Source": alias}},
-                    "Property": a.column,
-                }
-            },
-            "Function": _AGG_FN_INDEX[a.function],
-        },
-        "Name": _aggregate_ref_name(a),
-        "NativeReferenceName": f"{_AGG_FN_LABEL[a.function]} of {a.column}",
-    }
-
-
-def _order_by_clause(ob: TableOrderBy, alias_lookup: Any) -> dict[str, Any]:
-    direction = _SORT_DIR_INDEX[ob.direction]
-    f = ob.field
-    if isinstance(f, Column):
-        alias = alias_lookup(f.entity)
-        return {
-            "Direction": direction,
-            "Expression": {
-                "Column": {
-                    "Expression": {"SourceRef": {"Source": alias}},
-                    "Property": f.name,
-                }
-            },
-        }
-    if isinstance(f, Measure):
-        alias = alias_lookup(f.entity)
-        return {
-            "Direction": direction,
-            "Expression": {
-                "Measure": {
-                    "Expression": {"SourceRef": {"Source": alias}},
-                    "Property": f.name,
-                }
-            },
-        }
-    # Aggregate
-    alias = alias_lookup(f.entity)
-    return {
-        "Direction": direction,
-        "Expression": {
-            "Aggregation": {
-                "Expression": {
-                    "Column": {
-                        "Expression": {"SourceRef": {"Source": alias}},
-                        "Property": f.column,
+    if t.title is not None:
+        body["visualContainerObjects"] = {
+            "title": [
+                {
+                    "properties": {
+                        "show": {"expr": {"Literal": {"Value": "true"}}},
+                        "text": {
+                            "expr": {
+                                "Measure": {
+                                    "Expression": {
+                                        "SourceRef": {"Entity": t.title.entity}
+                                    },
+                                    "Property": t.title.name,
+                                }
+                            }
+                        },
                     }
-                },
-                "Function": _AGG_FN_INDEX[f.function],
-            }
-        },
-    }
+                }
+            ]
+        }
+    body["drillFilterOtherVisuals"] = True
+    return body
 
 
-# Capitalized labels used in NativeReferenceName for aggregates
-# (e.g. "Sum of missing_field_count") — matches what Power BI emits.
-_AGG_FN_LABEL: dict[AggregationFunction, str] = {
-    "sum": "Sum",
-    "avg": "Average",
-    "min": "Min",
-    "max": "Max",
-    "count": "Count",
-    "distinctCount": "Count (Distinct)",
-}
+def _sort_entry(ob: TableOrderBy) -> dict[str, Any]:
+    if not isinstance(ob.field, Column):
+        raise NotImplementedError(
+            "sort-by-measure/aggregate has no attested PBIR shape — "
+            "sort by a column or capture reference bytes"
+        )
+    entry = _field_ref(ob.field)
+    entry["direction"] = _SORT_DIRECTION[ob.direction]
+    return entry
 
 
-def _aggregate_ref_name(a: Aggregate) -> str:
-    """The queryRef name for an aggregate column, e.g. ``Sum(table.col)``."""
-    cap = _AGG_FN_LABEL[a.function].split(" ")[0]
-    return f"{cap}({a.entity}.{a.column})"
+# ── filterConfig (one filter per projected field) ──────────────────────────
+
+
+def _emit_filter_config(v: Visual) -> dict[str, Any]:
+    """One ``filterConfig.filters[]`` entry per projected field.
+
+    Columns use ``type:"Categorical"``; measures use ``type:"Advanced"``
+    (matches the reference reports). Filter ``name`` ids are derived
+    deterministically from the visual name + property so output is
+    byte-stable across saves.
+    """
+    fields = _filterable_fields(v)
+    filters = []
+    for ref in fields:
+        entry = _field_ref(ref)
+        entry_with_name: dict[str, Any] = {"name": _id20(v.name, ref.entity, ref.name)}
+        entry_with_name.update(entry)
+        entry_with_name["type"] = (
+            "Advanced" if isinstance(ref, Measure) else "Categorical"
+        )
+        filters.append(entry_with_name)
+    return {"filters": filters}
+
+
+def _filterable_fields(v: Visual) -> list[Column | Measure]:
+    if isinstance(v, Slicer):
+        return list(v.field_levels)
+    if isinstance(v, Table):
+        return [_projectable(f) for f in v.fields]
+    return []

--- a/tests/items/fixtures/pbir_report/rpt_golden.Report/.platform
+++ b/tests/items/fixtures/pbir_report/rpt_golden.Report/.platform
@@ -1,0 +1,11 @@
+{
+  "$schema": "https://developer.microsoft.com/json-schemas/fabric/gitIntegration/platformProperties/2.0.0/schema.json",
+  "metadata": {
+    "type": "Report",
+    "displayName": "rpt_golden"
+  },
+  "config": {
+    "version": "2.0",
+    "logicalId": "f1d606f1-d262-b501-40f8-1f64df6fb535"
+  }
+}

--- a/tests/items/fixtures/pbir_report/rpt_golden.Report/definition.pbir
+++ b/tests/items/fixtures/pbir_report/rpt_golden.Report/definition.pbir
@@ -1,0 +1,9 @@
+{
+  "$schema": "https://developer.microsoft.com/json-schemas/fabric/item/report/definitionProperties/2.0.0/schema.json",
+  "version": "4.0",
+  "datasetReference": {
+    "byPath": {
+      "path": "../sm_golden.SemanticModel"
+    }
+  }
+}

--- a/tests/items/fixtures/pbir_report/rpt_golden.Report/definition/pages/page001slicertable/page.json
+++ b/tests/items/fixtures/pbir_report/rpt_golden.Report/definition/pages/page001slicertable/page.json
@@ -1,0 +1,8 @@
+{
+  "$schema": "https://developer.microsoft.com/json-schemas/fabric/item/report/definition/page/2.1.0/schema.json",
+  "name": "page001slicertable",
+  "displayName": "Page 1",
+  "displayOption": "FitToPage",
+  "height": 720,
+  "width": 1280
+}

--- a/tests/items/fixtures/pbir_report/rpt_golden.Report/definition/pages/page001slicertable/visuals/vis0slicer0000000000/visual.json
+++ b/tests/items/fixtures/pbir_report/rpt_golden.Report/definition/pages/page001slicertable/visuals/vis0slicer0000000000/visual.json
@@ -1,0 +1,57 @@
+{
+  "$schema": "https://developer.microsoft.com/json-schemas/fabric/item/report/definition/visualContainer/2.10.0/schema.json",
+  "name": "vis0slicer0000000000",
+  "position": {
+    "x": 10,
+    "y": 0,
+    "z": 0,
+    "height": 280,
+    "width": 430,
+    "tabOrder": 0
+  },
+  "visual": {
+    "visualType": "listSlicer",
+    "query": {
+      "queryState": {
+        "Values": {
+          "projections": [
+            {
+              "field": {
+                "Column": {
+                  "Expression": {
+                    "SourceRef": {
+                      "Entity": "dim_x"
+                    }
+                  },
+                  "Property": "name"
+                }
+              },
+              "queryRef": "dim_x.name",
+              "nativeQueryRef": "name",
+              "active": true
+            }
+          ]
+        }
+      }
+    },
+    "drillFilterOtherVisuals": true
+  },
+  "filterConfig": {
+    "filters": [
+      {
+        "name": "2245af2be24353fc9cb7",
+        "field": {
+          "Column": {
+            "Expression": {
+              "SourceRef": {
+                "Entity": "dim_x"
+              }
+            },
+            "Property": "name"
+          }
+        },
+        "type": "Categorical"
+      }
+    ]
+  }
+}

--- a/tests/items/fixtures/pbir_report/rpt_golden.Report/definition/pages/page001slicertable/visuals/vis1tablecol00000000/visual.json
+++ b/tests/items/fixtures/pbir_report/rpt_golden.Report/definition/pages/page001slicertable/visuals/vis1tablecol00000000/visual.json
@@ -1,0 +1,101 @@
+{
+  "$schema": "https://developer.microsoft.com/json-schemas/fabric/item/report/definition/visualContainer/2.10.0/schema.json",
+  "name": "vis1tablecol00000000",
+  "position": {
+    "x": 460,
+    "y": 0,
+    "z": 1,
+    "height": 270,
+    "width": 780,
+    "tabOrder": 1
+  },
+  "visual": {
+    "visualType": "tableEx",
+    "query": {
+      "queryState": {
+        "Values": {
+          "projections": [
+            {
+              "field": {
+                "Column": {
+                  "Expression": {
+                    "SourceRef": {
+                      "Entity": "dim_x"
+                    }
+                  },
+                  "Property": "name"
+                }
+              },
+              "queryRef": "dim_x.name",
+              "nativeQueryRef": "name"
+            },
+            {
+              "field": {
+                "Column": {
+                  "Expression": {
+                    "SourceRef": {
+                      "Entity": "dim_x"
+                    }
+                  },
+                  "Property": "city"
+                }
+              },
+              "queryRef": "dim_x.city",
+              "nativeQueryRef": "city"
+            }
+          ]
+        }
+      },
+      "sortDefinition": {
+        "sort": [
+          {
+            "field": {
+              "Column": {
+                "Expression": {
+                  "SourceRef": {
+                    "Entity": "dim_x"
+                  }
+                },
+                "Property": "name"
+              }
+            },
+            "direction": "Ascending"
+          }
+        ]
+      }
+    },
+    "drillFilterOtherVisuals": true
+  },
+  "filterConfig": {
+    "filters": [
+      {
+        "name": "763a3b1139b75e7c99c7",
+        "field": {
+          "Column": {
+            "Expression": {
+              "SourceRef": {
+                "Entity": "dim_x"
+              }
+            },
+            "Property": "name"
+          }
+        },
+        "type": "Categorical"
+      },
+      {
+        "name": "7b2ecdc8811c5f9087f9",
+        "field": {
+          "Column": {
+            "Expression": {
+              "SourceRef": {
+                "Entity": "dim_x"
+              }
+            },
+            "Property": "city"
+          }
+        },
+        "type": "Categorical"
+      }
+    ]
+  }
+}

--- a/tests/items/fixtures/pbir_report/rpt_golden.Report/definition/pages/page001slicertable/visuals/vis2tablemeas0000000/visual.json
+++ b/tests/items/fixtures/pbir_report/rpt_golden.Report/definition/pages/page001slicertable/visuals/vis2tablemeas0000000/visual.json
@@ -1,0 +1,101 @@
+{
+  "$schema": "https://developer.microsoft.com/json-schemas/fabric/item/report/definition/visualContainer/2.10.0/schema.json",
+  "name": "vis2tablemeas0000000",
+  "position": {
+    "x": 460,
+    "y": 290,
+    "z": 2,
+    "height": 270,
+    "width": 780,
+    "tabOrder": 2
+  },
+  "visual": {
+    "visualType": "tableEx",
+    "query": {
+      "queryState": {
+        "Values": {
+          "projections": [
+            {
+              "field": {
+                "Column": {
+                  "Expression": {
+                    "SourceRef": {
+                      "Entity": "dim_x"
+                    }
+                  },
+                  "Property": "name"
+                }
+              },
+              "queryRef": "dim_x.name",
+              "nativeQueryRef": "name"
+            },
+            {
+              "field": {
+                "Measure": {
+                  "Expression": {
+                    "SourceRef": {
+                      "Entity": "fact_x"
+                    }
+                  },
+                  "Property": "Total Rows"
+                }
+              },
+              "queryRef": "fact_x.Total Rows",
+              "nativeQueryRef": "Total Rows"
+            }
+          ]
+        }
+      },
+      "sortDefinition": {
+        "sort": [
+          {
+            "field": {
+              "Column": {
+                "Expression": {
+                  "SourceRef": {
+                    "Entity": "dim_x"
+                  }
+                },
+                "Property": "name"
+              }
+            },
+            "direction": "Ascending"
+          }
+        ]
+      }
+    },
+    "drillFilterOtherVisuals": true
+  },
+  "filterConfig": {
+    "filters": [
+      {
+        "name": "e5d22a8189815a24a444",
+        "field": {
+          "Column": {
+            "Expression": {
+              "SourceRef": {
+                "Entity": "dim_x"
+              }
+            },
+            "Property": "name"
+          }
+        },
+        "type": "Categorical"
+      },
+      {
+        "name": "8f55b3c7692458d49185",
+        "field": {
+          "Measure": {
+            "Expression": {
+              "SourceRef": {
+                "Entity": "fact_x"
+              }
+            },
+            "Property": "Total Rows"
+          }
+        },
+        "type": "Advanced"
+      }
+    ]
+  }
+}

--- a/tests/items/fixtures/pbir_report/rpt_golden.Report/definition/pages/pages.json
+++ b/tests/items/fixtures/pbir_report/rpt_golden.Report/definition/pages/pages.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://developer.microsoft.com/json-schemas/fabric/item/report/definition/pagesMetadata/1.1.0/schema.json",
+  "pageOrder": [
+    "page001slicertable"
+  ],
+  "activePageName": "page001slicertable"
+}

--- a/tests/items/fixtures/pbir_report/rpt_golden.Report/definition/report.json
+++ b/tests/items/fixtures/pbir_report/rpt_golden.Report/definition/report.json
@@ -1,0 +1,26 @@
+{
+  "$schema": "https://developer.microsoft.com/json-schemas/fabric/item/report/definition/report/3.3.0/schema.json",
+  "objects": {
+    "section": [
+      {
+        "properties": {
+          "verticalAlignment": {
+            "expr": {
+              "Literal": {
+                "Value": "'Top'"
+              }
+            }
+          }
+        }
+      }
+    ]
+  },
+  "settings": {
+    "useStylableVisualContainerHeader": true,
+    "exportDataMode": "AllowSummarized",
+    "defaultDrillFilterOtherVisuals": true,
+    "allowChangeFilterTypes": true,
+    "useEnhancedTooltips": true,
+    "useDefaultAggregateDisplayName": true
+  }
+}

--- a/tests/items/fixtures/pbir_report/rpt_golden.Report/definition/version.json
+++ b/tests/items/fixtures/pbir_report/rpt_golden.Report/definition/version.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://developer.microsoft.com/json-schemas/fabric/item/report/definition/versionMetadata/1.0.0/schema.json",
+  "version": "2.0.0"
+}

--- a/tests/items/test_report.py
+++ b/tests/items/test_report.py
@@ -1,4 +1,19 @@
-"""Tests for the Report (PBIR-Legacy) builder."""
+"""Tests for the Report (modern PBIR) builder.
+
+The centerpiece is :class:`TestGoldenPbir`, a serializer proof: it
+reconstructs a hand-cleaned, Fabric-derived PBIR report via the builder
+(with every page/visual/filter id and position pinned to the fixture's
+exact values) and asserts **byte-equality** against each fixture file.
+The fixture under ``fixtures/pbir_report/`` was authored from the real
+Fabric output of a slicer + two tables, scrubbed to generic entity names
+and stripped of UI-default / drag / runtime-selection state — so the
+test is grounded in Fabric's structure without being circular.
+
+The remaining classes are focused unit tests per emitter (slicer, table,
+projections, sort, measure-bound title) and coverage of the
+``NotImplementedError`` boundaries for features whose PBIR bytes are not
+yet attested (Card/MultiCard, inline Aggregate, sort-by-measure).
+"""
 
 import json
 from pathlib import Path
@@ -19,475 +34,477 @@ from pyfabric.items.report import (
     Table,
     TableOrderBy,
     Theme,
-    ThemeColor,
 )
 
-# ── Fixtures ────────────────────────────────────────────────────────────────
+FIXTURE_ROOT = Path(__file__).parent / "fixtures" / "pbir_report" / "rpt_golden.Report"
 
 
-@pytest.fixture
-def basic_page() -> Page:
-    return Page(
-        display_name="QA Summary",
+# ── Golden byte-equality test ───────────────────────────────────────────────
+
+
+def _golden_report() -> Report:
+    """Reconstruct the golden fixture report via the builder.
+
+    Every id and position is pinned to the fixture's exact values so the
+    output is deterministic and byte-comparable.
+    """
+    page = Page(
+        display_name="Page 1",
+        name="page001slicertable",
+        width=1280,
+        height=720,
         visuals=[
             Slicer(
-                position=Position(x=10, y=10, width=200, height=80),
-                field=Column("dim_projection", "region"),
-                mode="Dropdown",
+                name="vis0slicer0000000000",
+                position=Position(x=10, y=0, z=0, width=430, height=280, tab_order=0),
+                field=Column("dim_x", "name"),
             ),
-            Card(
-                position=Position(x=10, y=100, width=200, height=120),
-                measure=Measure("fact_x", "# PDFs Total", format_string="#,0"),
+            Table(
+                name="vis1tablecol00000000",
+                position=Position(x=460, y=0, z=1, width=780, height=270, tab_order=1),
+                fields=[
+                    Column("dim_x", "name"),
+                    Column("dim_x", "city"),
+                ],
+                order_by=TableOrderBy(field=Column("dim_x", "name"), direction="asc"),
+            ),
+            Table(
+                name="vis2tablemeas0000000",
+                position=Position(
+                    x=460, y=290, z=2, width=780, height=270, tab_order=2
+                ),
+                fields=[
+                    Column("dim_x", "name"),
+                    Measure("fact_x", "Total Rows"),
+                ],
+                order_by=TableOrderBy(field=Column("dim_x", "name"), direction="asc"),
             ),
         ],
     )
-
-
-@pytest.fixture
-def report_minimal(basic_page: Page) -> Report:
     return Report(
-        name="rpt_test",
-        semantic_model_path="../sm_test.SemanticModel",
-        pages=[basic_page],
-        description="Test report fixture.",
+        name="rpt_golden",
+        semantic_model_path="../sm_golden.SemanticModel",
+        pages=[page],
+        description="Golden fixture report.",
+        logical_id="f1d606f1-d262-b501-40f8-1f64df6fb535",
     )
 
 
-# ── Report.save_to_disk ─────────────────────────────────────────────────────
+def _all_fixture_files() -> list[Path]:
+    return sorted(p for p in FIXTURE_ROOT.rglob("*") if p.is_file())
+
+
+class TestGoldenPbir:
+    def test_byte_equal_to_fixture(self, tmp_path: Path) -> None:
+        item_dir = _golden_report().save_to_disk(tmp_path)
+        assert item_dir == tmp_path / "rpt_golden.Report"
+
+        fixture_files = _all_fixture_files()
+        assert fixture_files, "fixture is empty — check FIXTURE_ROOT"
+
+        for fixture_file in fixture_files:
+            rel = fixture_file.relative_to(FIXTURE_ROOT)
+            emitted = item_dir / rel
+            assert emitted.exists(), f"builder did not emit {rel}"
+            expected = fixture_file.read_bytes()
+            actual = emitted.read_bytes()
+            assert actual == expected, (
+                f"byte mismatch in {rel}\n"
+                f"--- expected (fixture) ---\n{expected.decode('utf-8')}\n"
+                f"--- actual (emitted) ---\n{actual.decode('utf-8')}"
+            )
+
+    def test_emits_exactly_the_fixture_file_set(self, tmp_path: Path) -> None:
+        item_dir = _golden_report().save_to_disk(tmp_path)
+        emitted = {p.relative_to(item_dir) for p in item_dir.rglob("*") if p.is_file()}
+        expected = {p.relative_to(FIXTURE_ROOT) for p in _all_fixture_files()}
+        assert emitted == expected
+
+
+# ── Helpers for structural unit tests ───────────────────────────────────────
+
+
+def _visual_json(item_dir: Path, page_name: str, visual_name: str) -> dict:
+    p = (
+        item_dir
+        / "definition"
+        / "pages"
+        / page_name
+        / "visuals"
+        / visual_name
+        / "visual.json"
+    )
+    return json.loads(p.read_text("utf-8"))
+
+
+def _one_visual_report(visual: Slicer | Table, *, page_name: str = "p") -> Report:
+    page = Page(display_name="P", name=page_name, visuals=[visual])
+    return Report("rpt", "../x.SemanticModel", [page], strict_descriptions=False)
+
+
+# ── save_to_disk / folder structure ─────────────────────────────────────────
 
 
 class TestSaveToDisk:
-    def test_creates_full_folder_structure(
-        self, report_minimal: Report, tmp_path: Path
-    ) -> None:
-        item_dir = report_minimal.save_to_disk(tmp_path)
-        assert item_dir == tmp_path / "rpt_test.Report"
+    def test_creates_pbir_folder_structure(self, tmp_path: Path) -> None:
+        visual = Slicer(
+            name="v",
+            position=Position(x=0, y=0, width=200, height=80),
+            field=Column("dim_x", "region"),
+        )
+        item_dir = _one_visual_report(visual).save_to_disk(tmp_path)
         assert (item_dir / ".platform").exists()
         assert (item_dir / "definition.pbir").exists()
-        assert (item_dir / "report.json").exists()
+        assert (item_dir / "definition" / "version.json").exists()
+        assert (item_dir / "definition" / "report.json").exists()
+        assert (item_dir / "definition" / "pages" / "pages.json").exists()
+        assert (item_dir / "definition" / "pages" / "p" / "page.json").exists()
+        # No legacy single report.json at the item root.
+        assert not (item_dir / "report.json").exists()
 
-    def test_platform_metadata(self, report_minimal: Report, tmp_path: Path) -> None:
-        item_dir = report_minimal.save_to_disk(tmp_path)
+    def test_platform_omits_description(self, tmp_path: Path) -> None:
+        visual = Slicer(
+            name="v",
+            position=Position(x=0, y=0, width=200, height=80),
+            field=Column("dim_x", "region"),
+        )
+        report = Report(
+            "rpt",
+            "../x.SemanticModel",
+            [Page(display_name="P", name="p", visuals=[visual])],
+            description="A real description that Fabric would strip.",
+        )
+        item_dir = report.save_to_disk(tmp_path)
         platform = json.loads((item_dir / ".platform").read_text("utf-8"))
         assert platform["metadata"]["type"] == "Report"
-        assert platform["metadata"]["displayName"] == "rpt_test"
-        assert platform["config"]["version"] == "2.0"
-        assert platform["config"]["logicalId"]
+        assert platform["metadata"]["displayName"] == "rpt"
+        # Fabric strips report descriptions from .platform → we never write one.
+        assert "description" not in platform["metadata"]
 
-    def test_pbir_byPath_reference(
-        self, report_minimal: Report, tmp_path: Path
-    ) -> None:
-        item_dir = report_minimal.save_to_disk(tmp_path)
+    def test_pbir_byPath_reference(self, tmp_path: Path) -> None:
+        visual = Slicer(
+            name="v",
+            position=Position(x=0, y=0, width=200, height=80),
+            field=Column("dim_x", "region"),
+        )
+        item_dir = _one_visual_report(visual).save_to_disk(tmp_path)
         pbir = json.loads((item_dir / "definition.pbir").read_text("utf-8"))
         assert pbir["version"] == "4.0"
-        assert pbir["datasetReference"]["byPath"]["path"] == "../sm_test.SemanticModel"
+        assert pbir["datasetReference"]["byPath"]["path"] == "../x.SemanticModel"
 
-    def test_files_use_lf_no_trailing_newline(
-        self, report_minimal: Report, tmp_path: Path
-    ) -> None:
-        item_dir = report_minimal.save_to_disk(tmp_path)
-        for p in (
-            item_dir / ".platform",
-            item_dir / "definition.pbir",
-            item_dir / "report.json",
-        ):
+    def test_version_json(self, tmp_path: Path) -> None:
+        visual = Slicer(
+            name="v",
+            position=Position(x=0, y=0, width=200, height=80),
+            field=Column("dim_x", "region"),
+        )
+        item_dir = _one_visual_report(visual).save_to_disk(tmp_path)
+        version = json.loads(
+            (item_dir / "definition" / "version.json").read_text("utf-8")
+        )
+        assert version["version"] == "2.0.0"
+
+    def test_report_json_settings_are_enum_strings(self, tmp_path: Path) -> None:
+        visual = Slicer(
+            name="v",
+            position=Position(x=0, y=0, width=200, height=80),
+            field=Column("dim_x", "region"),
+        )
+        item_dir = _one_visual_report(visual).save_to_disk(tmp_path)
+        rj = json.loads((item_dir / "definition" / "report.json").read_text("utf-8"))
+        # exportDataMode is an enum string in modern PBIR, not the legacy int.
+        assert rj["settings"]["exportDataMode"] == "AllowSummarized"
+        assert rj["objects"]["section"]
+
+    def test_files_use_lf_no_trailing_newline(self, tmp_path: Path) -> None:
+        visual = Slicer(
+            name="v",
+            position=Position(x=0, y=0, width=200, height=80),
+            field=Column("dim_x", "region"),
+        )
+        item_dir = _one_visual_report(visual).save_to_disk(tmp_path)
+        for p in item_dir.rglob("*"):
+            if not p.is_file():
+                continue
             raw = p.read_bytes()
             assert b"\r\n" not in raw, f"{p.name} has CRLF"
             assert not raw.endswith(b"\n"), f"{p.name} has trailing newline"
 
-    def test_visual_names_auto_assigned(self, basic_page: Page, tmp_path: Path) -> None:
-        # No names supplied; save_to_disk should fill them deterministically.
-        for v in basic_page.visuals:
+    def test_visual_names_auto_assigned(self, tmp_path: Path) -> None:
+        page = Page(
+            display_name="P",
+            visuals=[
+                Slicer(
+                    position=Position(x=0, y=0, width=200, height=80),
+                    field=Column("dim_x", "region"),
+                ),
+            ],
+        )
+        for v in page.visuals:
             assert v.name == ""
         Report(
-            name="rpt",
-            semantic_model_path="../x.SemanticModel",
-            pages=[basic_page],
-            strict_descriptions=False,
+            "rpt", "../x.SemanticModel", [page], strict_descriptions=False
         ).save_to_disk(tmp_path)
-        for v in basic_page.visuals:
+        for v in page.visuals:
             assert v.name != ""
             assert len(v.name) == 20
 
-    def test_deterministic_ids(self, basic_page: Page, tmp_path: Path) -> None:
-        # Two saves of the same model produce identical visual ids.
+    def test_deterministic_ids(self, tmp_path: Path) -> None:
+        def fresh_page() -> Page:
+            return Page(
+                display_name="P",
+                visuals=[
+                    Slicer(
+                        position=Position(x=0, y=0, width=200, height=80),
+                        field=Column("dim_x", "region"),
+                    ),
+                ],
+            )
+
         a = Report(
-            name="rpt",
-            semantic_model_path="../x.SemanticModel",
-            pages=[basic_page],
-            strict_descriptions=False,
+            "rpt", "../x.SemanticModel", [fresh_page()], strict_descriptions=False
         ).save_to_disk(tmp_path / "a")
-        # Page+visual names persist across saves; rebuild fresh page object
-        page2 = Page(
-            display_name=basic_page.display_name,
-            visuals=[
-                type(v)(
-                    **{k: getattr(v, k) for k in v.__dataclass_fields__ if k != "name"}
-                )
-                for v in basic_page.visuals
-            ],
-        )
         b = Report(
-            name="rpt",
-            semantic_model_path="../x.SemanticModel",
-            pages=[page2],
-            strict_descriptions=False,
+            "rpt", "../x.SemanticModel", [fresh_page()], strict_descriptions=False
         ).save_to_disk(tmp_path / "b")
-        rj_a = json.loads((a / "report.json").read_text("utf-8"))
-        rj_b = json.loads((b / "report.json").read_text("utf-8"))
-        a_names = [
-            json.loads(v["config"])["name"]
-            for v in rj_a["sections"][0]["visualContainers"]
-        ]
-        b_names = [
-            json.loads(v["config"])["name"]
-            for v in rj_b["sections"][0]["visualContainers"]
-        ]
-        assert a_names == b_names
-
-
-# ── Report JSON structure ──────────────────────────────────────────────────
-
-
-def _load_report_json(item_dir: Path) -> dict:
-    return json.loads((item_dir / "report.json").read_text("utf-8"))
-
-
-def _visual_configs(rj: dict, page_index: int = 0) -> list[dict]:
-    return [
-        json.loads(v["config"]) for v in rj["sections"][page_index]["visualContainers"]
-    ]
-
-
-class TestReportStructure:
-    def test_pods_one_per_page(self, report_minimal: Report, tmp_path: Path) -> None:
-        item_dir = report_minimal.save_to_disk(tmp_path)
-        rj = _load_report_json(item_dir)
-        assert len(rj["pods"]) == 1
-        assert rj["pods"][0]["boundSection"] == report_minimal.pages[0].name
-
-    def test_section_dimensions_and_name(
-        self, report_minimal: Report, tmp_path: Path
-    ) -> None:
-        item_dir = report_minimal.save_to_disk(tmp_path)
-        rj = _load_report_json(item_dir)
-        section = rj["sections"][0]
-        assert section["displayName"] == "QA Summary"
-        assert section["width"] == 1280
-        assert section["height"] == 720
-        assert section["name"]
+        a_pages = json.loads(
+            (a / "definition" / "pages" / "pages.json").read_text("utf-8")
+        )["pageOrder"]
+        b_pages = json.loads(
+            (b / "definition" / "pages" / "pages.json").read_text("utf-8")
+        )["pageOrder"]
+        assert a_pages == b_pages
 
 
 # ── Slicer ──────────────────────────────────────────────────────────────────
 
 
 class TestSlicer:
-    def test_dropdown_mode(self, tmp_path: Path) -> None:
-        page = Page(
-            display_name="P",
-            visuals=[
-                Slicer(
-                    position=Position(x=0, y=0, width=200, height=80),
-                    field=Column("dim_projection", "region"),
-                    mode="Dropdown",
-                ),
-            ],
+    def test_list_slicer_projection(self, tmp_path: Path) -> None:
+        visual = Slicer(
+            name="v",
+            position=Position(x=0, y=0, width=200, height=80),
+            field=Column("dim_projection", "region"),
         )
-        Report(
-            "rpt", "../x.SemanticModel", [page], strict_descriptions=False
-        ).save_to_disk(tmp_path)
-        rj = _load_report_json(tmp_path / "rpt.Report")
-        cfg = _visual_configs(rj)[0]
-        assert cfg["singleVisual"]["visualType"] == "slicer"
+        item_dir = _one_visual_report(visual).save_to_disk(tmp_path)
+        vj = _visual_json(item_dir, "p", "v")
+        assert vj["visual"]["visualType"] == "listSlicer"
+        proj = vj["visual"]["query"]["queryState"]["Values"]["projections"]
+        assert proj[0]["queryRef"] == "dim_projection.region"
+        assert proj[0]["nativeQueryRef"] == "region"
+        assert proj[0]["active"] is True
         assert (
-            cfg["singleVisual"]["projections"]["Values"][0]["queryRef"]
-            == "dim_projection.region"
-        )
-        mode = cfg["singleVisual"]["objects"]["data"][0]["properties"]["mode"]
-        assert mode["expr"]["Literal"]["Value"] == "'Dropdown'"
-
-    def test_allow_values_emits_filter(self, tmp_path: Path) -> None:
-        page = Page(
-            display_name="P",
-            visuals=[
-                Slicer(
-                    position=Position(x=0, y=0, width=200, height=80),
-                    field=Column("fact_x", "status"),
-                    mode="Basic",
-                    allow_values=["INCOMPLETE", "NOT_DETECTED"],
-                ),
-            ],
-        )
-        Report(
-            "rpt", "../x.SemanticModel", [page], strict_descriptions=False
-        ).save_to_disk(tmp_path)
-        rj = _load_report_json(tmp_path / "rpt.Report")
-        cfg = _visual_configs(rj)[0]
-        general = cfg["singleVisual"]["objects"]["general"][0]["properties"]
-        values = general["filter"]["filter"]["Where"][0]["Condition"]["In"]["Values"]
-        flat = [v[0]["Literal"]["Value"] for v in values]
-        assert flat == ["'INCOMPLETE'", "'NOT_DETECTED'"]
-
-
-# ── Card (single-metric) ───────────────────────────────────────────────────
-
-
-class TestCard:
-    def test_display_units_none_emits_1D(self, tmp_path: Path) -> None:
-        page = Page(
-            display_name="P",
-            visuals=[
-                Card(
-                    position=Position(x=0, y=0, width=200, height=120),
-                    measure=Measure("fact_x", "# PDFs OK", format_string="#,0"),
-                    display_units="None",
-                ),
-            ],
-        )
-        Report(
-            "rpt", "../x.SemanticModel", [page], strict_descriptions=False
-        ).save_to_disk(tmp_path)
-        rj = _load_report_json(tmp_path / "rpt.Report")
-        cfg = _visual_configs(rj)[0]
-        assert cfg["singleVisual"]["visualType"] == "cardVisual"
-        value = cfg["singleVisual"]["objects"]["value"][0]["properties"]
-        assert value["displayUnits"]["expr"]["Literal"]["Value"] == "1D"
-        # format_string flows into columnProperties
-        cp = cfg["singleVisual"]["columnProperties"]
-        assert cp["fact_x.# PDFs OK"]["formatString"] == "#,0"
-
-    def test_display_units_auto_emits_0D(self, tmp_path: Path) -> None:
-        page = Page(
-            display_name="P",
-            visuals=[
-                Card(
-                    position=Position(x=0, y=0, width=200, height=120),
-                    measure=Measure("fact_x", "Total"),
-                    display_units="Auto",
-                ),
-            ],
-        )
-        Report(
-            "rpt", "../x.SemanticModel", [page], strict_descriptions=False
-        ).save_to_disk(tmp_path)
-        cfg = _visual_configs(_load_report_json(tmp_path / "rpt.Report"))[0]
-        value = cfg["singleVisual"]["objects"]["value"][0]["properties"]
-        assert value["displayUnits"]["expr"]["Literal"]["Value"] == "0D"
-
-
-# ── MultiCard ───────────────────────────────────────────────────────────────
-
-
-class TestMultiCard:
-    def test_emits_cards_layout_with_per_measure_referencing(
-        self, tmp_path: Path
-    ) -> None:
-        page = Page(
-            display_name="P",
-            visuals=[
-                MultiCard(
-                    position=Position(x=0, y=0, width=600, height=120),
-                    measures=[
-                        Measure("fact_x", "# PDFs Total", format_string="#,0"),
-                        Measure("fact_x", "# PDFs OK", format_string="#,0"),
-                    ],
-                    display_units="None",
-                ),
-            ],
-        )
-        Report(
-            "rpt", "../x.SemanticModel", [page], strict_descriptions=False
-        ).save_to_disk(tmp_path)
-        cfg = _visual_configs(_load_report_json(tmp_path / "rpt.Report"))[0]
-        objects = cfg["singleVisual"]["objects"]
-        # Cards layout style
-        assert (
-            objects["layout"][0]["properties"]["style"]["expr"]["Literal"]["Value"]
-            == "'Cards'"
-        )
-        # One referenceLabel entry per measure
-        refs = objects["referenceLabel"]
-        ref_names = sorted(r["selector"]["metadata"] for r in refs)
-        assert ref_names == ["fact_x.# PDFs OK", "fact_x.# PDFs Total"]
-        # 1D for each measure's valueDisplayUnits
-        assert all(
-            r["properties"]["valueDisplayUnits"]["expr"]["Literal"]["Value"] == "1D"
-            for r in objects["referenceLabelValue"]
+            proj[0]["field"]["Column"]["Expression"]["SourceRef"]["Entity"]
+            == "dim_projection"
         )
 
-    def test_polish_flags(self, tmp_path: Path) -> None:
-        page = Page(
-            display_name="P",
-            visuals=[
-                MultiCard(
-                    position=Position(x=0, y=0, width=600, height=120),
-                    measures=[Measure("fact_x", "M1")],
-                    show_outline=True,
-                    show_accent_bar=True,
-                    show_shadow=True,
-                ),
-            ],
+    def test_multi_column_first_active_rest_inactive(self, tmp_path: Path) -> None:
+        visual = Slicer(
+            name="v",
+            position=Position(x=0, y=0, width=200, height=80),
+            field=[Column("dim_x", "company"), Column("dim_x", "vendor_id")],
         )
-        Report(
-            "rpt", "../x.SemanticModel", [page], strict_descriptions=False
-        ).save_to_disk(tmp_path)
-        objects = _visual_configs(_load_report_json(tmp_path / "rpt.Report"))[0][
-            "singleVisual"
-        ]["objects"]
-        for key in ("outline", "accentBar", "shadowCustom"):
-            assert key in objects, f"{key} missing"
+        item_dir = _one_visual_report(visual).save_to_disk(tmp_path)
+        vj = _visual_json(item_dir, "p", "v")
+        proj = vj["visual"]["query"]["queryState"]["Values"]["projections"]
+        assert [p["active"] for p in proj] == [True, False]
 
-    def test_polish_flags_default_off_for_shadow(self, tmp_path: Path) -> None:
-        page = Page(
-            display_name="P",
-            visuals=[
-                MultiCard(
-                    position=Position(x=0, y=0, width=600, height=120),
-                    measures=[Measure("fact_x", "M1")],
-                ),
-            ],
+    def test_filter_config_per_column(self, tmp_path: Path) -> None:
+        visual = Slicer(
+            name="v",
+            position=Position(x=0, y=0, width=200, height=80),
+            field=Column("dim_x", "region"),
         )
-        Report(
-            "rpt", "../x.SemanticModel", [page], strict_descriptions=False
-        ).save_to_disk(tmp_path)
-        objects = _visual_configs(_load_report_json(tmp_path / "rpt.Report"))[0][
-            "singleVisual"
-        ]["objects"]
-        assert "shadowCustom" not in objects
-        assert "outline" in objects
-        assert "accentBar" in objects
+        item_dir = _one_visual_report(visual).save_to_disk(tmp_path)
+        vj = _visual_json(item_dir, "p", "v")
+        filters = vj["filterConfig"]["filters"]
+        assert len(filters) == 1
+        assert filters[0]["type"] == "Categorical"
+        assert len(filters[0]["name"]) == 20
 
-    def test_rejects_empty_measures(self, tmp_path: Path) -> None:
-        page = Page(
-            display_name="P",
-            visuals=[MultiCard(position=Position(x=0, y=0, width=600, height=120))],
+    def test_cross_entity_hierarchy_rejected(self, tmp_path: Path) -> None:
+        visual = Slicer(
+            name="v",
+            position=Position(x=0, y=0, width=200, height=80),
+            field=[Column("dim_x", "a"), Column("dim_y", "b")],
         )
-        with pytest.raises(ValueError, match="at least one measure"):
-            Report(
-                "rpt", "../x.SemanticModel", [page], strict_descriptions=False
-            ).save_to_disk(tmp_path)
+        with pytest.raises(ValueError, match="must share an entity"):
+            _one_visual_report(visual).save_to_disk(tmp_path)
 
-    def test_rejects_mixed_entities(self, tmp_path: Path) -> None:
-        page = Page(
-            display_name="P",
-            visuals=[
-                MultiCard(
-                    position=Position(x=0, y=0, width=600, height=120),
-                    measures=[
-                        Measure("fact_x", "M1"),
-                        Measure("fact_y", "M2"),
-                    ],
-                ),
-            ],
+    def test_allow_values_dropped_with_warning(self, tmp_path: Path) -> None:
+        # No attested PBIR bytes for the allow-list filter; it is dropped,
+        # not silently emitted wrong. Verify the slicer carries no scoping
+        # filter (filterConfig keeps the per-column entry, but the visual
+        # body has no objects/general filter).
+        visual = Slicer(
+            name="v",
+            position=Position(x=0, y=0, width=200, height=80),
+            field=Column("fact_x", "status"),
+            mode="Basic",
+            allow_values=["INCOMPLETE", "NOT_DETECTED"],
         )
-        with pytest.raises(ValueError, match="same entity"):
-            Report(
-                "rpt", "../x.SemanticModel", [page], strict_descriptions=False
-            ).save_to_disk(tmp_path)
+        item_dir = _one_visual_report(visual).save_to_disk(tmp_path)
+        vj = _visual_json(item_dir, "p", "v")
+        assert "objects" not in vj["visual"]
+
+    def test_non_default_mode_emits_plain_list_slicer(self, tmp_path: Path) -> None:
+        visual = Slicer(
+            name="v",
+            position=Position(x=0, y=0, width=200, height=80),
+            field=Column("dim_x", "region"),
+            mode="Between",
+        )
+        item_dir = _one_visual_report(visual).save_to_disk(tmp_path)
+        vj = _visual_json(item_dir, "p", "v")
+        assert vj["visual"]["visualType"] == "listSlicer"
 
 
 # ── Table ───────────────────────────────────────────────────────────────────
 
 
 class TestTable:
-    def test_columns_measures_and_aggregate(self, tmp_path: Path) -> None:
-        page = Page(
-            display_name="P",
-            visuals=[
-                Table(
-                    position=Position(x=0, y=0, width=1200, height=300),
-                    fields=[
-                        Column("dim_projection", "region"),
-                        Column("dim_projection", "project_number"),
-                        Measure("fact_x", "# PDFs OK"),
-                        Aggregate("fact_x", "missing_field_count", function="sum"),
-                    ],
-                    order_by=TableOrderBy(
-                        field=Aggregate(
-                            "fact_x", "missing_field_count", function="sum"
-                        ),
-                        direction="desc",
-                    ),
-                ),
+    def test_columns_and_measure_projections(self, tmp_path: Path) -> None:
+        visual = Table(
+            name="v",
+            position=Position(x=0, y=0, width=1200, height=300),
+            fields=[
+                Column("dim_x", "region"),
+                Measure("fact_x", "Total Rows"),
             ],
         )
-        Report(
-            "rpt", "../x.SemanticModel", [page], strict_descriptions=False
-        ).save_to_disk(tmp_path)
-        cfg = _visual_configs(_load_report_json(tmp_path / "rpt.Report"))[0]
-        assert cfg["singleVisual"]["visualType"] == "tableEx"
-        projections = cfg["singleVisual"]["projections"]["Values"]
-        refs = [p["queryRef"] for p in projections]
-        assert refs == [
-            "dim_projection.region",
-            "dim_projection.project_number",
-            "fact_x.# PDFs OK",
-            "Sum(fact_x.missing_field_count)",
-        ]
-        # From clause has one alias per distinct entity
-        from_entities = sorted(
-            f["Entity"] for f in cfg["singleVisual"]["prototypeQuery"]["From"]
-        )
-        assert from_entities == ["dim_projection", "fact_x"]
-        # OrderBy uses the Aggregation wrapper, direction=2 (desc)
-        ob = cfg["singleVisual"]["prototypeQuery"]["OrderBy"][0]
-        assert ob["Direction"] == 2
-        assert "Aggregation" in ob["Expression"]
-        assert ob["Expression"]["Aggregation"]["Function"] == 0  # sum
+        item_dir = _one_visual_report(visual).save_to_disk(tmp_path)
+        vj = _visual_json(item_dir, "p", "v")
+        assert vj["visual"]["visualType"] == "tableEx"
+        proj = vj["visual"]["query"]["queryState"]["Values"]["projections"]
+        assert proj[0]["queryRef"] == "dim_x.region"
+        assert "Column" in proj[0]["field"]
+        assert proj[1]["queryRef"] == "fact_x.Total Rows"
+        assert "Measure" in proj[1]["field"]
 
-    def test_orderby_by_column(self, tmp_path: Path) -> None:
-        page = Page(
-            display_name="P",
-            visuals=[
-                Table(
-                    position=Position(x=0, y=0, width=1200, height=300),
-                    fields=[Column("dim_projection", "region")],
-                    order_by=TableOrderBy(
-                        field=Column("dim_projection", "region"), direction="asc"
-                    ),
-                ),
-            ],
+    def test_measure_filter_is_advanced(self, tmp_path: Path) -> None:
+        visual = Table(
+            name="v",
+            position=Position(x=0, y=0, width=1200, height=300),
+            fields=[Column("dim_x", "region"), Measure("fact_x", "Total Rows")],
         )
-        Report(
-            "rpt", "../x.SemanticModel", [page], strict_descriptions=False
-        ).save_to_disk(tmp_path)
-        cfg = _visual_configs(_load_report_json(tmp_path / "rpt.Report"))[0]
-        ob = cfg["singleVisual"]["prototypeQuery"]["OrderBy"][0]
-        assert ob["Direction"] == 1
-        assert "Column" in ob["Expression"]
+        item_dir = _one_visual_report(visual).save_to_disk(tmp_path)
+        vj = _visual_json(item_dir, "p", "v")
+        filters = vj["filterConfig"]["filters"]
+        types = {
+            f["field"].get("Measure", f["field"].get("Column"))["Property"]: f["type"]
+            for f in filters
+        }
+        assert types["region"] == "Categorical"
+        assert types["Total Rows"] == "Advanced"
 
-    def test_no_orderby_when_unset(self, tmp_path: Path) -> None:
-        page = Page(
-            display_name="P",
-            visuals=[
-                Table(
-                    position=Position(x=0, y=0, width=1200, height=300),
-                    fields=[Column("dim_projection", "region")],
-                ),
-            ],
+    def test_sort_by_column(self, tmp_path: Path) -> None:
+        visual = Table(
+            name="v",
+            position=Position(x=0, y=0, width=1200, height=300),
+            fields=[Column("dim_x", "region")],
+            order_by=TableOrderBy(field=Column("dim_x", "region"), direction="desc"),
         )
-        Report(
-            "rpt", "../x.SemanticModel", [page], strict_descriptions=False
-        ).save_to_disk(tmp_path)
-        cfg = _visual_configs(_load_report_json(tmp_path / "rpt.Report"))[0]
-        assert "OrderBy" not in cfg["singleVisual"]["prototypeQuery"]
+        item_dir = _one_visual_report(visual).save_to_disk(tmp_path)
+        vj = _visual_json(item_dir, "p", "v")
+        sort = vj["visual"]["query"]["sortDefinition"]["sort"][0]
+        assert sort["direction"] == "Descending"
+        assert sort["field"]["Column"]["Property"] == "region"
+
+    def test_no_sort_when_unset(self, tmp_path: Path) -> None:
+        visual = Table(
+            name="v",
+            position=Position(x=0, y=0, width=1200, height=300),
+            fields=[Column("dim_x", "region")],
+        )
+        item_dir = _one_visual_report(visual).save_to_disk(tmp_path)
+        vj = _visual_json(item_dir, "p", "v")
+        assert "sortDefinition" not in vj["visual"]["query"]
+
+    def test_measure_bound_title(self, tmp_path: Path) -> None:
+        # NOTE: only the fully-styled title is attested in the references;
+        # this minimal form's exact bytes still need a UI capture. The hook
+        # is tested structurally, not byte-equal.
+        visual = Table(
+            name="v",
+            position=Position(x=0, y=0, width=1200, height=300),
+            fields=[Column("dim_x", "region")],
+            title=Measure("fact_x", "Vendor Title"),
+        )
+        item_dir = _one_visual_report(visual).save_to_disk(tmp_path)
+        vj = _visual_json(item_dir, "p", "v")
+        title = vj["visual"]["visualContainerObjects"]["title"][0]["properties"]
+        assert title["show"]["expr"]["Literal"]["Value"] == "true"
+        measure = title["text"]["expr"]["Measure"]
+        assert measure["Expression"]["SourceRef"]["Entity"] == "fact_x"
+        assert measure["Property"] == "Vendor Title"
 
     def test_rejects_empty_fields(self, tmp_path: Path) -> None:
-        page = Page(
-            display_name="P",
-            visuals=[Table(position=Position(x=0, y=0, width=1200, height=300))],
-        )
+        visual = Table(name="v", position=Position(x=0, y=0, width=1200, height=300))
         with pytest.raises(ValueError, match="at least one field"):
-            Report(
-                "rpt", "../x.SemanticModel", [page], strict_descriptions=False
-            ).save_to_disk(tmp_path)
+            _one_visual_report(visual).save_to_disk(tmp_path)
+
+
+# ── Position numeric rendering ──────────────────────────────────────────────
+
+
+class TestPosition:
+    def test_whole_numbers_emit_as_ints(self, tmp_path: Path) -> None:
+        visual = Slicer(
+            name="v",
+            position=Position(x=10, y=0, z=1, width=430, height=280),
+            field=Column("dim_x", "region"),
+        )
+        item_dir = _one_visual_report(visual).save_to_disk(tmp_path)
+        raw = (
+            item_dir / "definition" / "pages" / "p" / "visuals" / "v" / "visual.json"
+        ).read_text("utf-8")
+        # Whole numbers must be bare ints, not 0.0 / 10.0.
+        assert '"y": 0,' in raw
+        assert '"z": 1,' in raw
+        assert '"x": 10,' in raw
+        # No float-rendered coordinates (the schema URL "2.10.0" is fine).
+        assert '"x": 10.0' not in raw
+        assert '"y": 0.0' not in raw
+
+    def test_fractional_values_stay_floats(self, tmp_path: Path) -> None:
+        visual = Slicer(
+            name="v",
+            position=Position(x=9.5, y=0, width=430, height=280),
+            field=Column("dim_x", "region"),
+        )
+        item_dir = _one_visual_report(visual).save_to_disk(tmp_path)
+        vj = _visual_json(item_dir, "p", "v")
+        assert vj["position"]["x"] == 9.5
+
+    def test_tab_order_defaults_to_z(self, tmp_path: Path) -> None:
+        visual = Slicer(
+            name="v",
+            position=Position(x=0, y=0, z=3, width=200, height=80),
+            field=Column("dim_x", "region"),
+        )
+        item_dir = _one_visual_report(visual).save_to_disk(tmp_path)
+        vj = _visual_json(item_dir, "p", "v")
+        assert vj["position"]["tabOrder"] == 3
 
 
 # ── Theme ───────────────────────────────────────────────────────────────────
 
 
 class TestTheme:
-    def test_theme_file_emitted(self, tmp_path: Path) -> None:
+    def _slicer_page(self) -> Page:
+        return Page(
+            display_name="P",
+            name="p",
+            visuals=[
+                Slicer(
+                    name="v",
+                    position=Position(x=0, y=0, width=200, height=80),
+                    field=Column("dim_x", "region"),
+                ),
+            ],
+        )
+
+    def test_theme_file_emitted_and_registered(self, tmp_path: Path) -> None:
         theme = Theme(
             name="MyTheme",
             content={
@@ -497,289 +514,121 @@ class TestTheme:
                 "foreground": "#252423",
             },
         )
-        page = Page(
-            display_name="P",
-            visuals=[
-                Card(
-                    position=Position(x=0, y=0, width=200, height=120),
-                    measure=Measure("fact_x", "M"),
-                ),
-            ],
-        )
-        Report(
-            "rpt", "../x.SemanticModel", [page], theme=theme, strict_descriptions=False
+        item_dir = Report(
+            "rpt",
+            "../x.SemanticModel",
+            [self._slicer_page()],
+            theme=theme,
+            strict_descriptions=False,
         ).save_to_disk(tmp_path)
         theme_path = (
-            tmp_path
-            / "rpt.Report"
+            item_dir
             / "StaticResources"
             / "SharedResources"
             / "BaseThemes"
             / "MyTheme.json"
         )
         assert theme_path.exists()
-        loaded = json.loads(theme_path.read_text("utf-8"))
-        assert loaded["name"] == "MyTheme"
-        assert loaded["dataColors"] == ["#118DFF", "#12239E", "#E66C37"]
-
-    def test_theme_referenced_in_report_config(self, tmp_path: Path) -> None:
-        theme = Theme(name="MyTheme", content={"name": "MyTheme", "dataColors": []})
-        page = Page(
-            display_name="P",
-            visuals=[
-                Card(
-                    position=Position(x=0, y=0, width=200, height=120),
-                    measure=Measure("fact_x", "M"),
-                ),
-            ],
-        )
-        Report(
-            "rpt", "../x.SemanticModel", [page], theme=theme, strict_descriptions=False
-        ).save_to_disk(tmp_path)
-        rj = _load_report_json(tmp_path / "rpt.Report")
-        config = json.loads(rj["config"])
-        assert config["themeCollection"]["baseTheme"]["name"] == "MyTheme"
-        # resourcePackages registers the theme file
-        assert (
-            rj["resourcePackages"][0]["resourcePackage"]["items"][0]["name"]
-            == "MyTheme"
-        )
+        assert json.loads(theme_path.read_text("utf-8"))["name"] == "MyTheme"
+        rj = json.loads((item_dir / "definition" / "report.json").read_text("utf-8"))
+        assert rj["themeCollection"]["baseTheme"]["name"] == "MyTheme"
+        assert rj["resourcePackages"][0]["items"][0]["name"] == "MyTheme"
+        assert rj["resourcePackages"][0]["items"][0]["type"] == "BaseTheme"
 
     def test_no_theme_omits_collection_and_resources(self, tmp_path: Path) -> None:
-        page = Page(
-            display_name="P",
-            visuals=[
-                Card(
-                    position=Position(x=0, y=0, width=200, height=120),
-                    measure=Measure("fact_x", "M"),
-                ),
-            ],
-        )
-        Report(
-            "rpt", "../x.SemanticModel", [page], strict_descriptions=False
+        item_dir = Report(
+            "rpt",
+            "../x.SemanticModel",
+            [self._slicer_page()],
+            strict_descriptions=False,
         ).save_to_disk(tmp_path)
-        rj = _load_report_json(tmp_path / "rpt.Report")
+        rj = json.loads((item_dir / "definition" / "report.json").read_text("utf-8"))
+        assert "themeCollection" not in rj
         assert "resourcePackages" not in rj
-        config = json.loads(rj["config"])
-        assert "themeCollection" not in config
 
 
-# ── Hierarchy slicer ───────────────────────────────────────────────────────
+# ── NotImplemented boundaries (features without attested PBIR bytes) ─────────
 
 
-class TestHierarchySlicer:
-    def test_single_column_unchanged(self, tmp_path: Path) -> None:
-        page = Page(
-            display_name="P",
-            visuals=[
-                Slicer(
-                    position=Position(x=0, y=0, width=200, height=80),
-                    field=Column("dim_x", "region"),
-                    mode="Dropdown",
-                ),
-            ],
+class TestNotImplementedBoundaries:
+    def test_card_raises(self, tmp_path: Path) -> None:
+        visual = Card(
+            name="v",
+            position=Position(x=0, y=0, width=200, height=120),
+            measure=Measure("fact_x", "M"),
         )
-        Report(
-            "rpt", "../x.SemanticModel", [page], strict_descriptions=False
-        ).save_to_disk(tmp_path)
-        cfg = _visual_configs(_load_report_json(tmp_path / "rpt.Report"))[0]
-        # Single column → one projection, no expansionStates
-        assert len(cfg["singleVisual"]["projections"]["Values"]) == 1
-        assert "expansionStates" not in cfg["singleVisual"]
+        with pytest.raises(NotImplementedError, match="Card"):
+            _one_visual_report(visual).save_to_disk(tmp_path)
 
-    def test_multi_column_emits_hierarchy(self, tmp_path: Path) -> None:
-        page = Page(
-            display_name="P",
-            visuals=[
-                Slicer(
-                    position=Position(x=0, y=0, width=200, height=200),
-                    field=[
-                        Column("dim_x", "report_year"),
-                        Column("dim_x", "report_month"),
-                    ],
-                    mode="Basic",
-                ),
-            ],
+    def test_multicard_raises(self, tmp_path: Path) -> None:
+        visual = MultiCard(
+            name="v",
+            position=Position(x=0, y=0, width=600, height=120),
+            measures=[Measure("fact_x", "M")],
         )
-        Report(
-            "rpt", "../x.SemanticModel", [page], strict_descriptions=False
-        ).save_to_disk(tmp_path)
-        cfg = _visual_configs(_load_report_json(tmp_path / "rpt.Report"))[0]
-        proj = cfg["singleVisual"]["projections"]["Values"]
-        refs = [p["queryRef"] for p in proj]
-        assert refs == ["dim_x.report_year", "dim_x.report_month"]
-        # All hierarchy levels collapsed by default
-        ex = cfg["singleVisual"]["expansionStates"][0]["levels"]
-        assert all(level["isCollapsed"] for level in ex)
-        # Mode is Basic for hierarchy
-        mode = cfg["singleVisual"]["objects"]["data"][0]["properties"]["mode"]
-        assert mode["expr"]["Literal"]["Value"] == "'Basic'"
+        with pytest.raises(NotImplementedError, match="MultiCard"):
+            _one_visual_report(visual).save_to_disk(tmp_path)
 
-    def test_hierarchy_coerces_to_basic_mode(self, tmp_path: Path) -> None:
-        # Caller asks for Dropdown but provides multi-level field;
-        # emitter coerces to Basic since Dropdown can't render hierarchies.
-        page = Page(
-            display_name="P",
-            visuals=[
-                Slicer(
-                    position=Position(x=0, y=0, width=200, height=200),
-                    field=[Column("dim_x", "year"), Column("dim_x", "month")],
-                    mode="Dropdown",
-                ),
-            ],
+    def test_inline_aggregate_projection_raises(self, tmp_path: Path) -> None:
+        visual = Table(
+            name="v",
+            position=Position(x=0, y=0, width=1200, height=300),
+            fields=[Aggregate("fact_x", "missing_field_count", function="sum")],
         )
-        Report(
-            "rpt", "../x.SemanticModel", [page], strict_descriptions=False
-        ).save_to_disk(tmp_path)
-        cfg = _visual_configs(_load_report_json(tmp_path / "rpt.Report"))[0]
-        mode = cfg["singleVisual"]["objects"]["data"][0]["properties"]["mode"]
-        assert mode["expr"]["Literal"]["Value"] == "'Basic'"
+        with pytest.raises(NotImplementedError, match="Aggregate"):
+            _one_visual_report(visual).save_to_disk(tmp_path)
 
-    def test_hierarchy_rejects_cross_entity(self, tmp_path: Path) -> None:
-        page = Page(
-            display_name="P",
-            visuals=[
-                Slicer(
-                    position=Position(x=0, y=0, width=200, height=200),
-                    field=[Column("dim_x", "a"), Column("dim_y", "b")],
-                ),
-            ],
+    def test_sort_by_measure_raises(self, tmp_path: Path) -> None:
+        visual = Table(
+            name="v",
+            position=Position(x=0, y=0, width=1200, height=300),
+            fields=[Column("dim_x", "region"), Measure("fact_x", "M")],
+            order_by=TableOrderBy(field=Measure("fact_x", "M")),
         )
-        with pytest.raises(ValueError, match="must share an entity"):
-            Report(
-                "rpt", "../x.SemanticModel", [page], strict_descriptions=False
-            ).save_to_disk(tmp_path)
-
-    def test_hierarchy_allow_values_targets_leaf(self, tmp_path: Path) -> None:
-        page = Page(
-            display_name="P",
-            visuals=[
-                Slicer(
-                    position=Position(x=0, y=0, width=200, height=200),
-                    field=[Column("dim_x", "year"), Column("dim_x", "month")],
-                    allow_values=["6", "7"],
-                ),
-            ],
-        )
-        Report(
-            "rpt", "../x.SemanticModel", [page], strict_descriptions=False
-        ).save_to_disk(tmp_path)
-        cfg = _visual_configs(_load_report_json(tmp_path / "rpt.Report"))[0]
-        general = cfg["singleVisual"]["objects"]["general"][0]["properties"]
-        prop = general["filter"]["filter"]["Where"][0]["Condition"]["In"][
-            "Expressions"
-        ][0]["Column"]["Property"]
-        # Filter targets the deepest level, not the first
-        assert prop == "month"
+        with pytest.raises(NotImplementedError, match="sort-by-measure"):
+            _one_visual_report(visual).save_to_disk(tmp_path)
 
 
-# ── MultiCard label styling ────────────────────────────────────────────────
-
-
-class TestMultiCardLabelStyling:
-    def test_no_label_styling_omits_block(self, tmp_path: Path) -> None:
-        page = Page(
-            display_name="P",
-            visuals=[
-                MultiCard(
-                    position=Position(x=0, y=0, width=600, height=120),
-                    measures=[Measure("fact_x", "M")],
-                ),
-            ],
-        )
-        Report(
-            "rpt", "../x.SemanticModel", [page], strict_descriptions=False
-        ).save_to_disk(tmp_path)
-        objects = _visual_configs(_load_report_json(tmp_path / "rpt.Report"))[0][
-            "singleVisual"
-        ]["objects"]
-        # When no label knobs set, default: no label override emitted
-        assert "label" not in objects
-
-    def test_label_heading_and_position(self, tmp_path: Path) -> None:
-        page = Page(
-            display_name="P",
-            visuals=[
-                MultiCard(
-                    position=Position(x=0, y=0, width=600, height=120),
-                    measures=[Measure("fact_x", "M")],
-                    label_heading="Heading2",
-                    label_position="belowValue",
-                ),
-            ],
-        )
-        Report(
-            "rpt", "../x.SemanticModel", [page], strict_descriptions=False
-        ).save_to_disk(tmp_path)
-        objects = _visual_configs(_load_report_json(tmp_path / "rpt.Report"))[0][
-            "singleVisual"
-        ]["objects"]
-        label_props = objects["label"][0]["properties"]
-        assert label_props["heading"]["expr"]["Literal"]["Value"] == "'Heading2'"
-        assert label_props["position"]["expr"]["Literal"]["Value"] == "'belowValue'"
-
-    def test_label_font_color_emits_theme_data_color(self, tmp_path: Path) -> None:
-        page = Page(
-            display_name="P",
-            visuals=[
-                MultiCard(
-                    position=Position(x=0, y=0, width=600, height=120),
-                    measures=[Measure("fact_x", "M")],
-                    label_font_color=ThemeColor(color_id=1, percent=0.6),
-                ),
-            ],
-        )
-        Report(
-            "rpt", "../x.SemanticModel", [page], strict_descriptions=False
-        ).save_to_disk(tmp_path)
-        objects = _visual_configs(_load_report_json(tmp_path / "rpt.Report"))[0][
-            "singleVisual"
-        ]["objects"]
-        font_color = objects["label"][0]["properties"]["fontColor"]
-        td = font_color["solid"]["color"]["expr"]["ThemeDataColor"]
-        assert td["ColorId"] == 1
-        assert td["Percent"] == 0.6
-
-
-# ── Strict descriptions ────────────────────────────────────────────────────
+# ── Strict descriptions ─────────────────────────────────────────────────────
 
 
 class TestStrictDescriptions:
+    def _page(self) -> Page:
+        return Page(
+            display_name="P",
+            name="p",
+            visuals=[
+                Slicer(
+                    name="v",
+                    position=Position(x=0, y=0, width=200, height=80),
+                    field=Column("dim_x", "region"),
+                ),
+            ],
+        )
+
     def test_default_strict_blocks_save_when_description_missing(
-        self, basic_page: Page, tmp_path: Path
+        self, tmp_path: Path
     ) -> None:
         with pytest.raises(ReportError, match="needs a description"):
-            Report(
-                name="rpt",
-                semantic_model_path="../x.SemanticModel",
-                pages=[basic_page],
-            ).save_to_disk(tmp_path)
+            Report("rpt", "../x.SemanticModel", [self._page()]).save_to_disk(tmp_path)
 
-    def test_description_present_passes(self, basic_page: Page, tmp_path: Path) -> None:
+    def test_description_present_passes(self, tmp_path: Path) -> None:
         Report(
-            name="rpt",
-            semantic_model_path="../x.SemanticModel",
-            pages=[basic_page],
+            "rpt",
+            "../x.SemanticModel",
+            [self._page()],
             description="A real report description.",
         ).save_to_disk(tmp_path)
 
-    def test_opt_out_succeeds_when_description_missing(
-        self, basic_page: Page, tmp_path: Path
-    ) -> None:
+    def test_opt_out_succeeds_when_description_missing(self, tmp_path: Path) -> None:
         Report(
-            name="rpt",
-            semantic_model_path="../x.SemanticModel",
-            pages=[basic_page],
-            strict_descriptions=False,
+            "rpt", "../x.SemanticModel", [self._page()], strict_descriptions=False
         ).save_to_disk(tmp_path)
 
     def test_whitespace_only_description_treated_as_missing(
-        self, basic_page: Page, tmp_path: Path
+        self, tmp_path: Path
     ) -> None:
         with pytest.raises(ReportError, match="needs a description"):
             Report(
-                name="rpt",
-                semantic_model_path="../x.SemanticModel",
-                pages=[basic_page],
-                description="   ",
+                "rpt", "../x.SemanticModel", [self._page()], description="   "
             ).save_to_disk(tmp_path)


### PR DESCRIPTION
## What

Replaces the Report builder's legacy single-`report.json` emit (escaped `config` strings) with the **modern PBIR `definition/` folder format** — a per-page `page.json` and a per-visual `visual.json`, plus `version.json` / `report.json` / `pages.json`. This is Microsoft's current diff-able report format and the one current Fabric opens reliably (the legacy emit got stuck on "Loading your report..." and flip-flopped on every git-sync).

## Scope

Slicer + Table — the two visuals for which we have **attested reference bytes** from real Fabric report output:

- **Slicer** → `listSlicer` with one or more column projections (first `active`).
- **Table** → `tableEx` with mixed `Column` / `Measure` projections, optional sort-by-column, and a per-field `filterConfig` (columns `Categorical`, measures `Advanced`). Optional measure-bound dynamic title hook.

## Public API

Source-compatible: `Report, Page, Position, Slicer, Table, Column, Measure, Aggregate, TableOrderBy, Theme` (plus `Card, MultiCard, ThemeColor, ReportError`). Determinism/pinning hooks: `Position.tab_order`, `Page.name`, `Visual.name`, `Report.logical_id`, and deterministically-derived filter ids.

`Card` / `MultiCard` remain public but raise `NotImplementedError` in the PBIR emitter — they need UI-captured reference bytes.

## Fail-loud, never guess bytes

Features with no attested PBIR shape are **dropped-with-warning or raise** rather than emit invented JSON (silently emitting a valid-but-wrong report is the failure class this migration removes):

- slicer `mode` variants, `allow_values` allow-list filter → `log.warning`, dropped.
- inline `Aggregate` projection, sort-by-measure → `NotImplementedError`.
- `.platform` no longer writes a `description` (Fabric strips report descriptions there and would otherwise flap; the description is still validated/surfaced through the API).

## Golden test (serializer proof)

A hand-cleaned fixture — derived from **real Fabric report output**, scrubbed to generic entity names (`dim_x`, `fact_x`, `sm_golden`) and stripped of UI-default / drag / runtime-selection state — is reconstructed via the builder with every id/position pinned, then asserted **byte-equal file-by-file**. The fixture's structural bytes come from Fabric, the emitter is written independently, so the test isn't circular. Plus focused unit tests per emitter (slicer, table, projections, sort, measure title, position int/float rendering, theme) and explicit coverage of every `NotImplementedError` boundary.

## Needs a UI capture before it can be certified (explicit TODOs)

The byte-equal test proves serialization (key order, LF / no-trailing-newline, determinism, file set). It does **not** independently certify that Fabric *accepts* the no-theme `report.json`, the `objects`-free clean table, or the minimal measure-bound title — those were inferred by deletion from themed/styled originals. Real open/flap certification is a live Fabric sync, not inspection. Shapes still needing a UI capture: tooltip pages, bookmarks, drillthrough, hierarchy/expansion slicers, slicer modes, `allow_values` filter, inline aggregation, `format_string` column properties, sort-by-measure, the styled/minimal dynamic title, and Card/MultiCard.

## Pre-checkin

`ruff check` / `ruff format` / `mypy` / full `pytest` (845 passed, 4 e2e skipped — no creds) all pass; commit + pre-push hooks green. `pip-audit` reports 2 pre-existing environment vulnerabilities (`idna`, `pip`) — neither introduced by nor pinnable in this PR (it adds no dependencies).

Closes #106

🤖 Generated with [Claude Code](https://claude.com/claude-code)