### PR TITLE
feat(semantic-model): SqlEndpointSource import source + non-dbo LakehouseSource guard

### DIFF
--- a/src/pyfabric/items/semantic_model.py
+++ b/src/pyfabric/items/semantic_model.py
@@ -236,8 +236,47 @@ class SqlQuerySource:
             )
 
 
+@dataclass(frozen=True)
+class SqlEndpointSource:
+    """A lakehouse SQL analytics endpoint read via **import**-mode partitions.
+
+    The ``Lakehouse.Contents`` connector behind :class:`LakehouseSource`
+    returns an **empty navigation table** for schema-enabled lakehouses
+    (tables under ``Tables/<schema>/``), so every refresh fails with
+    ``Expression.Error: The key didn't match any rows in the table``.
+    This source navigates the SQL analytics endpoint instead, which
+    serves all schemas. Emits one shared expression::
+
+        expression <name> =
+                let
+                    Source = Sql.Database("<server>", "<database>")
+                in
+                    Source
+
+    and each table sourced from it emits an import M partition
+    navigating ``Source{[Schema="<schema>", Item="<table>"]}[Data]``.
+
+    ``server`` is the endpoint host
+    (``*.datawarehouse.fabric.microsoft.com`` — resolvable via
+    ``GET /workspaces/{ws}/lakehouses/{id}`` →
+    ``properties.sqlEndpointProperties.connectionString``);
+    ``database`` is the lakehouse display name.
+    """
+
+    name: str
+    server: str
+    database: str
+    description: str | None = None
+
+    def __post_init__(self) -> None:
+        if not self.name.isidentifier():
+            raise ValueError(
+                f"SqlEndpointSource.name must be a valid M identifier, got {self.name!r}"
+            )
+
+
 # Anything a Table can read from.
-Source = LakehouseSource | SqlDatabaseSource | SqlQuerySource
+Source = LakehouseSource | SqlDatabaseSource | SqlQuerySource | SqlEndpointSource
 
 
 # ── Columns ─────────────────────────────────────────────────────────────────
@@ -517,6 +556,19 @@ class SemanticModel:
                     f"SqlQuerySource source (got {type(t.source).__name__})"
                 )
 
+        # Lakehouse.Contents cannot address non-dbo schemas: against a
+        # schema-enabled lakehouse it returns an empty navigation table,
+        # so every refresh of such a model fails. Refuse to emit one.
+        for t in self.tables:
+            if isinstance(t.source, LakehouseSource) and t.schema != "dbo":
+                errors.append(
+                    f"{t.name}: schema {t.schema!r} is not addressable via "
+                    f"LakehouseSource — Lakehouse.Contents returns an empty "
+                    f"navigation table for schema-enabled lakehouses, so the "
+                    f"model can never refresh. Use SqlEndpointSource (SQL "
+                    f"analytics endpoint) for this table's source instead."
+                )
+
         if self.compatibility_level < 1604 and any(
             isinstance(s, SqlDatabaseSource) for s in self.sources
         ):
@@ -663,7 +715,8 @@ class SemanticModel:
     def _emit_model(self) -> str:
         # PBI_QueryOrder lists every M query in the model: the parameter +
         # navigation expressions a source contributes (LakehouseSource
-        # brings three, SqlDatabaseSource one, SqlQuerySource none — its
+        # brings three, SqlDatabaseSource/SqlEndpointSource one each,
+        # SqlQuerySource none — its
         # Sql.Database call is inlined per partition) and then the tables.
         lakehouse_sources = [s for s in self.sources if isinstance(s, LakehouseSource)]
         order = (
@@ -671,6 +724,7 @@ class SemanticModel:
             + [f"{s.name}LakehouseId" for s in lakehouse_sources]
             + [s.name for s in lakehouse_sources]
             + [s.name for s in self.sources if isinstance(s, SqlDatabaseSource)]
+            + [s.name for s in self.sources if isinstance(s, SqlEndpointSource)]
             + [t.name for t in self.tables]
         )
         # PBI_QueryOrder is a JSON array embedded as a TMDL annotation value.
