### PR TITLE
fix(testing): adopt mcp's renamed streamable_http_client transport

### DIFF
--- a/src/pyfabric/testing/data_agent.py
+++ b/src/pyfabric/testing/data_agent.py
@@ -37,6 +37,8 @@ variables so suites skip cleanly when no published agent is reachable.
 from __future__ import annotations
 
 import asyncio
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
 from typing import Any
 
 import structlog
@@ -114,7 +116,7 @@ class DataAgentClient:
     async def _ask_async(self, question: str) -> str:
         try:
             from mcp import ClientSession
-            from mcp.client.streamable_http import streamablehttp_client
+            from mcp.client import streamable_http
         except ImportError as e:
             raise DataAgentError(
                 "The 'mcp' package is required to query a data agent — "
@@ -123,15 +125,48 @@ class DataAgentClient:
 
         log.debug("Querying data agent", url=self.mcp_url)
         async with (
-            streamablehttp_client(self.mcp_url, headers=self._headers()) as (
-                read,
-                write,
-                _,
-            ),
+            self._open_transport(streamable_http) as (read, write, _),
             ClientSession(read, write) as session,
         ):
             await session.initialize()
             return await self._ask_with_session(session, question)
+
+    @asynccontextmanager
+    async def _open_transport(
+        self, streamable_http: Any
+    ) -> AsyncIterator[tuple[Any, Any, Any]]:
+        """Open the agent's streamable-HTTP transport; yield its streams.
+
+        mcp 1.24 renamed ``streamablehttp_client`` to
+        ``streamable_http_client``; newer releases emit a
+        ``DeprecationWarning`` for the old alias and mcp 2.0 removes it.
+        The two are not drop-in equivalents: the new function has no
+        ``headers=`` — HTTP settings ride on a caller-managed
+        ``httpx.AsyncClient`` passed as ``http_client=``. Prefer the new
+        API when present and fall back to the old name so the
+        ``dataagent`` extra's ``mcp>=1.23.0`` floor keeps working.
+
+        Takes the imported ``mcp.client.streamable_http`` module as a
+        parameter because the import is lazy (see :meth:`_ask_async`).
+        """
+        client_fn = getattr(streamable_http, "streamable_http_client", None)
+        if client_fn is not None:
+            # create_mcp_http_client applies the same defaults the old
+            # wrapper did (follow_redirects, 30 s timeout / 300 s read).
+            # We created the httpx client, so we own its lifecycle —
+            # streamable_http_client only closes clients it creates.
+            async with (
+                streamable_http.create_mcp_http_client(
+                    headers=self._headers()
+                ) as http_client,
+                client_fn(self.mcp_url, http_client=http_client) as streams,
+            ):
+                yield streams
+        else:
+            async with streamable_http.streamablehttp_client(
+                self.mcp_url, headers=self._headers()
+            ) as streams:
+                yield streams
 
     async def _ask_with_session(self, session: Any, question: str) -> str:
         """Run tool discovery + call on an initialized MCP session.

--- a/tests/testing/test_data_agent_client.py
+++ b/tests/testing/test_data_agent_client.py
@@ -2,6 +2,8 @@
 
 import asyncio
 import sys
+import types
+from contextlib import asynccontextmanager
 
 import pytest
 
@@ -126,7 +128,130 @@ class TestMissingMcpPackage:
         # Setting a sys.modules entry to None makes `import mcp` raise
         # ImportError regardless of whether mcp is actually installed.
         monkeypatch.setitem(sys.modules, "mcp", None)
+        monkeypatch.setitem(sys.modules, "mcp.client", None)
         monkeypatch.setitem(sys.modules, "mcp.client.streamable_http", None)
         client = DataAgentClient(WS, AGENT, credential=_FakeCredential())
         with pytest.raises(DataAgentError, match=r"pyfabric\[dataagent\]"):
             client.ask("anything")
+
+
+class _FakeInitializedSession(_FakeSession):
+    """A _FakeSession that also supports the initialize handshake."""
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.initialized = False
+
+    async def initialize(self):
+        self.initialized = True
+
+
+class _FakeClientSession:
+    """Minimal stand-in for ``mcp.ClientSession``."""
+
+    def __init__(self, read, write):
+        self.read = read
+        self.write = write
+        self.session = _FakeInitializedSession(
+            tools=[_FakeTool()],
+            result=_FakeCallResult([_FakeTextBlock("answer")]),
+        )
+
+    async def __aenter__(self):
+        return self.session
+
+    async def __aexit__(self, *exc):
+        return False
+
+
+class _FakeHttpxClient:
+    """Stands in for the httpx.AsyncClient the mcp factory returns."""
+
+    def __init__(self, headers):
+        self.headers = headers
+        self.closed = False
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *exc):
+        self.closed = True
+        return False
+
+
+def _install_fake_mcp(monkeypatch, streamable_http_mod):
+    """Register fake ``mcp`` / ``mcp.client`` / ``...streamable_http`` modules.
+
+    Lets ``_ask_async`` run its lazy imports against controlled modules,
+    so tests can pin exactly which transport names exist.
+    """
+    mcp_mod = types.ModuleType("mcp")
+    mcp_mod.ClientSession = _FakeClientSession
+    client_mod = types.ModuleType("mcp.client")
+    client_mod.streamable_http = streamable_http_mod
+    mcp_mod.client = client_mod
+    monkeypatch.setitem(sys.modules, "mcp", mcp_mod)
+    monkeypatch.setitem(sys.modules, "mcp.client", client_mod)
+    monkeypatch.setitem(sys.modules, "mcp.client.streamable_http", streamable_http_mod)
+
+
+class TestTransportSelection:
+    """mcp renamed streamablehttp_client -> streamable_http_client (1.24).
+
+    The client must prefer the new name (which takes a caller-managed
+    ``http_client=`` instead of ``headers=``) and fall back to the old
+    one so the extra's ``mcp>=1.23.0`` floor keeps working.
+    """
+
+    def test_prefers_new_transport_name(self, monkeypatch):
+        calls = {}
+        sh = types.ModuleType("mcp.client.streamable_http")
+
+        def create_mcp_http_client(headers=None):
+            calls["factory_headers"] = headers
+            return _FakeHttpxClient(headers)
+
+        @asynccontextmanager
+        async def streamable_http_client(url, *, http_client=None):
+            calls["url"] = url
+            calls["http_client"] = http_client
+            yield ("read", "write", lambda: None)
+
+        @asynccontextmanager
+        async def streamablehttp_client(url, headers=None):
+            raise AssertionError(
+                "deprecated transport name must not be used when the new one exists"
+            )
+            yield  # pragma: no cover
+
+        sh.create_mcp_http_client = create_mcp_http_client
+        sh.streamable_http_client = streamable_http_client
+        sh.streamablehttp_client = streamablehttp_client
+        _install_fake_mcp(monkeypatch, sh)
+
+        client = DataAgentClient(WS, AGENT, credential=_FakeCredential())
+        assert client.ask("q") == "answer"
+        assert calls["url"] == client.mcp_url
+        assert calls["factory_headers"] == {"Authorization": "Bearer fake-token"}
+        assert isinstance(calls["http_client"], _FakeHttpxClient)
+        # We created the httpx client, so we must close it ourselves —
+        # the new transport API only closes clients it creates itself.
+        assert calls["http_client"].closed
+
+    def test_falls_back_to_old_transport_name(self, monkeypatch):
+        calls = {}
+        sh = types.ModuleType("mcp.client.streamable_http")
+
+        @asynccontextmanager
+        async def streamablehttp_client(url, headers=None):
+            calls["url"] = url
+            calls["headers"] = headers
+            yield ("read", "write", lambda: None)
+
+        sh.streamablehttp_client = streamablehttp_client
+        _install_fake_mcp(monkeypatch, sh)
+
+        client = DataAgentClient(WS, AGENT, credential=_FakeCredential())
+        assert client.ask("q") == "answer"
+        assert calls["url"] == client.mcp_url
+        assert calls["headers"] == {"Authorization": "Bearer fake-token"}


### PR DESCRIPTION
## Summary

`DataAgentClient._ask_async` imported `streamablehttp_client` from `mcp.client.streamable_http`. mcp 1.24 renamed it to `streamable_http_client`; with mcp 1.28.1 every `ask()` call emits `DeprecationWarning: Use 'streamable_http_client' instead.` (observed when querying a published data agent), and mcp 2.0 (in beta) removes the old alias entirely.

The rename is not drop-in — the new function has no `headers=`; HTTP settings ride on a caller-managed `httpx.AsyncClient` passed as `http_client=`. This PR adds a small `_open_transport` async context manager that:

- prefers `streamable_http_client` when present, building the httpx client via `create_mcp_http_client(headers=...)` (same defaults the old wrapper applied: follow_redirects, 30 s timeout / 300 s read) and managing its lifecycle, since the new API only closes clients it creates itself;
- falls back to `streamablehttp_client(url, headers=...)` so the `dataagent` extra's `mcp>=1.23.0` floor — which ships only the old name — keeps working.

The lazy import + `DataAgentError` install-hint behavior is unchanged.

Closes #115

## Verification

- Unit tests: two new `TestTransportSelection` cases drive `ask()` end-to-end against fake `mcp` modules — one exposing both names (asserts the new one is used, headers reach the factory, and the caller-created httpx client is closed) and one exposing only the old name (asserts the fallback path passes `headers=`). The missing-package test now also patches `mcp.client`.
- Smoke-tested against a real mcp 1.28.1 install: with `-W error::DeprecationWarning`, the new path is selected and fails only at the connection level (no warning, no `TypeError`); with the new name hidden, the fallback path is taken.
- Confirmed via the published wheels that mcp 1.23.0 has only `streamablehttp_client` and the rename first appears in 1.24.0.
- Pre-checkin: `ruff check`, `ruff format --check`, `mypy src` (strict), `pytest -q` (887 passed), `pip-audit` (findings are pre-existing dev-env transitive deps; this change adds no dependencies).

🤖 Generated with [Claude Code](https://claude.com/claude-code)