### PR TITLE
fix(client): raw_request honors params= and resolves relative paths

### DIFF
--- a/src/pyfabric/client/http.py
+++ b/src/pyfabric/client/http.py
@@ -126,7 +126,8 @@ class FabricClient:
         method: str,
         url: str,
         body: Any = None,
-        **kwargs,
+        *,
+        timeout: float | None = None,
     ) -> requests.Response:
         """Send a single HTTP request. Raises FabricError on 4xx/5xx."""
         data = json.dumps(body) if body is not None else None
@@ -136,7 +137,7 @@ class FabricClient:
             url,
             headers=self._headers(),
             data=data,
-            timeout=kwargs.get("timeout", self._timeout),
+            timeout=timeout if timeout is not None else self._timeout,
         )
         log.debug("  -> %d (%d bytes)", resp.status_code, len(resp.content))
         if resp.status_code >= 400:
@@ -203,15 +204,30 @@ class FabricClient:
     # ------------------------------------------------------------------
 
     def raw_request(
-        self, method: str, url: str, body: Any = None, **kwargs: Any
+        self,
+        method: str,
+        url: str,
+        body: Any = None,
+        *,
+        params: dict | None = None,
+        timeout: float | None = None,
     ) -> requests.Response:
         """Low-level HTTP request for custom polling patterns.
 
         Unlike post()/get() which handle LRO and pagination automatically,
         this returns the raw response for callers that need custom handling
         (e.g., graph refresh with non-standard LRO status values).
+
+        ``url`` may be a path relative to the client's base URL (like
+        ``get``/``post``) or a fully-qualified ``https://`` URL (e.g. an LRO
+        ``Location`` header) — absolute URLs pass through unchanged.
+        ``params`` are encoded into the query string either way; keyword
+        arguments other than ``params``/``timeout`` raise ``TypeError``
+        rather than being silently dropped.
         """
-        return self._request(method, url, body, **kwargs)
+        return self._request(
+            method, self._build_url(url, params), body, timeout=timeout
+        )
 
     def get(self, path: str, params: dict | None = None) -> dict:
         """GET a single resource."""
@@ -256,5 +272,6 @@ class FabricClient:
 def _build_url(path: str, params: dict | None = None, base_url: str = BASE_URL) -> str:
     url = path if path.startswith("http") else f"{base_url}/{path.lstrip('/')}"
     if params:
-        url = f"{url}?{urllib.parse.urlencode(params)}"
+        sep = "&" if "?" in url else "?"
+        url = f"{url}{sep}{urllib.parse.urlencode(params)}"
     return url

--- a/tests/client/test_http.py
+++ b/tests/client/test_http.py
@@ -24,6 +24,10 @@ class TestBuildUrl:
         url = _build_url("/workspaces/ws-1")
         assert "//workspaces" not in url
 
+    def test_params_append_to_existing_query(self):
+        url = _build_url("https://example.com/api?type=driver", {"fileName": "stdout"})
+        assert url == "https://example.com/api?type=driver&fileName=stdout"
+
 
 class TestFabricError:
     def test_parses_json_error(self):
@@ -129,6 +133,68 @@ class TestFabricClientRequests:
         client = self._make_client(mock_requests_session)
         result = client.post("workspaces", {"displayName": "test"})
         assert result["id"] == "new"
+
+
+class TestRawRequest:
+    """``raw_request`` must honor ``params=`` and resolve relative paths.
+
+    Historically it forwarded ``**kwargs`` to ``_request``, which only read
+    ``timeout`` — so ``params={...}`` was silently dropped and the request
+    returned a 200 for the *wrong* resource (e.g. the default Spark driver
+    log instead of the requested file/window).
+    """
+
+    def _make_client(self, mock_session):
+        client = FabricClient("fake-token")
+        client._session = mock_session
+        return client
+
+    def _ok(self, mock_session):
+        mock_session.request.return_value.status_code = 200
+        mock_session.request.return_value.text = "{}"
+        mock_session.request.return_value.content = b"{}"
+
+    def test_params_encoded_into_query_string(self, mock_requests_session):
+        self._ok(mock_requests_session)
+        client = self._make_client(mock_requests_session)
+        client.raw_request(
+            "GET",
+            "https://api.fabric.microsoft.com/v1/some/log",
+            params={"type": "driver", "fileName": "stdout"},
+        )
+        url = mock_requests_session.request.call_args[0][1]
+        assert url == (
+            "https://api.fabric.microsoft.com/v1/some/log?type=driver&fileName=stdout"
+        )
+
+    def test_relative_path_resolved_against_base_url(self, mock_requests_session):
+        self._ok(mock_requests_session)
+        client = self._make_client(mock_requests_session)
+        client.raw_request("GET", "workspaces/ws-1/items")
+        url = mock_requests_session.request.call_args[0][1]
+        assert url == "https://api.fabric.microsoft.com/v1/workspaces/ws-1/items"
+
+    def test_absolute_url_with_embedded_query_passes_through(
+        self, mock_requests_session
+    ):
+        # Back-compat: existing callers pass full URLs with the query string
+        # already embedded; those must be sent byte-for-byte unchanged.
+        self._ok(mock_requests_session)
+        client = self._make_client(mock_requests_session)
+        full = "https://api.fabric.microsoft.com/v1/some/log?type=driver&size=100"
+        client.raw_request("GET", full)
+        assert mock_requests_session.request.call_args[0][1] == full
+
+    def test_unknown_kwargs_raise_type_error(self, mock_requests_session):
+        client = self._make_client(mock_requests_session)
+        with pytest.raises(TypeError):
+            client.raw_request("GET", "workspaces", prams={"oops": 1})
+
+    def test_timeout_forwarded(self, mock_requests_session):
+        self._ok(mock_requests_session)
+        client = self._make_client(mock_requests_session)
+        client.raw_request("GET", "workspaces", timeout=99)
+        assert mock_requests_session.request.call_args[1]["timeout"] == 99
 
 
 class TestPollLroTerminalStatus:


### PR DESCRIPTION
## Problem

`FabricClient.raw_request(method, url, body=None, **kwargs)` forwarded kwargs to `_request`, which only read `timeout`:

- **`params={...}` was silently ignored** — the request went out without its query string and returned 200 for the *wrong* resource (verified against a Spark driver-log endpoint, which served the default log instead of the requested file/window). A data-correctness footgun, not just an inconvenience.
- **No `_build_url`** — unlike `get`/`post`/`patch`/`delete`, relative paths failed; callers had to pre-build fully-qualified URLs.

## Fix

- `raw_request` now takes explicit keyword-only `params`/`timeout`; any other kwarg raises `TypeError` instead of being dropped.
- The URL routes through `_build_url`, so relative paths resolve against the client base URL. Absolute `https://` URLs (including embedded query strings, e.g. LRO `Location` headers) pass through unchanged — existing callers keep working.
- `_build_url` appends params with `&` when the URL already carries a query string.

## Tests

New `TestRawRequest` covering params encoding, relative-path resolution, absolute-URL passthrough (byte-for-byte), unknown-kwarg `TypeError`, and timeout forwarding; plus a `_build_url` existing-query case. Full suite: 893 passed.

Fixes #121

🤖 Generated with [Claude Code](https://claude.com/claude-code)