@@ -720,6 +774,8 @@ class SemanticModel:
                 chunks.append(_emit_lakehouse_expression(s, _lineage(s.name)))
             elif isinstance(s, SqlDatabaseSource):
                 chunks.append(_emit_sql_database_expression(s, _lineage(s.name)))
+            elif isinstance(s, SqlEndpointSource):
+                chunks.append(_emit_sql_endpoint_expression(s, _lineage(s.name)))
             # SqlQuerySource contributes no expression — its Sql.Database
             # call is inlined in each table partition.
         return "\n\n".join(chunks)
@@ -870,6 +926,22 @@ def _emit_sql_database_expression(s: SqlDatabaseSource, lineage_tag: str) -> str
     )
 
 
+def _emit_sql_endpoint_expression(s: SqlEndpointSource, lineage_tag: str) -> str:
+    """The shared ``Sql.Database`` navigation expression for import partitions."""
+    return (
+        f"expression {s.name} =\n"
+        "\t\tlet\n"
+        f'\t\t    Source = Sql.Database("{s.server}", "{s.database}")\n'
+        "\t\tin\n"
+        "\t\t    Source\n"
+        f"\tlineageTag: {lineage_tag}\n"
+        "\n"
+        "\tannotation PBI_NavigationStepName = Navigation\n"
+        "\n"
+        "\tannotation PBI_ResultType = Database"
+    )
+
+
 def _emit_partition(t: Table) -> str:
     """The ``partition`` block, shaped by the table's source kind."""
     if isinstance(t.source, SqlDatabaseSource):
@@ -901,6 +973,22 @@ def _emit_partition(t: Table) -> str:
             f'"{t.source.database}", [Query="{escaped_query}"])\n'
             "\t\t\t\tin\n"
             "\t\t\t\t    Source"
