### PR TITLE
test(data): fail fast on malformed GUID env vars in the live DDL suite

### DIFF
--- a/tests/data/test_lakehouse_ddl_e2e.py
+++ b/tests/data/test_lakehouse_ddl_e2e.py
@@ -40,6 +40,22 @@ class TestLakehouseDdlLive:
             pytest.skip("PYFABRIC_TEST_WORKSPACE_ID not set")
         if real_lakehouse_id is None:
             pytest.skip("PYFABRIC_TEST_LAKEHOUSE_ID not set")
+        # A malformed GUID (e.g. a character dropped while copying from
+        # the portal) reaches OneLake as a bad filesystem path and comes
+        # back as a bare "400 Bad Request" — fail with a pointed message
+        # instead.
+        for label, value in (
+            ("PYFABRIC_TEST_WORKSPACE_ID", real_workspace_id),
+            ("PYFABRIC_TEST_LAKEHOUSE_ID", real_lakehouse_id),
+        ):
+            try:
+                uuid.UUID(value)
+            except ValueError:
+                pytest.fail(
+                    f"{label} is not a valid GUID: {value!r} "
+                    f"({len(value)} chars, expected 36) — re-copy the id "
+                    "from the portal (Settings → Identifier)"
+                )
         from pyfabric.client.auth import AuthError, FabricCredential
 
         self.ws_id = real_workspace_id


### PR DESCRIPTION
## What happened

First field run of the #138 live DDL suite hit `requests.exceptions.HTTPError: 400 Client Error: Bad Request` at fixture setup. Root cause: the `PYFABRIC_TEST_LAKEHOUSE_ID` value had a character dropped while copying (35 chars instead of 36) — OneLake answers a malformed filesystem path with a bare 400 and no hint.

## Change

The gating fixture now validates both env vars with `uuid.UUID` before touching the network and fails with a pointed message:

```
Failed: PYFABRIC_TEST_LAKEHOUSE_ID is not a valid GUID: 'cadb9113-...-67aab2b54f9' (35 chars, expected 36) — re-copy the id from the portal (Settings → Identifier)
```

Deliberate `pytest.fail` (not skip): a malformed value is operator error worth surfacing loudly, unlike the unset-variable case which stays a clean skip.

## Validation

Guard verified against the exact malformed value from the field run; unset-variable behavior still skips cleanly; full suite green; ruff/mypy/pip-audit green.

Follow-up to #138 / issue #52.

🤖 Generated with [Claude Code](https://claude.com/claude-code)