### PR TITLE
fix(items): reuse existing .platform logicalId in save_to_disk

### DIFF
--- a/src/pyfabric/claude_memory/pyfabric.md
+++ b/src/pyfabric/claude_memory/pyfabric.md
@@ -53,16 +53,19 @@ for the current shell is the tenant pyfabric talks to. Pass `tenant=` to
   `testing` extra.
 - Lakehouse GUIDs are easiest to grab from the Fabric UI (Settings →
   Identifier). Workspace GUIDs come from listing workspaces via pyfabric.
-- **Pin the `logical_id=` on every `SemanticModel(...)` / `Report(...)` you
-  regenerate from a build script.** The builders mint a fresh logicalId
-  via `<factory>` on each run; Fabric git-sync keys deployed items by
-  `.platform/logicalId`, so a rebuild lands as a **new** artifact that
-  collides with the already-deployed one (same displayName, different
-  logicalId). The sync fails, listing both the deployed item (real
-  ObjectId) and the new one (ObjectId `00000000-…`). Fix: declare
-  module-level UUID constants once, pass them via `logical_id=` on every
-  rebuild, and never let a `<factory>`-generated logicalId reach main.
-  If one slips through, restore from the first successful deploy with
+- **logicalId identity on rebuild**: Fabric git-sync keys deployed items
+  by `.platform/logicalId`; a rebuild that changes it lands as a **new**
+  artifact colliding with the deployed one (same displayName, different
+  logicalId) and the sync fails. Since pyfabric 0.1.11, `save_to_disk`
+  on every builder **reuses the logicalId of an existing `.platform`**
+  in the target directory when you don't pass `logical_id=`, so
+  re-running a build script over a committed artifact is identity-stable
+  by default. Passing an explicit `logical_id=` that differs from the
+  on-disk one still wins but logs a `logical_id_mismatch` warning —
+  that's almost always a mistake. Pinning module-level UUID constants
+  via `logical_id=` remains good practice for builds into **fresh**
+  directories (CI temp dirs, first-time builds). If a wrong id ever
+  reaches main, restore from the first successful deploy with
   `git show <sha>:path/to/.platform`.
 
 **Common operations:**

--- a/src/pyfabric/items/bundle.py
+++ b/src/pyfabric/items/bundle.py
@@ -28,7 +28,7 @@ Usage:
 import base64
 import json
 import uuid
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
@@ -36,6 +36,7 @@ import structlog
 
 from pyfabric.items.crud import encode_part
 from pyfabric.items.normalize import write_artifact_file
+from pyfabric.items.types import resolve_logical_id
 
 log = structlog.get_logger()
 
@@ -55,15 +56,30 @@ class ArtifactBundle:
     display_name: str  # e.g. "NB_My_Notebook"
     parts: dict[str, str | bytes]  # {relative_path: content}
     description: str = ""
-    logical_id: str = field(default_factory=lambda: str(uuid.uuid4()))
+    # None = "not pinned by the caller": disk saves reuse an existing
+    # .platform logicalId; otherwise a fresh uuid4 is minted on first emit.
+    logical_id: str | None = None
 
     @property
     def dir_name(self) -> str:
         """Directory name in git-sync format: {DisplayName}.{ItemType}"""
         return f"{self.display_name}.{self.item_type}"
 
+    def platform_json_for(self, artifact_dir: str | Path) -> str:
+        """Generate .platform content for a disk save into ``artifact_dir``.
+
+        Reuses the logicalId of an existing ``artifact_dir/.platform``
+        when the caller didn't pin one, so rebuild scripts are idempotent
+        on item identity (regenerated ids break workspace git-sync with a
+        delete+add name clash).
+        """
+        self.logical_id = resolve_logical_id(artifact_dir, self.logical_id)
+        return self.platform_json()
+
     def platform_json(self) -> str:
         """Generate the .platform file content."""