+        )
+    if isinstance(t.source, SqlEndpointSource):
+        # Import partition over the SQL analytics endpoint — note the
+        # `Schema=`/`Item=` navigation key (NOT `Id=`): this is the shape
+        # the Sql.Database navigation table matches, and it works for
+        # schema-enabled lakehouses where Lakehouse.Contents returns
+        # nothing.
+        return (
+            f"\tpartition {t.name} = m\n"
+            "\t\tmode: import\n"
+            "\t\tsource =\n"
+            "\t\t\t\tlet\n"
+            f"\t\t\t\t    Source = {t.source.name},\n"
+            f'\t\t\t\t    tbl = Source{{[Schema="{t.schema}", Item="{t.name}"]}}[Data]\n'
+            "\t\t\t\tin\n"
+            "\t\t\t\t    tbl"
         )
     return (
         f"\tpartition {t.name} = m\n"

--- a/tests/items/test_semantic_model.py
+++ b/tests/items/test_semantic_model.py
@@ -13,6 +13,7 @@ from pyfabric.items.semantic_model import (
     SemanticModel,
     SemanticModelError,
     SqlDatabaseSource,
+    SqlEndpointSource,
     SqlQuerySource,
     Table,
     arrow_to_tmdl,
@@ -843,3 +844,162 @@ class TestLakehouseSourceRegression:
             '["GoldWorkspaceId", "GoldLakehouseId", "Gold", '
             '"dim_section", "fact_status"]'
         ) in model_tmdl
+
+
+@pytest.fixture
+def sql_endpoint() -> SqlEndpointSource:
+    return SqlEndpointSource(
+        name="lh_gold",
+        server="srv.datawarehouse.fabric.microsoft.com",
+        database="lh_gold",
+    )
+
+
+def _endpoint_table(source: SqlEndpointSource, schema: str = "gold") -> Table:
+    return Table(
+        name="fact_orders",
+        source=source,
+        schema=schema,
+        description="Orders fact.",
+        columns=[Column("order_no", "string", description="Order number.")],
+    )
+
+
+class TestSqlEndpointSource:
+    """Issue #129: import-mode source for schema-enabled lakehouses."""
+
+    def test_invalid_identifier_rejected(self) -> None:
+        with pytest.raises(ValueError, match="M identifier"):
+            SqlEndpointSource(name="bad name", server="s", database="d")
+
+    def test_emits_navigation_expression_and_import_partition(
+        self, tmp_path: Path, sql_endpoint: SqlEndpointSource
+    ) -> None:
+        # Expression + partition shapes match the field-proven
+        # SQL-analytics-endpoint navigation that refreshes successfully
+        # against a schema-enabled lakehouse.
+        sm = SemanticModel(
+            name="sm_endpoint",
+            description="SQL endpoint import test model.",
+            sources=[sql_endpoint],
+            tables=[_endpoint_table(sql_endpoint)],
+        )
+        item_dir = sm.save_to_disk(tmp_path)
+
+        expressions = (item_dir / "definition" / "expressions.tmdl").read_text("utf-8")
+        assert (
+            "expression lh_gold =\n"
+            "\t\tlet\n"
+            '\t\t    Source = Sql.Database("srv.datawarehouse.fabric.microsoft.com", "lh_gold")\n'
+            "\t\tin\n"
+            "\t\t    Source\n"
+        ) in expressions
+        # No Lakehouse.Contents and no parameter expressions.
+        assert "Lakehouse.Contents" not in expressions
+        assert "IsParameterQuery" not in expressions
+
+        table_tmdl = (
+            item_dir / "definition" / "tables" / "fact_orders.tmdl"
+        ).read_text("utf-8")
+        assert (
+            "\tpartition fact_orders = m\n"
+            "\t\tmode: import\n"
+            "\t\tsource =\n"
+            "\t\t\t\tlet\n"
+            "\t\t\t\t    Source = lh_gold,\n"
+            '\t\t\t\t    tbl = Source{[Schema="gold", Item="fact_orders"]}[Data]\n'
+            "\t\t\t\tin\n"
+            "\t\t\t\t    tbl"
+        ) in table_tmdl
+
+    def test_dbo_schema_also_works(
+        self, tmp_path: Path, sql_endpoint: SqlEndpointSource
+    ) -> None:
+        sm = SemanticModel(
+            name="sm_endpoint",
+            description="SQL endpoint dbo test model.",
+            sources=[sql_endpoint],
+            tables=[_endpoint_table(sql_endpoint, schema="dbo")],
+        )
+        item_dir = sm.save_to_disk(tmp_path)
+        table_tmdl = (
+            item_dir / "definition" / "tables" / "fact_orders.tmdl"
+        ).read_text("utf-8")
+        assert 'Source{[Schema="dbo", Item="fact_orders"]}[Data]' in table_tmdl
+
+    def test_query_order_lists_expression_then_tables(
+        self, tmp_path: Path, sql_endpoint: SqlEndpointSource
+    ) -> None:
+        sm = SemanticModel(
+            name="sm_endpoint",
+            description="SQL endpoint query-order test model.",
+            sources=[sql_endpoint],
+            tables=[_endpoint_table(sql_endpoint)],
+        )
+        item_dir = sm.save_to_disk(tmp_path)
+        model_tmdl = (item_dir / "definition" / "model.tmdl").read_text("utf-8")
+        assert '["lh_gold", "fact_orders"]' in model_tmdl
+
+    def test_table_query_rejected(self, sql_endpoint: SqlEndpointSource) -> None:
+        sm = SemanticModel(
+            name="sm_endpoint",
+            description="Query misuse test model.",
+            sources=[sql_endpoint],
+            tables=[
+                Table(
+                    name="t",
+                    source=sql_endpoint,
+                    description="T.",
+                    columns=[Column("c", "string", description="C.")],
+                    query="SELECT 1",
+                )
+            ],
+        )
+        errs = sm.validate()
+        assert any("only valid with a" in e for e in errs)
+
+
+class TestLakehouseSourceSchemaValidation:
+    """Issue #129: LakehouseSource + non-dbo schema can never refresh."""
+
+    def test_non_dbo_schema_is_hard_error(self, gold: LakehouseSource) -> None:
+        sm = SemanticModel(
+            name="sm_bad",
+            description="Non-dbo lakehouse test model.",
+            sources=[gold],
+            tables=[
+                Table(
+                    name="fact_x",
+                    source=gold,
+                    schema="bc",
+                    description="Fact.",
+                    columns=[Column("k", "string", description="Key.")],
+                )
+            ],
+        )
+        errs = sm.validate()
+        assert any(
+            "not addressable via LakehouseSource" in e and "SqlEndpointSource" in e
+            for e in errs
+        )
+
+    def test_save_to_disk_raises(self, tmp_path: Path, gold: LakehouseSource) -> None:
+        sm = SemanticModel(
+            name="sm_bad",
+            description="Non-dbo lakehouse test model.",
+            sources=[gold],
+            tables=[
+                Table(
+                    name="fact_x",
+                    source=gold,
+                    schema="bc",
+                    description="Fact.",
+                    columns=[Column("k", "string", description="Key.")],
+                )
+            ],
+        )
+        with pytest.raises(SemanticModelError, match="not addressable"):
+            sm.save_to_disk(tmp_path)
+
+    def test_dbo_schema_still_fine(self, minimal_model: SemanticModel) -> None:
+        assert minimal_model.validate() == []


### PR DESCRIPTION
## Problem

`Lakehouse.Contents` returns an **empty navigation table** for schema-enabled lakehouses (tables under `Tables/<schema>/`), so every refresh of an import model built on `LakehouseSource` with a non-dbo schema fails:

> Expression.Error: The key didn't match any rows in the table

The builder's `Table(schema=...)` accepted the schema and emitted it into a navigation key that can never match.

## Change — both fixes from the issue

**(a) New `SqlEndpointSource(name, server, database)`** — import-mode source navigating the SQL analytics endpoint (serves all schemas). Emits exactly the field-proven working shape:

```
expression <name> =
        let
            Source = Sql.Database("<server>", "<database>")
        in
            Source

-- per-table partition (mode: import):
tbl = Source{[Schema="<schema>", Item="<table>"]}[Data]
```

Note `Item=`, not `Id=` — the `Sql.Database` navigation key. `server` is resolvable by the caller via `GET /workspaces/{ws}/lakehouses/{id}` → `properties.sqlEndpointProperties.connectionString`; resolution intentionally stays out of the builder, matching the literal-strings design of the other sources. Included in `PBI_QueryOrder`.

**(b) Validation-time error** — `validate()` (and therefore `save_to_disk`) now hard-errors when a table's source is `LakehouseSource` and its schema isn't `dbo`, with a message pointing at `SqlEndpointSource`. A model that can never refresh now fails at build time instead of in the portal.

## Validation

- Byte-exact emission tests for the expression and the `Schema=`/`Item=` partition (non-dbo and dbo), PBI_QueryOrder, identifier validation, `Table.query` misuse
- Hard-error tests: `validate()` message + `save_to_disk` raising `SemanticModelError`
- **`test_import_output_unchanged_by_new_source_kinds` untouched and green** — default-dbo `Lakehouse.Contents` output stays byte-identical
- Live refresh verification is out of scope (needs one-time portal credential binding); the emitted M is byte-matched to the shape verified refreshing successfully against a schema-enabled lakehouse
- `ruff check` / `ruff format --check` / `mypy src/` / `pytest` (971 passed) / `pip-audit` green

Closes #129

🤖 Generated with [Claude Code](https://claude.com/claude-code)