### PR TITLE
feat(deploy): substitute_parameters for multi-environment promotion

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,6 +16,7 @@ repos:
         additional_dependencies:
           - structlog>=24.0
           - pytest>=8.0
+          - types-PyYAML>=6.0
         pass_filenames: false
         entry: mypy src/
 

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -145,14 +145,43 @@ at artifacts excluded by `item_types_in_scope` — are ignored with a
 debug log. A dependency **cycle** raises `PublishOrderError` naming
 the participating artifacts.
 
+## Parameter substitution (multi-environment promotion)
+
+`substitute_parameters` applies a fabric-cicd-style `parameter.yml`
+find/replace to a copy of the repo, so one artifact bundle promotes
+across DEV / PPE / PROD workspaces with different lakehouse ids,
+connection strings, etc. Requires the `deploy` extra
+(`pip install 'pyfabric[deploy]'` — pulls in PyYAML).
+
+```yaml
+# parameter.yml
+find_replace:
+  - find_value: "11111111-1111-1111-1111-111111111111"   # DEV lakehouse id
+    replace_value:
+      DEV: "11111111-1111-1111-1111-111111111111"
+      PROD: "22222222-2222-2222-2222-222222222222"
+```
+
+```python
+from pyfabric.deploy import publish_repo, substitute_parameters
+
+staged = substitute_parameters(
+    "definitions/", "parameter.yml", environment="PROD"
+)  # returns a temp copy; pass output_dir= to control the location
+publish_repo(client, prod_ws_id, staged, item_types_in_scope=["Notebook"])
+```
+
+Guarantees: the source repo is never modified; the copy is
+byte-faithful except the replaced spans; binary files (e.g.
+`Resources/builtin/*.whl`) copy untouched; a missing `parameter.yml`
+raises instead of silently no-oping; an entry with no value for the
+requested environment raises naming the variable and the environments
+it does define.
+
 ## Not currently in scope
 
 These would be follow-ups, not v1:
 