+        if self.logical_id is None:
+            self.logical_id = str(uuid.uuid4())
         return json.dumps(
             {
                 "$schema": _PLATFORM_SCHEMA,
@@ -102,7 +118,7 @@ def save_to_disk(bundle: ArtifactBundle, output_dir: str | Path) -> Path:
     # match Fabric's canonical form (LF, no BOM, per-file-type trailing
     # newline). Binary parts fall through canonical_bytes unchanged.
     platform_path = artifact_dir / ".platform"
-    write_artifact_file(platform_path, bundle.platform_json())
+    write_artifact_file(platform_path, bundle.platform_json_for(artifact_dir))
     log.debug("Wrote %s", platform_path)
 
     for rel_path, content in bundle.parts.items():

--- a/src/pyfabric/items/datapipeline.py
+++ b/src/pyfabric/items/datapipeline.py
@@ -311,7 +311,9 @@ class DataPipelineBuilder:
         )
         artifact_dir = Path(output_dir) / bundle.dir_name
         artifact_dir.mkdir(parents=True, exist_ok=True)
-        write_artifact_file(artifact_dir / ".platform", bundle.platform_json())
+        write_artifact_file(
+            artifact_dir / ".platform", bundle.platform_json_for(artifact_dir)
+        )
         write_artifact_file(
             artifact_dir / "pipeline-content.json", self.to_pipeline_content()
         )

--- a/src/pyfabric/items/environment.py
+++ b/src/pyfabric/items/environment.py
@@ -252,7 +252,9 @@ class EnvironmentBuilder:
         artifact_dir = Path(output_dir) / bundle.dir_name
         artifact_dir.mkdir(parents=True, exist_ok=True)
 
-        write_artifact_file(artifact_dir / ".platform", bundle.platform_json())
+        write_artifact_file(
+            artifact_dir / ".platform", bundle.platform_json_for(artifact_dir)
+        )
 
         sparkcompute_path = artifact_dir / _SPARKCOMPUTE_PATH
         sparkcompute_path.parent.mkdir(parents=True, exist_ok=True)

--- a/src/pyfabric/items/mirrored_database.py
+++ b/src/pyfabric/items/mirrored_database.py
@@ -170,7 +170,9 @@ class MirroredDatabaseBuilder:
         artifact_dir = Path(output_dir) / bundle.dir_name
         artifact_dir.mkdir(parents=True, exist_ok=True)
 
-        write_artifact_file(artifact_dir / ".platform", bundle.platform_json())
+        write_artifact_file(
+            artifact_dir / ".platform", bundle.platform_json_for(artifact_dir)
+        )
         write_artifact_file(artifact_dir / "mirroring.json", self.to_mirroring_json())
         log.info(
             "mirrored_database_saved",

--- a/src/pyfabric/items/notebook.py
+++ b/src/pyfabric/items/notebook.py
@@ -288,7 +288,9 @@ class NotebookBuilder:
 
         # Route every file through write_artifact_file so line-ending
         # rules are applied regardless of OS default.
-        write_artifact_file(artifact_dir / ".platform", bundle.platform_json())
+        write_artifact_file(
+            artifact_dir / ".platform", bundle.platform_json_for(artifact_dir)
+        )
         write_artifact_file(
             artifact_dir / "notebook-content.py", self.to_source_string()
         )

--- a/src/pyfabric/items/report.py
+++ b/src/pyfabric/items/report.py
@@ -89,6 +89,7 @@ from typing import Any, Literal
 import structlog
 
 from pyfabric.items.normalize import write_artifact_file
+from pyfabric.items.types import resolve_logical_id
 
 log = structlog.get_logger()
 
@@ -481,7 +482,11 @@ class Report:
     description: str = ""
     theme: Theme | None = None
     strict_descriptions: bool = True
-    logical_id: str = field(default_factory=lambda: str(uuid.uuid4()))
+    # None = "not pinned by the caller": save_to_disk reuses the logicalId
+    # of an existing .platform in the target directory, so rebuild scripts
+    # are idempotent on item identity. A fresh uuid4 is minted only when
+    # neither an explicit id nor an existing .platform is available.
+    logical_id: str | None = None
 
     def validate(self) -> list[str]:
         """Return a list of human-readable error messages.
@@ -521,6 +526,7 @@ class Report:
 
         output_dir = Path(output_dir)
         item_dir = output_dir / f"{self.name}.Report"
+        self.logical_id = resolve_logical_id(item_dir, self.logical_id)
 
         # Stamp deterministic ids on any unnamed pages/visuals before emit.
         for page_index, page in enumerate(self.pages):
@@ -576,6 +582,8 @@ class Report:
     def _emit_platform(self) -> str:
         # NOTE: no ``description`` key — Fabric strips report descriptions
         # from .platform on sync, so emitting one causes a permanent flap.
+        if self.logical_id is None:
+            self.logical_id = str(uuid.uuid4())
         return json.dumps(
             {
                 "$schema": "https://developer.microsoft.com/json-schemas/fabric/gitIntegration/platformProperties/2.0.0/schema.json",

--- a/src/pyfabric/items/semantic_model.py
+++ b/src/pyfabric/items/semantic_model.py
@@ -98,6 +98,7 @@ from typing import Literal
 import structlog
 
 from pyfabric.items.normalize import write_artifact_file
+from pyfabric.items.types import resolve_logical_id
 from pyfabric.items.validate_tmdl import check_name_collisions
 
 log = structlog.get_logger()
@@ -434,7 +435,11 @@ class SemanticModel:
     culture: str = "en-US"
     annotations: dict[str, str] = field(default_factory=dict)
     strict_descriptions: bool = True
-    logical_id: str = field(default_factory=lambda: str(uuid.uuid4()))
+    # None = "not pinned by the caller": save_to_disk reuses the logicalId
+    # of an existing .platform in the target directory, so rebuild scripts
+    # are idempotent on item identity. A fresh uuid4 is minted only when
+    # neither an explicit id nor an existing .platform is available.
+    logical_id: str | None = None
 
     # ── Validation ──────────────────────────────────────────────────────────
 
@@ -585,6 +590,7 @@ class SemanticModel:
         item_dir = output_dir / f"{self.name}.SemanticModel"
         definition = item_dir / "definition"
 
+        self.logical_id = resolve_logical_id(item_dir, self.logical_id)
         write_artifact_file(item_dir / ".platform", self._emit_platform())
         write_artifact_file(item_dir / "definition.pbism", self._emit_pbism())
         write_artifact_file(definition / "database.tmdl", self._emit_database())
@@ -631,6 +637,8 @@ class SemanticModel:
     def _emit_platform(self) -> str:
         import json
 
+        if self.logical_id is None:
+            self.logical_id = str(uuid.uuid4())
         return json.dumps(
             {
                 "$schema": "https://developer.microsoft.com/json-schemas/fabric/gitIntegration/platformProperties/2.0.0/schema.json",

--- a/src/pyfabric/items/types.py
+++ b/src/pyfabric/items/types.py
@@ -7,7 +7,13 @@ files, and provides parsing/validation for .platform metadata files.
 from __future__ import annotations
 
 import json
+import uuid
 from dataclasses import dataclass, field
+from pathlib import Path
+
+import structlog
+
+log = structlog.get_logger()
 
 # ── .platform file model ─────────────────────────────────────────────────────
 
@@ -88,6 +94,52 @@ def parse_platform(content: str) -> PlatformFile:
         ),
         schema=data.get("$schema", PLATFORM_SCHEMA),
     )
+
+
+def resolve_logical_id(item_dir: Path | str, explicit: str | None) -> str:
+    """Return the logicalId to stamp into ``item_dir/.platform``.
+
+    Fabric identifies items by logicalId. Regenerating one when rebuilding
+    an existing artifact directory silently re-identifies the item, and the
+    next workspace "Update from Git" sees a delete+add pair with the same
+    display name and fails. Precedence:
+
+    - caller passed an explicit id → use it (a warning is logged when it
+      differs from an existing ``.platform``, since that is almost always
+      a mistake);
+    - an existing ``.platform`` is present → reuse its logicalId;
+    - otherwise → mint a fresh uuid4.
+    """
+    existing: str | None = None
+    platform_path = Path(item_dir) / ".platform"
+    if platform_path.exists():
+        try:
+            existing = parse_platform(
+                platform_path.read_text(encoding="utf-8")
+            ).config.logical_id
+        except (OSError, ValueError) as e:
+            log.warning(
+                "platform_unreadable — minting a fresh logicalId",
+                path=str(platform_path),
+                error=str(e),
+            )
+    if explicit is not None:
+        if existing is not None and existing != explicit:
+            log.warning(
+                "logical_id_mismatch — explicit id overrides on-disk .platform",
+                path=str(platform_path),
+                existing=existing,
+                explicit=explicit,
+            )
+        return explicit
+    if existing is not None:
+        log.info(
+            "logical_id_reused from existing .platform",
+            path=str(platform_path),
+            logical_id=existing,
+        )
+        return existing
+    return str(uuid.uuid4())
 
 
 # ── Item type registry ───────────────────────────────────────────────────────

--- a/tests/items/test_logical_id_reuse.py
+++ b/tests/items/test_logical_id_reuse.py
@@ -1,0 +1,157 @@
+"""Cross-builder tests for logicalId identity stability on rebuild.
+
+Fabric git-sync keys deployed items by ``.platform/logicalId``. Re-running
+a build script over an existing artifact directory must not re-identify
+the item — ``save_to_disk`` reuses the on-disk logicalId when the caller
+didn't pin one. See issue #130.
+"""
+
+import json
+import uuid
+from pathlib import Path
+
+from pyfabric.items.bundle import ArtifactBundle
+from pyfabric.items.bundle import save_to_disk as bundle_save_to_disk
+from pyfabric.items.datapipeline import DataPipelineBuilder
+from pyfabric.items.environment import EnvironmentBuilder
+from pyfabric.items.mirrored_database import MirroredDatabaseBuilder
+from pyfabric.items.notebook import NotebookBuilder
+from pyfabric.items.report import Page, Report
+from pyfabric.items.semantic_model import (
+    Column,
+    LakehouseSource,
+    SemanticModel,
+    Table,
+)
+
+
+def _platform_logical_id(item_dir: Path) -> str:
+    data = json.loads((item_dir / ".platform").read_text(encoding="utf-8"))
+    return data["config"]["logicalId"]
+
+
+def _minimal_model() -> SemanticModel:
+    source = LakehouseSource(name="Gold", workspace_id="ws-1", lakehouse_id="lh-1")
+    return SemanticModel(
+        name="sm_reuse",
+        description="Identity-reuse test model.",
+        sources=[source],
+        tables=[
+            Table(
+                name="dim_x",
+                source=source,
+                description="Test dim.",
+                columns=[Column("x_key", "string", description="PK.")],
+            )
+        ],
+    )
+
+
+def _minimal_report() -> Report:
+    return Report(
+        name="rpt_reuse",
+        semantic_model_path="../sm_reuse.SemanticModel",
+        pages=[Page(name="p1", display_name="Page 1")],
+        description="Identity-reuse test report.",
+    )
+
+
+class TestDoubleSaveKeepsIdentity:
+    """Second save into the same directory must not change .platform."""
+
+    def test_notebook_builder(self, tmp_path: Path) -> None:
+        first = NotebookBuilder().add_python("pass")
+        d1 = first.save_to_disk(tmp_path, display_name="nb_reuse")
+        original = (d1 / ".platform").read_bytes()
+        # A NEW builder instance (fresh script run) must adopt the id.
+        second = NotebookBuilder().add_python("pass")
+        d2 = second.save_to_disk(tmp_path, display_name="nb_reuse")
+        assert (d2 / ".platform").read_bytes() == original
+
+    def test_datapipeline_builder(self, tmp_path: Path) -> None:
+        d1 = DataPipelineBuilder().save_to_disk(tmp_path, display_name="pl_reuse")
+        original = (d1 / ".platform").read_bytes()
+        d2 = DataPipelineBuilder().save_to_disk(tmp_path, display_name="pl_reuse")
+        assert (d2 / ".platform").read_bytes() == original
+
+    def test_environment_builder(self, tmp_path: Path) -> None:
+        d1 = EnvironmentBuilder().save_to_disk(tmp_path, display_name="env_reuse")
+        original = (d1 / ".platform").read_bytes()
+        d2 = EnvironmentBuilder().save_to_disk(tmp_path, display_name="env_reuse")
+        assert (d2 / ".platform").read_bytes() == original
+
+    def test_mirrored_database_builder(self, tmp_path: Path) -> None:
+        d1 = MirroredDatabaseBuilder().save_to_disk(tmp_path, display_name="mdb_reuse")
+        original = (d1 / ".platform").read_bytes()
+        d2 = MirroredDatabaseBuilder().save_to_disk(tmp_path, display_name="mdb_reuse")
+        assert (d2 / ".platform").read_bytes() == original
+
+    def test_semantic_model(self, tmp_path: Path) -> None:
+        d1 = _minimal_model().save_to_disk(tmp_path)
+        original = (d1 / ".platform").read_bytes()
+        d2 = _minimal_model().save_to_disk(tmp_path)
+        assert (d2 / ".platform").read_bytes() == original
+
+    def test_report(self, tmp_path: Path) -> None:
+        d1 = _minimal_report().save_to_disk(tmp_path)
+        original = (d1 / ".platform").read_bytes()
+        d2 = _minimal_report().save_to_disk(tmp_path)
+        assert (d2 / ".platform").read_bytes() == original
+
+    def test_module_level_bundle_save(self, tmp_path: Path) -> None:
+        d1 = bundle_save_to_disk(
+            ArtifactBundle(
+                item_type="Notebook",
+                display_name="nb_bundle_reuse",
+                parts={"notebook-content.py": "# stub\n"},
+            ),
+            tmp_path,
+        )
+        original = (d1 / ".platform").read_bytes()
+        d2 = bundle_save_to_disk(
+            ArtifactBundle(
+                item_type="Notebook",
+                display_name="nb_bundle_reuse",
+                parts={"notebook-content.py": "# stub\n"},
+            ),
+            tmp_path,
+        )
+        assert (d2 / ".platform").read_bytes() == original
+
+
+class TestExplicitIdPrecedence:
+    def test_explicit_id_overrides_existing_platform(self, tmp_path: Path) -> None:
+        NotebookBuilder().add_python("pass").save_to_disk(
+            tmp_path, display_name="nb_pin"
+        )
+        pinned = str(uuid.uuid4())
+        d = (
+            NotebookBuilder()
+            .add_python("pass")
+            .save_to_disk(tmp_path, display_name="nb_pin", logical_id=pinned)
+        )
+        assert _platform_logical_id(d) == pinned
+
+    def test_semantic_model_explicit_id_survives(self, tmp_path: Path) -> None:
+        pinned = str(uuid.uuid4())
+        model = _minimal_model()
+        model.logical_id = pinned
+        d = model.save_to_disk(tmp_path)
+        assert _platform_logical_id(d) == pinned
+
+    def test_instance_id_stable_across_two_dirs(self, tmp_path: Path) -> None:
+        # One instance saved to two fresh dirs keeps the id it minted first
+        # (the resolver treats the now-set instance id as explicit).
+        model = _minimal_model()
+        d1 = model.save_to_disk(tmp_path / "a")
+        d2 = model.save_to_disk(tmp_path / "b")
+        assert _platform_logical_id(d1) == _platform_logical_id(d2)
+
+
+class TestRestUploadPathStillMintsIds:
+    def test_platform_json_memoizes_fresh_uuid(self) -> None:
+        bundle = ArtifactBundle(item_type="Notebook", display_name="nb_rest", parts={})
+        first = bundle.platform_json()
+        assert bundle.logical_id is not None
+        uuid.UUID(bundle.logical_id)
+        assert bundle.platform_json() == first

--- a/tests/items/test_types.py
+++ b/tests/items/test_types.py
@@ -8,6 +8,7 @@ import pytest
 from pyfabric.items.types import (
     ITEM_TYPES,
     parse_platform,
+    resolve_logical_id,
 )
 
 
@@ -164,3 +165,55 @@ class TestPlatformFile:
         }
         pf = parse_platform(json.dumps(data))
         assert pf.expected_dir_name == "nb_test.Notebook"
+
+
+class TestResolveLogicalId:
+    """resolve_logical_id: the identity-stability contract for rebuilds."""
+
+    @staticmethod
+    def _write_platform(item_dir, logical_id):
+        item_dir.mkdir(parents=True, exist_ok=True)
+        (item_dir / ".platform").write_text(
+            json.dumps(
+                {
+                    "metadata": {"type": "Notebook", "displayName": "nb"},
+                    "config": {"version": "2.0", "logicalId": logical_id},
+                }
+            ),
+            encoding="utf-8",
+        )
+
+    def test_reuses_existing_platform_id_when_not_pinned(self, tmp_path):
+        existing = str(uuid.uuid4())
+        self._write_platform(tmp_path / "nb.Notebook", existing)
+        assert resolve_logical_id(tmp_path / "nb.Notebook", None) == existing
+
+    def test_mints_fresh_uuid_for_new_directory(self, tmp_path):
+        resolved = resolve_logical_id(tmp_path / "nb.Notebook", None)
+        uuid.UUID(resolved)  # raises if not a valid uuid
+
+    def test_explicit_id_wins_over_existing(self, tmp_path):
+        self._write_platform(tmp_path / "nb.Notebook", str(uuid.uuid4()))
+        explicit = str(uuid.uuid4())
+        assert resolve_logical_id(tmp_path / "nb.Notebook", explicit) == explicit
+
+    def test_explicit_id_used_for_new_directory(self, tmp_path):
+        explicit = str(uuid.uuid4())
+        assert resolve_logical_id(tmp_path / "nb.Notebook", explicit) == explicit
+
+    def test_corrupt_platform_falls_back_to_fresh_uuid(self, tmp_path):
+        item_dir = tmp_path / "nb.Notebook"
+        item_dir.mkdir(parents=True)
+        (item_dir / ".platform").write_text("{not json", encoding="utf-8")
+        resolved = resolve_logical_id(item_dir, None)
+        uuid.UUID(resolved)
+
+    def test_platform_missing_logical_id_falls_back(self, tmp_path):
+        item_dir = tmp_path / "nb.Notebook"
+        item_dir.mkdir(parents=True)
+        (item_dir / ".platform").write_text(
+            json.dumps({"metadata": {"type": "Notebook", "displayName": "nb"}}),
+            encoding="utf-8",
+        )
+        resolved = resolve_logical_id(item_dir, None)
+        uuid.UUID(resolved)


### PR DESCRIPTION
## Problem

`SemanticModel`, `Report`, and every bundle-based builder defaulted `logical_id` to a fresh `uuid4` per instance. Re-running a build script over an existing artifact directory overwrote `.platform` with a new logicalId — silently changing the artifact's git-sync identity. The next workspace "Update from Git" then failed:

> We can't update from Git because one item was added and another with the same name and type was deleted.

## Fix

- `logical_id` fields on `SemanticModel`, `Report`, and `ArtifactBundle` become `str | None = None` sentinels, so "caller pinned an id" is distinguishable from "defaulted".
- New `items.types.resolve_logical_id(item_dir, explicit)`: explicit id wins (a `logical_id_mismatch` warning is logged when it differs from an existing `.platform` — that's almost always a mistake); otherwise an existing `.platform`'s logicalId is **reused**; otherwise a fresh uuid4 is minted.
- Every disk-save path routes through it: module-level `bundle.save_to_disk`, plus the direct `.platform` writes in Notebook / DataPipeline / Environment / MirroredDatabase builders via the new `ArtifactBundle.platform_json_for(artifact_dir)`.
- REST upload path unchanged (`platform_json()` memoizes a fresh uuid4 when unpinned).
- Shipped claude-memory `pyfabric.md` updated: pinning constants stays recommended for fresh dirs, but rebuilds over committed artifacts are now identity-stable by default.

## Compatibility note

`SemanticModel.logical_id` / `Report.logical_id` / `ArtifactBundle.logical_id` are now `None` until first emit. Code reading `.logical_id` before `save_to_disk`/`platform_json()` gets `None` instead of a pre-minted uuid; all in-repo consumers only read it at emit time.

## Validation

- New `tests/items/test_logical_id_reuse.py`: double-save byte-identity for all 6 builder types, explicit-id precedence, REST-path memoization.
- New `TestResolveLogicalId` in `tests/items/test_types.py` incl. corrupt/partial `.platform` fallback.
- Manual check: two consecutive builds of all 6 artifact types into a git repo → `git status --porcelain` empty on the second build.
- `ruff check` / `ruff format --check` / `mypy src/` / `pytest` (963 passed) / `pip-audit` all green.

Closes #130

🤖 Generated with [Claude Code](https://claude.com/claude-code)