### PR TITLE
test(data): live lakehouse DDL e2e suite gated on the validation workspace

### DIFF
--- a/docs/testing.md
+++ b/docs/testing.md
@@ -213,3 +213,20 @@ E2E validation as part of your test suite:
 ```bash
 PYFABRIC_TEST_WORKSPACE=/path/to/workspace pytest -m e2e
 ```
+
+## Live E2E environment variables
+
+All `@pytest.mark.e2e` tests skip cleanly when their variables are unset,
+so the default suite never needs Fabric access.
+
+| Variable | Used by | Meaning |
+| --- | --- | --- |
+| `PYFABRIC_TEST_WORKSPACE` | `test_validate_e2e.py` | Local path of a git-synced workspace folder |
+| `PYFABRIC_TEST_WORKSPACE_ID` | REST lifecycle e2e (deploy, notebook, environment) + DDL | Validation workspace GUID |
+| `PYFABRIC_TEST_LAKEHOUSE_ID` | `tests/data/test_lakehouse_ddl_e2e.py` | A **schema-enabled** lakehouse GUID inside the validation workspace |
+
+The live DDL suite works inside a throwaway `it_<hex8>` schema per run
+and drops it in teardown (pass or fail). If a run is killed hard
+(Ctrl-C at the wrong moment), an orphaned `it_*` schema can remain —
+they carry no data anyone needs and are always safe to remove with
+`pyfabric.data.lakehouse.drop_schema` or from the portal.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -227,3 +227,15 @@ def real_workspace_id() -> str | None:
     contributors who don't have a validation workspace.
     """
     return os.environ.get("PYFABRIC_TEST_WORKSPACE_ID") or None
+
+
+@pytest.fixture
+def real_lakehouse_id() -> str | None:
+    """Lakehouse ID (GUID) inside the validation workspace for live DDL
+    E2E testing. The lakehouse should be schema-enabled (tests skip with
+    setup instructions otherwise).
+
+    Set the PYFABRIC_TEST_LAKEHOUSE_ID environment variable to enable.
+    Returns None if the env var is not set so tests skip cleanly.
+    """
+    return os.environ.get("PYFABRIC_TEST_LAKEHOUSE_ID") or None

--- a/tests/data/test_lakehouse_ddl_e2e.py
+++ b/tests/data/test_lakehouse_ddl_e2e.py
@@ -1,0 +1,140 @@
+"""Live DDL e2e tests against a real (validation-workspace) lakehouse.
+
+The mocked suite in ``test_lakehouse_ddl.py`` covers the DFS-seam
+behavior; nothing there ever talks to real OneLake. These tests replay
+the same operations live to catch DFS-protocol drift (rename semantics,
+``recursive=true`` behavior) and auth-surface bugs that only appear
+against a real workspace. See issue #52.
+
+Gating (both required; tests skip cleanly otherwise):
+
+- ``PYFABRIC_TEST_WORKSPACE_ID`` — validation workspace GUID
+- ``PYFABRIC_TEST_LAKEHOUSE_ID`` — a schema-enabled lakehouse in it
+
+Isolation: every run works inside a throwaway ``it_<hex8>`` schema and
+drops it in teardown regardless of pass/fail, so a crashed run leaves at
+most one orphaned ``it_*`` schema (safe to drop manually — see
+docs/testing.md).
+"""
+
+from __future__ import annotations
+
+import contextlib
+import uuid
+from collections.abc import Iterator
+
+import pytest
+
+pa = pytest.importorskip("pyarrow")
+
+from pyfabric.data import lakehouse  # noqa: E402
+
+
+@pytest.mark.e2e
+class TestLakehouseDdlLive:
+    @pytest.fixture(autouse=True)
+    def _require_live_lakehouse(
+        self, real_workspace_id: str | None, real_lakehouse_id: str | None
+    ) -> Iterator[None]:
+        if real_workspace_id is None:
+            pytest.skip("PYFABRIC_TEST_WORKSPACE_ID not set")
+        if real_lakehouse_id is None:
+            pytest.skip("PYFABRIC_TEST_LAKEHOUSE_ID not set")
+        from pyfabric.client.auth import AuthError, FabricCredential
+
+        self.ws_id = real_workspace_id
+        self.lh_id = real_lakehouse_id
+        try:
+            self.cred = FabricCredential()
+            existing = lakehouse.list_schemas(self.cred, self.ws_id, self.lh_id)
+        except AuthError as e:
+            pytest.skip(f"credential unavailable for live DDL tests: {e}")
+        if "dbo" not in existing:
+            pytest.skip(
+                "lakehouse does not look schema-enabled (no schemas listed); "
+                "create a schema-enabled lakehouse in the validation "
+                "workspace and point PYFABRIC_TEST_LAKEHOUSE_ID at it"
+            )
+        self.schema = f"it_{uuid.uuid4().hex[:8]}"
+        try:
+            yield
+        finally:
+            # Best-effort cleanup of both the primary and the renamed
+            # schema so a crashed test never leaves litter behind.
+            for schema in (self.schema, f"{self.schema}b"):
+                with contextlib.suppress(Exception):
+                    lakehouse.drop_schema(self.cred, self.ws_id, self.lh_id, schema)
+
+    def _seed(self, table: str, schema: str | None = None) -> None:
+        data = pa.table({"id": ["a", "b"], "n": [1, 2]})
+        lakehouse.write_table(
+            self.cred,
+            self.ws_id,
+            self.lh_id,
+            table,
+            data,
+            schema=schema or self.schema,
+        )
+
+    def test_full_ddl_lifecycle(self) -> None:
+        """One serial pass over the whole DDL surface (issue #52 matrix).
+
+        Serial by design: each op builds on the last, so one seeded
+        Delta table exercises create → list → rename_table →
+        rename_schema → delete_table → drop_schema without re-seeding.
+        """
+        # write_table creates the schema implicitly.
+        self._seed("t_alpha")
+        assert self.schema in lakehouse.list_schemas(self.cred, self.ws_id, self.lh_id)
+        assert lakehouse.list_tables(
+            self.cred, self.ws_id, self.lh_id, schema=self.schema
+        ) == ["t_alpha"]
+
+        # rename_table: new name visible, old name gone.
+        lakehouse.rename_table(
+            self.cred,
+            self.ws_id,
+            self.lh_id,
+            "t_alpha",
+            "t_beta",
+            schema=self.schema,
+        )
+        tables = lakehouse.list_tables(
+            self.cred, self.ws_id, self.lh_id, schema=self.schema
+        )
+        assert tables == ["t_beta"]
+
+        # rename_schema: both tables move.
+        self._seed("t_gamma")
+        renamed = f"{self.schema}b"
+        lakehouse.rename_schema(self.cred, self.ws_id, self.lh_id, self.schema, renamed)
+        schemas = lakehouse.list_schemas(self.cred, self.ws_id, self.lh_id)
+        assert renamed in schemas
+        assert self.schema not in schemas
+        assert sorted(
+            lakehouse.list_tables(self.cred, self.ws_id, self.lh_id, schema=renamed)
+        ) == ["t_beta", "t_gamma"]
+
+        # delete_table: gone from the listing.
+        lakehouse.delete_table(
+            self.cred, self.ws_id, self.lh_id, "t_beta", schema=renamed
+        )
+        assert lakehouse.list_tables(
+            self.cred, self.ws_id, self.lh_id, schema=renamed
+        ) == ["t_gamma"]
+
+        # drop_schema: schema disappears entirely.
+        lakehouse.drop_schema(self.cred, self.ws_id, self.lh_id, renamed)
+        assert renamed not in lakehouse.list_schemas(self.cred, self.ws_id, self.lh_id)
+
+    def test_rename_table_same_name_raises(self) -> None:
+        self._seed("t_same")
+        with pytest.raises(ValueError):
+            lakehouse.rename_table(
+                self.cred,
+                self.ws_id,
+                self.lh_id,
+                "t_same",
+                "t_same",
+                schema=self.schema,
+            )


### PR DESCRIPTION
## Problem

The DDL helpers from #51 (`delete_table`, `rename_table`, `rename_schema`, `drop_schema`, `list_schemas`, `list_tables`) had mocked-DFS coverage only. DFS-protocol drift on OneLake and auth-surface bugs (storage-token scope/tenant resolution) are invisible to mocks.

## Change

New `tests/data/test_lakehouse_ddl_e2e.py` replaying the mocked suite's operations live:

- **One serial lifecycle pass** over the issue's coverage matrix: seed a Delta table via `write_table` into a throwaway schema → `list_schemas`/`list_tables` cross-check → `rename_table` (new visible, old gone) → `rename_schema` (both tables move) → `delete_table` → `drop_schema`. Plus the rename-to-same-name error path. (`rename_schema` partial-failure is not forced live — per the issue, skippable on first iteration.)
- **Gating** reuses the existing convention: `PYFABRIC_TEST_WORKSPACE_ID` + new `PYFABRIC_TEST_LAKEHOUSE_ID` (new `real_lakehouse_id` conftest fixture) rather than the issue's proposed new names. Skips cleanly when either is unset, when the credential can't be created (skip, not fail — per the issue's auth note), or when the lakehouse isn't schema-enabled (skip message carries setup instructions).
- **Isolation**: per-run `it_<hex8>` schema, dropped in a `finally` for both the primary and renamed names — a crashed run leaves at most one orphaned `it_*` schema. Design question 3 (stale sweep) resolved as **no automated sweep**: the names carry no timestamp so age is unknowable; `docs/testing.md` documents that orphaned `it_*` schemas are always safe to drop manually.
- CI behavior unchanged: env vars stay unset in CI (per the issue); the suite is a local DDL-change validation harness.

## Validation

- Both tests **skip cleanly** with the env vars unset (verified); full suite 1000 passed.
- **Live run pending**: the validation workspace currently has no capacity assignment (old trial expired — 403 `FeatureNotAvailable` on item APIs). Once it's re-assigned and a schema-enabled lakehouse GUID is set in `PYFABRIC_TEST_LAKEHOUSE_ID`, the acceptance run is `pytest tests/data/test_lakehouse_ddl_e2e.py -m e2e` twice → green both, no `it_*` residue — planned before the v0.1.11 release.
- `ruff check` / `ruff format --check` / `mypy src/` / `pytest` / `pip-audit` green.

Closes #52

🤖 Generated with [Claude Code](https://claude.com/claude-code)