-- **Parameter substitution.** No equivalent to the `parameter.yml`
-  find-replace flow that some external CI/CD tools provide. If you
-  need per-environment value substitution, do it in your CI pipeline
-  before calling `publish_repo`.
 - **Concurrent publish.** Items publish serially. Fast enough for
   typical workspaces; parallelize externally if needed.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,15 +75,23 @@ testing = [
 dataagent = [
     "mcp>=1.23.0",
 ]
+# parameter.yml (find_replace) parsing for deploy.substitute_parameters.
+# PyYAML has no transitive dependencies; floor at the current release
+# (yaml.safe_load only — the historic PyYAML CVEs are full_load-only).
+deploy = [
+    "pyyaml>=6.0.2",
+]
 all = [
     "pyfabric[azure]",
     "pyfabric[data]",
     "pyfabric[lakehouse-io]",
     "pyfabric[testing]",
     "pyfabric[dataagent]",
+    "pyfabric[deploy]",
 ]
 dev = [
     "pyfabric[all]",
+    "types-PyYAML>=6.0",
     "pytest>=8.0",
     "pytest-cov>=6.0",
     "pytest-json-report>=1.5",

--- a/src/pyfabric/deploy.py
+++ b/src/pyfabric/deploy.py
@@ -37,6 +37,8 @@ from __future__ import annotations
 
 import heapq
 import json
+import shutil
+import tempfile
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -374,3 +376,152 @@ def unpublish_orphans(
             dry_run=dry_run,
         )
     return results
+
+
+# ── Parameter substitution (multi-environment promotion) ────────────────────
+
+
+def _load_find_replace(
+    parameter_yml: Path,
+) -> list[tuple[str, dict[str, str]]]:
+    """Parse and validate a fabric-cicd-style ``parameter.yml``.
+
+    Expected schema::
+
+        find_replace:
+          - find_value: "<DEV_LAKEHOUSE_ID>"
+            replace_value:
+              DEV: "1111..."
+              PROD: "2222..."
+
+    Returns ``[(find_value, {env: replace_value})]`` in file order.
+    """
+    try:
+        import yaml
+    except ImportError as e:  # pragma: no cover - exercised via sys.modules patch
+        raise ImportError(
+            "substitute_parameters needs PyYAML — install the deploy extra: "
+            "pip install 'pyfabric[deploy]'"
+        ) from e
+
+    if not parameter_yml.is_file():
+        raise FileNotFoundError(
+            f"parameter file not found: {parameter_yml} — substitution "
+            "refuses to silently no-op"
+        )
+    data = yaml.safe_load(parameter_yml.read_text(encoding="utf-8"))
+    if not isinstance(data, dict) or "find_replace" not in data:
+        raise ValueError(
+            f"{parameter_yml}: expected a mapping with a 'find_replace' list "
+            "(fabric-cicd parameter.yml schema)"
+        )
+    entries = data["find_replace"]
+    if not isinstance(entries, list):
+        raise ValueError(f"{parameter_yml}: 'find_replace' must be a list")
+
+    parsed: list[tuple[str, dict[str, str]]] = []
+    for i, entry in enumerate(entries):
+        if not isinstance(entry, dict) or "find_value" not in entry:
+            raise ValueError(f"{parameter_yml}: find_replace[{i}] needs a 'find_value'")
+        replace_value = entry.get("replace_value")
+        if not isinstance(replace_value, dict) or not replace_value:
+            raise ValueError(
+                f"{parameter_yml}: find_replace[{i}] "
+                f"({entry['find_value']!r}) needs a non-empty "
+                "'replace_value' environment map"
+            )
+        parsed.append(
+            (
+                str(entry["find_value"]),
+                {str(k): str(v) for k, v in replace_value.items()},
+            )
+        )
+    return parsed
+
+
+def substitute_parameters(
+    repo_dir: Path | str,
+    parameter_yml: Path | str,
+    *,
+    environment: str,
+    output_dir: Path | str | None = None,
+) -> Path:
+    """Apply ``parameter.yml`` find/replace values for ``environment``.
+
+    Copies ``repo_dir`` and replaces every ``find_value`` string with its
+    ``replace_value[environment]`` in all text-decodable files, so the
+    same artifact bundle can promote across DEV / PPE / PROD workspaces
+    with different lakehouse ids, connection strings, etc. The returned
+    directory is suitable as input to :func:`publish_repo`::
+
+        staged = substitute_parameters(
+            "definitions/", "parameter.yml", environment="PROD"
+        )
+        publish_repo(client, prod_ws_id, staged, item_types_in_scope=[...])
+
+    The copy is **byte-faithful**: text files keep their exact bytes
+    except the replaced spans (no re-normalization), and binary files
+    (e.g. ``Resources/builtin/*.whl``) are copied untouched. The source
+    ``repo_dir`` is never modified.
+
+    Args:
+        parameter_yml: fabric-cicd-style ``find_replace`` file (see
+            :func:`_load_find_replace` for the schema). Missing file →
+            ``FileNotFoundError`` (never a silent no-op).
+        environment: Key into each entry's ``replace_value`` map. An
+            entry without this key raises ``ValueError`` naming the
+            ``find_value`` and the environments it does define.
+        output_dir: Destination root. Defaults to a fresh temp
+            directory the caller is responsible for cleaning up.
+
+    Requires the ``deploy`` extra (``pip install 'pyfabric[deploy]'``).
+    """
+    repo_dir = Path(repo_dir)
+    if not repo_dir.is_dir():
+        raise FileNotFoundError(f"repo_dir not found: {repo_dir}")
+    replacements = _load_find_replace(Path(parameter_yml))
+
+    resolved: list[tuple[str, str]] = []
+    for find_value, env_map in replacements:
+        if environment not in env_map:
+            available = ", ".join(sorted(env_map))
+            raise ValueError(
+                f"parameter {find_value!r} has no value for environment "
+                f"{environment!r} (available: {available})"
+            )
+        resolved.append((find_value, env_map[environment]))
+
+    if output_dir is None:
+        out_root = Path(tempfile.mkdtemp(prefix="pyfabric-substitute-"))
+    else:
+        out_root = Path(output_dir)
+        out_root.mkdir(parents=True, exist_ok=True)
+
+    substituted_files = 0
+    for src in repo_dir.rglob("*"):
+        rel = src.relative_to(repo_dir)
+        dest = out_root / rel
+        if src.is_dir():
+            dest.mkdir(parents=True, exist_ok=True)
+            continue
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        raw = src.read_bytes()
+        try:
+            text = raw.decode("utf-8")
+        except UnicodeDecodeError:
+            shutil.copyfile(src, dest)  # binary: byte-for-byte
+            continue
+        original = text
+        for find_value, replace_value in resolved:
+            text = text.replace(find_value, replace_value)
+        if text != original:
+            substituted_files += 1
+        dest.write_bytes(text.encode("utf-8"))
+
+    log.info(
+        "parameters_substituted",
+        environment=environment,
+        files_changed=substituted_files,
+        output_dir=str(out_root),
+    )
+    return out_root

--- a/tests/test_deploy.py
+++ b/tests/test_deploy.py
@@ -14,6 +14,7 @@ from pyfabric.deploy import (
     PublishResult,
     UnpublishResult,
     publish_repo,
+    substitute_parameters,
     unpublish_orphans,
 )
 from pyfabric.items.bundle import ArtifactBundle, save_to_disk
@@ -410,3 +411,119 @@ class TestDependencyOrder:
         second = _publish_order(MagicMock(), tmp_path)
         assert first == second
         assert first.index("nb_1") < first.index("pl_1")
+
+
+# ── substitute_parameters (issue #97) ────────────────────────────────────────
+
+
+_PARAM_YML = """\
+find_replace:
+  - find_value: "11111111-1111-1111-1111-111111111111"
+    replace_value:
+      DEV: "22222222-2222-2222-2222-222222222222"
+      PROD: "33333333-3333-3333-3333-333333333333"
+  - find_value: "<CONN_STRING>"
+    replace_value:
+      DEV: "dev-endpoint.example"
+      PROD: "prod-endpoint.example"
+"""
+
+
+def _staged_repo(tmp_path: Path) -> tuple[Path, Path]:
+    repo = tmp_path / "repo"
+    _make_item(
+        repo,
+        "nb_x",
+        "Notebook",
+        files={
+            "notebook-content.py": (
+                "# lakehouse: 11111111-1111-1111-1111-111111111111\n"
+                "# server: <CONN_STRING>\n"
+            )
+        },
+    )
+    yml = tmp_path / "parameter.yml"
+    yml.write_text(_PARAM_YML, encoding="utf-8")
+    return repo, yml
+
+
+class TestSubstituteParameters:
+    def test_substitutes_for_selected_environment(self, tmp_path: Path) -> None:
+        repo, yml = _staged_repo(tmp_path)
+        out = substitute_parameters(repo, yml, environment="PROD")
+        content = (out / "nb_x.Notebook" / "notebook-content.py").read_text("utf-8")
+        assert "33333333-3333-3333-3333-333333333333" in content
+        assert "prod-endpoint.example" in content
+        assert "11111111" not in content
+
+    def test_environment_selection_differs(self, tmp_path: Path) -> None:
+        repo, yml = _staged_repo(tmp_path)
+        dev = substitute_parameters(repo, yml, environment="DEV")
+        content = (dev / "nb_x.Notebook" / "notebook-content.py").read_text("utf-8")
+        assert "22222222-2222-2222-2222-222222222222" in content
+
+    def test_source_repo_untouched(self, tmp_path: Path) -> None:
+        repo, yml = _staged_repo(tmp_path)
+        before = (repo / "nb_x.Notebook" / "notebook-content.py").read_bytes()
+        substitute_parameters(repo, yml, environment="PROD")
+        assert (repo / "nb_x.Notebook" / "notebook-content.py").read_bytes() == before
+
+    def test_output_dir_honored(self, tmp_path: Path) -> None:
+        repo, yml = _staged_repo(tmp_path)
+        dest = tmp_path / "staged"
+        out = substitute_parameters(repo, yml, environment="DEV", output_dir=dest)
+        assert out == dest
+        assert (dest / "nb_x.Notebook" / ".platform").exists()
+
+    def test_binary_files_copied_untouched(self, tmp_path: Path) -> None:
+        repo, yml = _staged_repo(tmp_path)
+        wheel = repo / "nb_x.Notebook" / "Resources" / "builtin" / "pkg.whl"
+        wheel.parent.mkdir(parents=True)
+        payload = bytes([0, 255, 254, 1]) + b"11111111-1111-1111-1111-111111111111"
+        wheel.write_bytes(payload)
+        out = substitute_parameters(repo, yml, environment="PROD")
+        copied = out / "nb_x.Notebook" / "Resources" / "builtin" / "pkg.whl"
+        assert copied.read_bytes() == payload
+
+    def test_missing_environment_names_variable_and_options(
+        self, tmp_path: Path
+    ) -> None:
+        repo, yml = _staged_repo(tmp_path)
+        with pytest.raises(ValueError, match=r"'PPE'.*DEV, PROD"):
+            substitute_parameters(repo, yml, environment="PPE")
+
+    def test_missing_yml_raises(self, tmp_path: Path) -> None:
+        repo, _ = _staged_repo(tmp_path)
+        with pytest.raises(FileNotFoundError, match="parameter file not found"):
+            substitute_parameters(repo, tmp_path / "nope.yml", environment="DEV")
+
+    def test_malformed_yml_raises(self, tmp_path: Path) -> None:
+        repo, yml = _staged_repo(tmp_path)
+        yml.write_text("something_else: []\n", encoding="utf-8")
+        with pytest.raises(ValueError, match="find_replace"):
+            substitute_parameters(repo, yml, environment="DEV")
+
+    def test_entry_without_replace_value_raises(self, tmp_path: Path) -> None:
+        repo, yml = _staged_repo(tmp_path)
+        yml.write_text('find_replace:\n  - find_value: "x"\n', encoding="utf-8")
+        with pytest.raises(ValueError, match="replace_value"):
+            substitute_parameters(repo, yml, environment="DEV")
+
+    def test_composes_with_publish_repo(self, tmp_path: Path) -> None:
+        repo, yml = _staged_repo(tmp_path)
+        out = substitute_parameters(repo, yml, environment="PROD")
+        client = MagicMock()
+        client.get_paged.return_value = []
+        client.post.return_value = {"id": "x"}
+        results = publish_repo(client, "ws-x", out)
+        assert [r.display_name for r in results] == ["nb_x"]
+
+    def test_import_error_names_the_extra(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        import sys
+
+        repo, yml = _staged_repo(tmp_path)
+        monkeypatch.setitem(sys.modules, "yaml", None)
+        with pytest.raises(ImportError, match=r"pyfabric\[deploy\]"):
+            substitute_parameters(repo, yml, environment="DEV")


### PR DESCRIPTION
> Was stacked on #135; **rebased onto `main` after its merge** — conflict-free and ready to review standalone.

## Change

`deploy.substitute_parameters(repo_dir, parameter_yml, *, environment, output_dir=None) -> Path` — the value-substitution helper from the issue, matching **fabric-cicd's `find_replace` schema** so consumers can migrate without rewriting their `parameter.yml`:

```yaml
find_replace:
  - find_value: "<DEV_LAKEHOUSE_ID>"
    replace_value:
      DEV: "1111..."
      PROD: "2222..."
```

Returns a staged copy suitable as `publish_repo` input. Guarantees:
- **byte-faithful**: text files keep exact bytes outside replaced spans (no re-normalization); binary files (`Resources/builtin/*.whl`) copy untouched; source repo never modified
- **never a silent no-op**: missing yml → `FileNotFoundError`; entry lacking the requested environment → `ValueError` naming the `find_value` and available environments; malformed schema → `ValueError` pointing at the entry

## Dependency decision

First parse-dependency in the deploy path: **PyYAML ≥ 6.0.2 in a new optional `deploy` extra** (lazy import with a `pip install 'pyfabric[deploy]'` hint), wired into `[all]`; `types-PyYAML` added to `dev` + the pre-commit mypy hook env. Rationale: real-world `parameter.yml` files use arbitrary YAML (quoting, comments, multiline) — a hand-rolled subset parser would fail silently on exactly the files we claim compatibility with. Supply chain: PyYAML has zero transitive deps; all GitHub advisories affect < 5.4 and the unsafe-load path (this uses `yaml.safe_load` only); wheel hash-verified against the PyPI record before local install; `types-PyYAML` has zero advisories; `pip-audit` clean.

## Acceptance criteria from the issue

- [x] Returns a Path to a substituted copy with `replace_value[environment]` applied
- [x] Missing environment → clear error naming variable + available environments
- [x] Missing yml → clear error (no silent no-op)
- [x] Binary files copied untouched
- [x] Unit tests (11 new, incl. ImportError-path via `sys.modules` patch); composes with `publish_repo` (mocked)
- [x] `docs/deploy.md` documents the recommended multi-environment flow

## Validation

`ruff check` / `ruff format --check` / `mypy src/` (strict on deploy.py) / `pytest` (965 passed) / `pip-audit` green.

Closes #97

🤖 Generated with [Claude Code](https://claude.com/claude-code)