### PR TITLE
feat(notebook): add_sparksql cells, byte-exact to a Fabric-emitted fixture

### DIFF
--- a/src/pyfabric/items/notebook.py
+++ b/src/pyfabric/items/notebook.py
@@ -48,11 +48,12 @@ CellLanguage = Literal["python", "sparksql"]
 
 
 # Cell language → language_group mapping for the per-cell trailing META
-# block. Keyed on the concrete cell language; the language_group is the
-# kernel family Fabric associates with each language.
+# block. Fabric's canonical git bytes carry a language_group only for
+# python cells; a sparksql cell's META block is just
+# ``{"language": "sparksql"}`` (verified against a Fabric-emitted
+# fixture — see tests/fixtures/notebooks/nb_sparksql.Notebook).
 _LANGUAGE_GROUP: dict[CellLanguage, str] = {
     "python": "synapse_pyspark",
-    "sparksql": "synapse_pyspark",
 }
 
 
@@ -172,6 +173,17 @@ class NotebookBuilder:
     def add_python(self, code: str) -> "NotebookBuilder":
         """Append a Python code cell."""
         self._cells.append(_Cell(kind="code", content=code, language="python"))
+        return self
+
+    def add_sparksql(self, sql: str) -> "NotebookBuilder":
+        """Append a Spark SQL cell.
+
+        Emits a regular ``# CELL`` block whose trailing META block is
+        ``{"language": "sparksql"}`` — the language-switched cell form
+        Fabric produces when a cell's language is set to Spark SQL in
+        the portal. The SQL body is raw text (no ``%%sql`` magic).
+        """
+        self._cells.append(_Cell(kind="code", content=sql, language="sparksql"))
         return self
 
     def add_parameters_cell(self, code: str) -> "NotebookBuilder":
@@ -367,13 +379,13 @@ class NotebookBuilder:
     def _render_code_cell(
         self, code: str, language: CellLanguage, *, parameters: bool = False
     ) -> str:
-        meta_body = json.dumps(
-            {
-                "language": language,
-                "language_group": _LANGUAGE_GROUP[language],
-            },
-            indent=2,
-        )
+        # language_group appears only for languages that have one in
+        # Fabric's canonical output (python); sparksql cells carry just
+        # the language key — see the nb_sparksql fixture.
+        meta: dict[str, str] = {"language": language}
+        if language in _LANGUAGE_GROUP:
+            meta["language_group"] = _LANGUAGE_GROUP[language]
+        meta_body = json.dumps(meta, indent=2)
         marker = (
             "# PARAMETERS CELL ********************"
             if parameters

--- a/tests/fixtures/notebooks/nb_sparksql.Notebook/notebook-content.py
+++ b/tests/fixtures/notebooks/nb_sparksql.Notebook/notebook-content.py
@@ -1,0 +1,19 @@
+# Fabric notebook source
+
+# METADATA ********************
+
+# META {
+# META   "kernel_info": {
+# META     "name": "synapse_pyspark"
+# META   }
+# META }
+
+# CELL ********************
+
+SELECT 1 AS probe
+
+# METADATA ********************
+
+# META {
+# META   "language": "sparksql"
+# META }

--- a/tests/items/test_notebook.py
+++ b/tests/items/test_notebook.py
@@ -392,3 +392,37 @@ class TestAttachEnvironment:
         src = nb.to_source_string()
         assert '"environmentId": "env-new"' in src
         assert "env-old" not in src
+
+
+# ── Spark SQL cells (issue #55) ──────────────────────────────────────────────
+
+
+class TestSparkSqlCells:
+    def test_sparksql_round_trip_byte_identical_to_fabric_fixture(self):
+        """The fixture was captured from a real Fabric notebook: created
+        via an ipynb-format definition with a Spark SQL cell, fetched
+        back in git format. The builder must reproduce it byte-for-byte
+        or the artifact flaps on every sync."""
+        nb = NotebookBuilder().add_sparksql("SELECT 1 AS probe")
+        assert nb.to_source_string().encode("utf-8") == _fixture_bytes("nb_sparksql")
+
+    def test_sparksql_meta_block_has_no_language_group(self):
+        src = NotebookBuilder().add_sparksql("SELECT 1").to_source_string()
+        assert '# META   "language": "sparksql"' in src
+        assert "language_group" not in src.split("# CELL")[1]
+
+    def test_python_cells_keep_language_group(self):
+        src = NotebookBuilder().add_python("x = 1").to_source_string()
+        assert '# META   "language": "python",' in src
+        assert '# META   "language_group": "synapse_pyspark"' in src
+
+    def test_add_sparksql_is_chainable(self):
+        nb = (
+            NotebookBuilder()
+            .add_markdown("# Report")
+            .add_sparksql("SELECT 1 AS probe")
+            .add_python("x = 1")
+        )
+        src = nb.to_source_string()
+        assert src.count("# CELL ********************") == 2
+        assert "# MARKDOWN ********************" in src


### PR DESCRIPTION
## Background

#36 deferred `add_sparksql` because no real-world sparksql `notebook-content.py` existed to validate the cell layout against — shipping the format unverified risked bytes that flap on every git-sync cycle.

## Fixture (the unblock)

Captured from a live workspace per the issue's runbook: created a throwaway notebook via an **ipynb-format definition** containing one cell with `metadata.microsoft.language = "sparksql"`, fetched the definition back in git format, checked the returned `notebook-content.py` in **verbatim** at `tests/fixtures/notebooks/nb_sparksql.Notebook/` (it contains no workspace/lakehouse ids, so nothing to scrub), then deleted the notebook.

**The fixture corrected the code's guess**, exactly as the issue predicted it might: a sparksql cell's trailing META block is

```
# META {
# META   "language": "sparksql"
# META }
```

— **no `language_group` key**. (The old `_LANGUAGE_GROUP` mapping speculatively said `sparksql → "synapse_pyspark"`; trusted the fixture per the issue's rule.) Side observation from a two-cell capture: a `%%sql` magic in a plain cell round-trips as `# MAGIC`-wrapped lines with no META block at all — that's a different (python-magic) form and stays out of scope here.

## Change

- `NotebookBuilder.add_sparksql(sql)` — regular `# CELL` block, raw SQL body (no `%%sql` magic), language-only META. Chainable like the other cell methods.
- `_render_code_cell` emits `language_group` only for languages that have one in Fabric's canonical output; `_LANGUAGE_GROUP` drops the speculative sparksql entry. Python cells unchanged — still byte-locked by the `nb_full` fixture.

## Acceptance criteria from the issue

- [x] Fabric-emitted fixture checked in (ids: none present)
- [x] `add_sparksql(sql)` implemented to match
- [x] Round-trip test: builder output **byte-identical** to the fixture
- [x] META emits `"language": "sparksql"`; the `language_group` question resolved by the fixture (omitted)

## Validation

40 notebook tests green incl. the byte-identity round-trip; full suite 1031 passed; ruff / mypy / pip-audit green.

Closes #55

🤖 Generated with [Claude Code](https://claude.com/claude-code)